### PR TITLE
fix: enable compression features by default in redb-cli

### DIFF
--- a/crates/redb-cli/Cargo.toml
+++ b/crates/redb-cli/Cargo.toml
@@ -15,3 +15,9 @@ redb = { path = "../.." }
 clap = { version = "4.5", features = ["derive"] }
 comfy-table = "7.1"
 xxhash-rust = { version = "0.8", features = ["xxh3"] }
+
+[features]
+default = ["compression"]
+compression_lz4 = ["redb/compression_lz4"]
+compression_zstd = ["redb/compression_zstd"]
+compression = ["compression_lz4", "compression_zstd"]


### PR DESCRIPTION
## Summary
- CLI binary couldn't open compressed databases because it depended on `redb` without compression features
- Added `compression`, `compression_lz4`, `compression_zstd` features to redb-cli that forward to the redb crate
- `compression` enabled by default so the CLI can inspect any redb database out of the box

## Test plan
- `redb info test_lz4.redb` shows `Compression: lz4`
- `redb info test_zstd.redb` shows `Compression: zstd`
- `redb header test_lz4.redb` shows `Compression algo: lz4 (byte 36 = 0x01)`
- Compiles clean with `--all-features`, `--no-default-features`, and default features