### PR TITLE
chore: remove page-level compression dead code

### DIFF
--- a/src/tree_store/page_store/cached_file.rs
+++ b/src/tree_store/page_store/cached_file.rs
@@ -1,7 +1,4 @@
 use crate::tree_store::page_store::base::PageHint;
-use crate::tree_store::page_store::compression::{
-    CompressionConfig, CompressionStats, compress_page, decompress_page,
-};
 use crate::tree_store::page_store::lru_cache::LRUCache;
 use crate::{CacheStats, DatabaseError, Result, StorageBackend, StorageError};
 use std::ops::{Index, IndexMut};
@@ -213,8 +210,6 @@ pub(super) struct PagedCachedFile {
     read_cache: Vec<RwLock<LRUCache<Arc<[u8]>>>>,
     // TODO: maybe move this cache to WriteTransaction?
     write_buffer: Arc<Mutex<LRUWriteCache>>,
-    compression: CompressionConfig,
-    compression_stats: CompressionStats,
 }
 
 impl PagedCachedFile {
@@ -247,13 +242,7 @@ impl PagedCachedFile {
             evictions: Default::default(),
             read_cache,
             write_buffer: Arc::new(Mutex::new(LRUWriteCache::new())),
-            compression: CompressionConfig::None,
-            compression_stats: CompressionStats::new(),
         })
-    }
-
-    pub(super) fn set_compression(&mut self, config: CompressionConfig) {
-        self.compression = config;
     }
 
     #[allow(clippy::unused_self)]
@@ -305,42 +294,12 @@ impl PagedCachedFile {
         131
     }
 
-    /// Whether the given offset is eligible for compression.
-    /// The super-header (first `page_size` bytes) is never compressed.
-    fn is_compressible_offset(&self, offset: u64) -> bool {
-        offset >= self.page_size
-    }
-
-    /// Try to compress a page buffer for writing to disk.
-    /// Returns the compressed buffer if successful, or the original buffer if not.
-    fn compress_for_write(&self, offset: u64, buffer: &[u8]) -> Vec<u8> {
-        if self.compression.is_enabled()
-            && self.is_compressible_offset(offset)
-            && let Some(compressed) =
-                compress_page(buffer, self.compression, &self.compression_stats)
-        {
-            return compressed;
-        }
-        buffer.to_vec()
-    }
-
-    /// Try to decompress a page buffer read from disk.
-    /// Returns the decompressed data if the page was compressed, or None if not.
-    /// Only checks for compression markers if the database was opened with compression enabled.
-    fn decompress_from_read(&self, offset: u64, buffer: &[u8]) -> Result<Option<Vec<u8>>> {
-        if !self.compression.is_enabled() || !self.is_compressible_offset(offset) {
-            return Ok(None);
-        }
-        decompress_page(buffer, &self.compression_stats)
-    }
-
     fn flush_write_buffer(&self) -> Result {
         let mut write_buffer = self.write_buffer.lock().unwrap();
 
         for (offset, buffer) in write_buffer.cache.iter() {
             let raw = buffer.as_ref().unwrap();
-            let disk_data = self.compress_for_write(*offset, raw);
-            self.file.write(*offset, &disk_data)?;
+            self.file.write(*offset, raw)?;
         }
         for (offset, buffer) in write_buffer.cache.iter_mut() {
             let buffer = buffer.take().unwrap();
@@ -396,17 +355,6 @@ impl PagedCachedFile {
         Ok(buffer)
     }
 
-    /// Read a page from disk and decompress if necessary.
-    /// Returns the uncompressed page data.
-    fn read_page_direct(&self, offset: u64, len: usize) -> Result<Vec<u8>> {
-        let buffer = self.read_direct(offset, len)?;
-        if let Some(decompressed) = self.decompress_from_read(offset, &buffer)? {
-            Ok(decompressed)
-        } else {
-            Ok(buffer)
-        }
-    }
-
     // Read with caching. Caller must not read overlapping ranges without first calling invalidate_cache().
     // Doing so will not cause UB, but is a logic error.
     pub(super) fn read(&self, offset: u64, len: usize, hint: PageHint) -> Result<Arc<[u8]>> {
@@ -435,8 +383,8 @@ impl PagedCachedFile {
             }
         }
 
-        // Cache miss — read from disk and decompress if needed
-        let buffer: Arc<[u8]> = self.read_page_direct(offset, len)?.into();
+        // Cache miss — read from disk
+        let buffer: Arc<[u8]> = self.read_direct(offset, len)?.into();
         let cache_size = self
             .read_cache_bytes
             .fetch_add(buffer.len(), Ordering::AcqRel);
@@ -537,9 +485,7 @@ impl PagedCachedFile {
                 while removed_bytes < len {
                     if let Some((evict_offset, buffer)) = lock.pop_lowest_priority() {
                         let removed_len = buffer.len();
-                        // Compress before writing evicted page to disk
-                        let disk_data = self.compress_for_write(evict_offset, &buffer);
-                        let result = self.file.write(evict_offset, &disk_data);
+                        let result = self.file.write(evict_offset, &buffer);
                         if result.is_err() {
                             lock.insert(evict_offset, buffer);
                         }
@@ -565,8 +511,7 @@ impl PagedCachedFile {
                 self.writes_hits.fetch_add(1, Ordering::AcqRel);
                 vec![0; len].into()
             } else {
-                // Reading existing page from disk — decompress if needed
-                self.read_page_direct(offset, len)?.into()
+                self.read_direct(offset, len)?.into()
             };
             lock.insert(offset, result);
             lock.take_value(offset).unwrap()

--- a/src/tree_store/page_store/compression.rs
+++ b/src/tree_store/page_store/compression.rs
@@ -1,99 +1,21 @@
-//! Page-level transparent compression for redb.
+//! Compression support for redb.
 //!
-//! Compression is applied at the cache-to-disk boundary:
-//! - Pages in memory are ALWAYS uncompressed (B-tree code is untouched)
-//! - On flush: page bytes are compressed before writing to disk
-//! - On read: page bytes are decompressed after reading from disk
+//! Value-level compression compresses individual values BEFORE they enter
+//! the B-tree. Shorter values → fewer pages → smaller files.
 //!
-//! # On-disk format (compressed page)
+//! # Compressed value envelope
 //!
 //! ```text
-//! [0]      page type (LEAF=1, BRANCH=2) — preserved uncompressed
-//! [1]      compression algorithm ID (0=none, 1=lz4, 2=zstd)
-//! [2..6]   compressed data length as u32 LE (NOT including this 6-byte header)
-//! [6..]    compressed(original_page[2..])
-//!          zero-padded to allocation size
+//! [0]     flags: bit 0 = compressed, bits 1-2 = algo (01=lz4, 10=zstd)
+//! [1..5]  original_size (u32 LE)
+//! [5..]   compressed data
 //! ```
 //!
-//! # In-memory format (always uncompressed)
-//!
-//! ```text
-//! [0]      page type
-//! [1]      0x00 (always zero — no compression flag in memory)
-//! [2..]    normal page content
-//! ```
-//!
-//! # Design decisions
-//!
-//! - **Compress `page[2..]`**: everything after type byte + algo byte is compressed.
-//!   This means the original `page[2..]` content (including any B-tree metadata at
-//!   those offsets) is fully preserved through the compress/decompress round-trip.
-//! - **Stored compressed length**: the compressed data length is stored at `[2..6]`
-//!   so the decompressor knows exactly where the real data ends (ignoring zero padding).
-//! - **Skip small pages**: pages smaller than 128 bytes are never compressed
-//!   (compression overhead exceeds savings).
-//! - **Skip incompressible data**: if compressed size >= 87.5% of original,
-//!   the page is stored uncompressed (avoids wasting CPU on random/encrypted data).
-//! - **Header bytes always in the clear**: `page[0]` (type) and `page[1]` (algo) are
-//!   never compressed, so the reader can determine format without decompression.
+//! If flags == 0x00: the value is stored raw (no envelope overhead).
+//! The flags byte is self-describing: decompression never needs config.
 
 use crate::{Result, StorageError};
 use std::borrow::Cow;
-use std::sync::atomic::{AtomicU64, Ordering};
-
-/// Byte offset where the compressed-data-length field starts in a compressed page.
-const COMP_LEN_OFFSET: usize = 2;
-/// Byte offset where compressed data starts.
-const COMP_DATA_OFFSET: usize = 6;
-/// Byte offset where the compressible payload starts in the original in-memory page.
-/// We compress everything from this offset onward: `page[PAYLOAD_OFFSET..]`.
-const PAYLOAD_OFFSET: usize = 2;
-/// Minimum page size worth compressing (bytes). Smaller pages have too much
-/// overhead relative to savings.
-const MIN_COMPRESS_SIZE: usize = 128;
-/// If `compressed_size / original_size` exceeds this ratio, store uncompressed.
-/// 7/8 = 0.875 — less than 12.5% savings means not worth the CPU.
-const INCOMPRESSIBLE_RATIO: f64 = 0.875;
-
-/// Algorithm identifier stored in `page[1]` on disk.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-#[repr(u8)]
-pub(crate) enum CompressionAlgorithm {
-    None = 0,
-    #[cfg(feature = "compression_lz4")]
-    Lz4 = 1,
-    #[cfg(feature = "compression_zstd")]
-    Zstd = 2,
-}
-
-impl CompressionAlgorithm {
-    pub(crate) fn from_byte(b: u8) -> Result<Self> {
-        match b {
-            0 => Ok(Self::None),
-            #[cfg(feature = "compression_lz4")]
-            1 => Ok(Self::Lz4),
-            #[cfg(feature = "compression_zstd")]
-            2 => Ok(Self::Zstd),
-            #[cfg(not(feature = "compression_lz4"))]
-            1 => Err(StorageError::Corrupted(
-                "page uses LZ4 compression but the compression_lz4 feature is not enabled"
-                    .to_string(),
-            )),
-            #[cfg(not(feature = "compression_zstd"))]
-            2 => Err(StorageError::Corrupted(
-                "page uses zstd compression but the compression_zstd feature is not enabled"
-                    .to_string(),
-            )),
-            other => Err(StorageError::Corrupted(format!(
-                "unknown compression algorithm: {other}"
-            ))),
-        }
-    }
-
-    pub(crate) fn as_byte(self) -> u8 {
-        self as u8
-    }
-}
 
 /// User-facing compression configuration.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -120,23 +42,19 @@ impl Default for CompressionConfig {
 }
 
 impl CompressionConfig {
-    pub(crate) fn algorithm(self) -> CompressionAlgorithm {
-        match self {
-            Self::None => CompressionAlgorithm::None,
-            #[cfg(feature = "compression_lz4")]
-            Self::Lz4 => CompressionAlgorithm::Lz4,
-            #[cfg(feature = "compression_zstd")]
-            Self::Zstd { .. } => CompressionAlgorithm::Zstd,
-        }
-    }
-
     pub(crate) fn is_enabled(self) -> bool {
         !matches!(self, Self::None)
     }
 
     /// Persistent identifier stored in the database header (1 byte).
     pub(crate) fn header_byte(self) -> u8 {
-        self.algorithm().as_byte()
+        match self {
+            Self::None => 0,
+            #[cfg(feature = "compression_lz4")]
+            Self::Lz4 => 1,
+            #[cfg(feature = "compression_zstd")]
+            Self::Zstd { .. } => 2,
+        }
     }
 
     /// Reconstruct from header byte. Level is not stored in the header —
@@ -166,193 +84,9 @@ impl CompressionConfig {
     }
 }
 
-/// Runtime compression statistics (lock-free).
-pub(crate) struct CompressionStats {
-    /// Total bytes before compression (input to compressor).
-    pub(crate) bytes_in: AtomicU64,
-    /// Total bytes after compression (output from compressor).
-    pub(crate) bytes_out: AtomicU64,
-    /// Number of pages compressed.
-    pub(crate) pages_compressed: AtomicU64,
-    /// Number of pages skipped (too small or incompressible).
-    pub(crate) pages_skipped: AtomicU64,
-    /// Number of pages decompressed on read.
-    pub(crate) pages_decompressed: AtomicU64,
-}
-
-impl CompressionStats {
-    pub(crate) fn new() -> Self {
-        Self {
-            bytes_in: AtomicU64::new(0),
-            bytes_out: AtomicU64::new(0),
-            pages_compressed: AtomicU64::new(0),
-            pages_skipped: AtomicU64::new(0),
-            pages_decompressed: AtomicU64::new(0),
-        }
-    }
-
-    /// Current compression ratio (0.0 = perfect, 1.0 = no savings).
-    /// Returns `None` if no pages have been compressed yet.
-    #[allow(dead_code, clippy::cast_precision_loss)]
-    pub(crate) fn ratio(&self) -> Option<f64> {
-        let bytes_in = self.bytes_in.load(Ordering::Relaxed);
-        if bytes_in == 0 {
-            return None;
-        }
-        let bytes_out = self.bytes_out.load(Ordering::Relaxed);
-        Some(bytes_out as f64 / bytes_in as f64)
-    }
-}
-
-/// Compress a page for writing to disk.
-///
-/// Takes a full page buffer (e.g. 4096 bytes) and returns a new buffer of the
-/// SAME size with compressed content in the on-disk format:
-///   `[0]` = original `page[0]` (type byte)
-///   `[1]` = algorithm ID
-///   `[2..6]` = compressed data length (u32 LE)
-///   `[6..]` = `compressed(page[2..])`, zero-padded
-///
-/// If compression would not save space, returns `None` (caller stores uncompressed).
-#[allow(clippy::cast_precision_loss, unreachable_code, unused_variables)]
-pub(crate) fn compress_page(
-    page: &[u8],
-    config: CompressionConfig,
-    stats: &CompressionStats,
-) -> Option<Vec<u8>> {
-    if !config.is_enabled() || page.len() < MIN_COMPRESS_SIZE {
-        stats.pages_skipped.fetch_add(1, Ordering::Relaxed);
-        return None;
-    }
-
-    // Compress everything from page[2..] onward — this preserves all B-tree
-    // content at those offsets through the round-trip. page[0] (type) and
-    // page[1] (will become algo ID on disk) stay in the clear.
-    let payload = &page[PAYLOAD_OFFSET..];
-    let payload_len = payload.len();
-
-    let compressed: Vec<u8> = match config {
-        CompressionConfig::None => {
-            stats.pages_skipped.fetch_add(1, Ordering::Relaxed);
-            return None;
-        }
-        #[cfg(feature = "compression_lz4")]
-        CompressionConfig::Lz4 => lz4_flex::compress_prepend_size(payload),
-        #[cfg(feature = "compression_zstd")]
-        CompressionConfig::Zstd { level } => {
-            if let Ok(c) = zstd::bulk::compress(payload, level) {
-                c
-            } else {
-                stats.pages_skipped.fetch_add(1, Ordering::Relaxed);
-                return None;
-            }
-        }
-    };
-
-    // Check if compression is actually worth it.
-    // The compressed on-disk page needs: 6-byte header + compressed data.
-    let compressed_total = COMP_DATA_OFFSET + compressed.len();
-    if compressed_total >= page.len()
-        || compressed.len() as f64 > payload_len as f64 * INCOMPRESSIBLE_RATIO
-    {
-        stats.pages_skipped.fetch_add(1, Ordering::Relaxed);
-        return None;
-    }
-
-    // Build the on-disk page
-    let mut out = vec![0u8; page.len()];
-    out[0] = page[0]; // preserve type byte
-    out[1] = config.algorithm().as_byte();
-    #[allow(clippy::cast_possible_truncation)]
-    let compressed_len_u32 = compressed.len() as u32;
-    out[COMP_LEN_OFFSET..COMP_DATA_OFFSET].copy_from_slice(&compressed_len_u32.to_le_bytes());
-    out[COMP_DATA_OFFSET..COMP_DATA_OFFSET + compressed.len()].copy_from_slice(&compressed);
-    // Rest is already zeroed (padding)
-
-    stats
-        .bytes_in
-        .fetch_add(payload_len as u64, Ordering::Relaxed);
-    stats
-        .bytes_out
-        .fetch_add(compressed.len() as u64, Ordering::Relaxed);
-    stats.pages_compressed.fetch_add(1, Ordering::Relaxed);
-
-    Some(out)
-}
-
-/// Decompress a page read from disk.
-///
-/// Checks `page[1]` for compression algorithm. If 0, returns the buffer unchanged.
-/// Otherwise, decompresses and returns a full-size page with `page[1]` cleared to 0.
-#[allow(unreachable_code, unused_variables)]
-pub(crate) fn decompress_page(page: &[u8], stats: &CompressionStats) -> Result<Option<Vec<u8>>> {
-    if page.len() < COMP_DATA_OFFSET {
-        return Ok(None); // Too small to have compression header
-    }
-
-    let algo = CompressionAlgorithm::from_byte(page[1])?;
-    if matches!(algo, CompressionAlgorithm::None) {
-        return Ok(None); // Not compressed
-    }
-
-    let compressed_len =
-        u32::from_le_bytes(page[COMP_LEN_OFFSET..COMP_DATA_OFFSET].try_into().unwrap()) as usize;
-
-    if COMP_DATA_OFFSET + compressed_len > page.len() {
-        return Err(StorageError::Corrupted(format!(
-            "compressed page claims compressed length {compressed_len} \
-             but only {} bytes available after header",
-            page.len() - COMP_DATA_OFFSET
-        )));
-    }
-
-    // Slice only the actual compressed data (excluding zero padding)
-    let compressed_data = &page[COMP_DATA_OFFSET..COMP_DATA_OFFSET + compressed_len];
-
-    // Maximum decompressed size: the original page could not have been larger
-    // than page.len() (same allocation size), and we compressed page[2..],
-    // so max decompressed = page.len() - PAYLOAD_OFFSET.
-    let max_decompressed = page.len() - PAYLOAD_OFFSET;
-
-    let decompressed: Vec<u8> = match algo {
-        CompressionAlgorithm::None => unreachable!(),
-        #[cfg(feature = "compression_lz4")]
-        CompressionAlgorithm::Lz4 => lz4_flex::decompress_size_prepended(compressed_data)
-            .map_err(|e| StorageError::Corrupted(format!("LZ4 decompression failed: {e}")))?,
-        #[cfg(feature = "compression_zstd")]
-        CompressionAlgorithm::Zstd => zstd::bulk::decompress(compressed_data, max_decompressed)
-            .map_err(|e| StorageError::Corrupted(format!("zstd decompression failed: {e}")))?,
-    };
-
-    // Reconstruct the full in-memory page:
-    //   [0] = type byte (from disk)
-    //   [1] = 0 (cleared — no compression flag in memory)
-    //   [2..] = decompressed payload (original page[2..])
-    let mut out = vec![0u8; PAYLOAD_OFFSET + decompressed.len()];
-    out[0] = page[0]; // type byte preserved
-    // out[1] = 0 — already zeroed, no compression in memory
-    out[PAYLOAD_OFFSET..].copy_from_slice(&decompressed);
-
-    stats.pages_decompressed.fetch_add(1, Ordering::Relaxed);
-
-    Ok(Some(out))
-}
-
 // ──────────────────────────────────────────────────────────────────────
 // Value-level compression
 // ──────────────────────────────────────────────────────────────────────
-//
-// Unlike page-level compression (which zero-pads to fixed page slots and
-// saves nothing), value-level compression compresses individual values
-// BEFORE they enter the B-tree. Shorter values → fewer pages → smaller files.
-//
-// Compressed value envelope:
-//   [0]     flags: bit 0 = compressed, bits 1-2 = algo (01=lz4, 10=zstd)
-//   [1..5]  original_size (u32 LE)
-//   [5..]   compressed data
-//
-// If flags == 0x00: the value is stored raw (no envelope overhead).
-// The flags byte is self-describing: decompression never needs config.
 
 /// Minimum value size worth compressing. Below this the 5-byte envelope
 /// overhead exceeds any realistic savings.
@@ -489,195 +223,9 @@ pub(crate) fn decompress_value(data: &[u8]) -> Result<Cow<'_, [u8]>> {
 }
 
 #[cfg(test)]
-#[allow(clippy::cast_possible_truncation, clippy::needless_range_loop)]
+#[allow(clippy::cast_possible_truncation)]
 mod tests {
     use super::*;
-
-    fn make_test_page(size: usize) -> Vec<u8> {
-        let mut page = vec![0u8; size];
-        page[0] = 1; // LEAF type
-        // page[1] = 0 (no compression in memory)
-        // Simulate B-tree metadata at page[2..6]
-        page[2] = 10; // e.g. num_pairs low byte
-        page[3] = 0;
-        page[4] = 0xFF; // some flags
-        page[5] = 0x42; // some data
-        // Compressible repeating pattern for the rest
-        for i in 6..size {
-            page[i] = (i % 64) as u8;
-        }
-        page
-    }
-
-    #[cfg(feature = "compression_lz4")]
-    #[test]
-    fn lz4_round_trip() {
-        let page = make_test_page(4096);
-        let config = CompressionConfig::Lz4;
-        let stats = CompressionStats::new();
-
-        let compressed = compress_page(&page, config, &stats).expect("should compress");
-        assert_eq!(compressed.len(), page.len());
-        assert_eq!(compressed[0], 1); // type preserved
-        assert_eq!(compressed[1], 1); // LZ4 algo
-
-        let decompressed = decompress_page(&compressed, &stats)
-            .expect("no error")
-            .expect("should decompress");
-
-        // Full round-trip: the entire page content must match
-        assert_eq!(decompressed[0], page[0]); // type preserved
-        assert_eq!(decompressed[1], 0); // algo cleared
-        assert_eq!(&decompressed[2..], &page[2..]); // ALL content from offset 2 preserved
-    }
-
-    #[cfg(feature = "compression_zstd")]
-    #[test]
-    fn zstd_round_trip() {
-        let page = make_test_page(4096);
-        let config = CompressionConfig::Zstd { level: 3 };
-        let stats = CompressionStats::new();
-
-        let compressed = compress_page(&page, config, &stats).expect("should compress");
-        assert_eq!(compressed.len(), page.len());
-        assert_eq!(compressed[0], 1); // type preserved
-        assert_eq!(compressed[1], 2); // zstd algo
-
-        let decompressed = decompress_page(&compressed, &stats)
-            .expect("no error")
-            .expect("should decompress");
-
-        assert_eq!(decompressed[0], page[0]);
-        assert_eq!(decompressed[1], 0);
-        assert_eq!(&decompressed[2..], &page[2..]); // ALL content preserved
-    }
-
-    #[cfg(feature = "compression_lz4")]
-    #[test]
-    fn lz4_preserves_btree_metadata() {
-        // Specifically verify that bytes [2..6] survive the round-trip
-        let page = make_test_page(4096);
-        let config = CompressionConfig::Lz4;
-        let stats = CompressionStats::new();
-
-        let compressed = compress_page(&page, config, &stats).expect("should compress");
-        let decompressed = decompress_page(&compressed, &stats)
-            .expect("no error")
-            .expect("should decompress");
-
-        assert_eq!(decompressed[2], 10);
-        assert_eq!(decompressed[3], 0);
-        assert_eq!(decompressed[4], 0xFF);
-        assert_eq!(decompressed[5], 0x42);
-    }
-
-    #[test]
-    fn no_compression_passthrough() {
-        let page = make_test_page(4096);
-        let config = CompressionConfig::None;
-        let stats = CompressionStats::new();
-
-        assert!(compress_page(&page, config, &stats).is_none());
-        assert_eq!(stats.pages_skipped.load(Ordering::Relaxed), 1);
-    }
-
-    #[cfg(feature = "compression_lz4")]
-    #[test]
-    fn small_page_skipped() {
-        let page = make_test_page(64);
-        let stats = CompressionStats::new();
-        let config = CompressionConfig::Lz4;
-        assert!(compress_page(&page, config, &stats).is_none());
-    }
-
-    #[cfg(feature = "compression_lz4")]
-    #[test]
-    fn incompressible_skipped() {
-        // Random data doesn't compress well
-        let mut page = vec![0u8; 4096];
-        page[0] = 1;
-        // Fill with pseudo-random bytes
-        let mut state = 0x12345678u32;
-        for byte in &mut page[2..] {
-            state = state.wrapping_mul(1_103_515_245).wrapping_add(12345);
-            *byte = (state >> 16) as u8;
-        }
-
-        let config = CompressionConfig::Lz4;
-        let stats = CompressionStats::new();
-        let result = compress_page(&page, config, &stats);
-        // Whether it compresses or not depends on the data, but the logic path is tested
-        let _ = result;
-    }
-
-    #[test]
-    fn uncompressed_page_decompress_noop() {
-        let page = make_test_page(4096);
-        let stats = CompressionStats::new();
-        // page[1] == 0, so decompress should return None
-        assert!(decompress_page(&page, &stats).unwrap().is_none());
-    }
-
-    #[cfg(feature = "compression_lz4")]
-    #[test]
-    fn stats_tracking() {
-        let page = make_test_page(4096);
-        let config = CompressionConfig::Lz4;
-        let stats = CompressionStats::new();
-
-        let compressed = compress_page(&page, config, &stats);
-        assert!(compressed.is_some());
-        assert_eq!(stats.pages_compressed.load(Ordering::Relaxed), 1);
-        assert!(stats.bytes_in.load(Ordering::Relaxed) > 0);
-        assert!(stats.bytes_out.load(Ordering::Relaxed) > 0);
-        assert!(stats.ratio().unwrap() < 1.0); // compression saved space
-
-        let _ = decompress_page(&compressed.unwrap(), &stats);
-        assert_eq!(stats.pages_decompressed.load(Ordering::Relaxed), 1);
-    }
-
-    #[cfg(feature = "compression_lz4")]
-    #[test]
-    fn various_page_sizes() {
-        for &size in &[512, 1024, 2048, 4096, 8192, 16384, 65536] {
-            let page = make_test_page(size);
-            let config = CompressionConfig::Lz4;
-            let stats = CompressionStats::new();
-
-            if let Some(compressed) = compress_page(&page, config, &stats) {
-                let decompressed = decompress_page(&compressed, &stats)
-                    .expect("no error")
-                    .expect("should decompress");
-                assert_eq!(decompressed.len(), page.len());
-                assert_eq!(&decompressed[..], &page[..]);
-            }
-        }
-    }
-
-    #[cfg(all(feature = "compression_lz4", feature = "compression_zstd"))]
-    #[test]
-    fn cross_algorithm_detection() {
-        let page = make_test_page(4096);
-        let stats = CompressionStats::new();
-
-        // Compress with LZ4
-        let lz4_compressed =
-            compress_page(&page, CompressionConfig::Lz4, &stats).expect("should compress");
-        assert_eq!(lz4_compressed[1], 1); // LZ4
-
-        // Compress with zstd
-        let zstd_compressed = compress_page(&page, CompressionConfig::Zstd { level: 3 }, &stats)
-            .expect("should compress");
-        assert_eq!(zstd_compressed[1], 2); // zstd
-
-        // Decompress each — the decompressor auto-detects from page[1]
-        let d1 = decompress_page(&lz4_compressed, &stats).unwrap().unwrap();
-        let d2 = decompress_page(&zstd_compressed, &stats).unwrap().unwrap();
-        assert_eq!(d1, d2);
-        assert_eq!(&d1[..], &page[..]);
-    }
-
-    // ── Value-level compression tests ──
 
     fn make_compressible_value(size: usize) -> Vec<u8> {
         (0..size).map(|i| (i % 64) as u8).collect()

--- a/src/tree_store/page_store/page_manager.rs
+++ b/src/tree_store/page_store/page_manager.rs
@@ -53,9 +53,8 @@ pub(crate) const FILE_FORMAT_VERSION2: u8 = 2;
 // * New persistent savepoint format
 pub(crate) const FILE_FORMAT_VERSION3: u8 = 3;
 // New file format:
-// * Adds transparent page-level compression (LZ4 / zstd)
+// * Adds value-level compression (LZ4 / zstd)
 // * Compression algorithm stored in database header
-// * Compressed pages use page[1] as algorithm ID on disk
 pub(crate) const FILE_FORMAT_VERSION4: u8 = 4;
 
 #[derive(Copy, Clone)]
@@ -131,7 +130,6 @@ pub(crate) struct TransactionalMemory {
     // code path where there is no locking
     region_size: u64,
     region_header_with_padding_size: u64,
-    #[allow(dead_code)]
     compression: CompressionConfig,
 }
 
@@ -157,7 +155,7 @@ impl TransactionalMemory {
         );
         assert!(region_size.is_power_of_two());
 
-        let mut storage = PagedCachedFile::new(
+        let storage = PagedCachedFile::new(
             file,
             page_size as u64,
             read_cache_size_bytes,
@@ -242,9 +240,7 @@ impl TransactionalMemory {
         let header_bytes = storage.read_direct(0, DB_HEADER_SIZE)?;
         let (mut header, repair_info) = DatabaseHeader::from_bytes(&header_bytes)?;
         // For existing databases, the on-disk compression config takes precedence.
-        // This ensures we can always decompress pages written with the original algorithm.
         let compression = header.compression;
-        storage.set_compression(compression);
 
         assert_eq!(header.page_size() as usize, page_size);
         assert!(storage.raw_file_len()? >= header.layout().len());
@@ -300,7 +296,6 @@ impl TransactionalMemory {
         })
     }
 
-    #[allow(dead_code)]
     pub(crate) fn compression(&self) -> CompressionConfig {
         self.compression
     }


### PR DESCRIPTION
## Summary

Page-level compression (compressing entire B-tree pages at the cache↔disk boundary) produced **zero file size savings** because pages occupy fixed-size slots that get zero-padded regardless. Value-level compression (PR #35) replaced it by compressing individual values before B-tree insertion, delivering real savings.

This PR removes all page-level compression code:

- **cached_file.rs**: Removed `compression`/`compression_stats` fields, `set_compression()`, `is_compressible_offset()`, `compress_for_write()`, `decompress_from_read()`, `read_page_direct()`. Simplified `flush_write_buffer()` and `write()` to use raw buffers directly.
- **compression.rs**: Removed `CompressionAlgorithm` enum, `CompressionStats`, `compress_page()`, `decompress_page()`, page-level constants, 10 page-level tests. Simplified `CompressionConfig::header_byte()`.
- **page_manager.rs**: Removed `#[allow(dead_code)]` (compression field/method now actively used for value-level), removed `storage.set_compression()` call, updated format version comment.

**-536 lines** of dead code removed.

## Test plan
- [x] `cargo test --all-features` — all tests pass
- [x] `cargo clippy --all-features` — clean
- [x] `cargo fmt --check` — clean
- [x] Compiles clean under no-features, default, and all-features