### PR TITLE
feat: drain() and backup() APIs

### DIFF
--- a/src/db.rs
+++ b/src/db.rs
@@ -552,6 +552,45 @@ impl Database {
         Ok(true)
     }
 
+    /// Creates a consistent backup of the database at the given path.
+    ///
+    /// The backup captures a snapshot of the last committed transaction. This method
+    /// can be called while other read or write transactions are active — it will not
+    /// block writers and will not include uncommitted data.
+    ///
+    /// The resulting file is a valid redb database. Open it with [`Database::open`]
+    /// (recommended, handles any needed repair) or [`Builder::open`].
+    #[allow(clippy::cast_possible_truncation)]
+    pub fn backup(&self, path: impl AsRef<Path>) -> Result<(), StorageError> {
+        use std::io::Write;
+
+        const CHUNK_SIZE: usize = 1024 * 1024; // 1 MB
+
+        // Pin a consistent snapshot so pages aren't reclaimed during the copy
+        let _read_txn = self.begin_read().map_err(|e| e.into_storage_error())?;
+
+        // Flush pending writes to ensure we copy a complete state
+        self.mem.flush_data()?;
+
+        let file_len = self.mem.raw_len()?;
+        let mut dest = File::create(path.as_ref()).map_err(StorageError::Io)?;
+        let mut buf = vec![0u8; CHUNK_SIZE];
+        let mut offset = 0u64;
+
+        while offset < file_len {
+            let remaining = (file_len - offset) as usize;
+            let to_read = remaining.min(CHUNK_SIZE);
+            let chunk = &mut buf[..to_read];
+            self.mem.read_raw(offset, chunk)?;
+            dest.write_all(chunk).map_err(StorageError::Io)?;
+            offset += to_read as u64;
+        }
+
+        dest.sync_all().map_err(StorageError::Io)?;
+
+        Ok(())
+    }
+
     /// Force a check of the integrity of the database file, and repair it if possible.
     ///
     /// Note: Calling this function is unnecessary during normal operation. redb will automatically

--- a/src/multimap_table.rs
+++ b/src/multimap_table.rs
@@ -1325,6 +1325,38 @@ impl<'txn, K: Key + 'static, V: Key + 'static> MultimapTable<'txn, K, V> {
         Ok(existed)
     }
 
+    /// Removes all keys (and their associated values) in the given range
+    ///
+    /// Returns the number of keys removed
+    pub fn drain<'a, KR>(&mut self, range: impl RangeBounds<KR> + 'a) -> Result<u64>
+    where
+        KR: Borrow<K::SelfType<'a>> + 'a,
+    {
+        // Collect keys first to avoid borrow conflict with remove_all
+        let keys: Vec<Vec<u8>> = self
+            .range(range)?
+            .map(|result| result.map(|(k, _)| K::as_bytes(&k.value()).as_ref().to_vec()))
+            .collect::<Result<Vec<_>>>()?;
+
+        let mut count = 0u64;
+        for key_bytes in &keys {
+            let key = K::from_bytes(key_bytes);
+            // Consume the returned iterator to trigger page cleanup
+            for result in self.remove_all(&key)? {
+                result?;
+            }
+            count += 1;
+        }
+        Ok(count)
+    }
+
+    /// Removes all keys (and their associated values) from the table
+    ///
+    /// Returns the number of keys removed
+    pub fn drain_all(&mut self) -> Result<u64> {
+        self.drain::<K::SelfType<'_>>(..)
+    }
+
     /// Removes all values for the given key
     ///
     /// Returns an iterator over the removed values. Values are in ascending order.

--- a/src/table.rs
+++ b/src/table.rs
@@ -194,6 +194,28 @@ impl<'txn, K: Key + 'static, V: Value + 'static> Table<'txn, K, V> {
         self.tree.retain_in(predicate, range)
     }
 
+    /// Removes all key-value pairs in the given range
+    ///
+    /// Returns the number of entries removed
+    pub fn drain<'a, KR>(&mut self, range: impl RangeBounds<KR> + 'a) -> Result<u64>
+    where
+        KR: Borrow<K::SelfType<'a>> + 'a,
+    {
+        let mut count = 0u64;
+        for result in self.extract_from_if(range, |_, _| true)? {
+            result?;
+            count += 1;
+        }
+        Ok(count)
+    }
+
+    /// Removes all key-value pairs from the table
+    ///
+    /// Returns the number of entries removed
+    pub fn drain_all(&mut self) -> Result<u64> {
+        self.drain::<K::SelfType<'_>>(..)
+    }
+
     /// Insert mapping of the given key to the given value
     ///
     /// If key is already present it is replaced

--- a/src/tree_store/page_store/page_manager.rs
+++ b/src/tree_store/page_store/page_manager.rs
@@ -1185,6 +1185,23 @@ impl TransactionalMemory {
         self.page_size.try_into().unwrap()
     }
 
+    /// Flush all pending writes to the underlying storage
+    pub(crate) fn flush_data(&self) -> Result {
+        self.storage.flush()
+    }
+
+    /// Read raw bytes from the underlying storage, bypassing the cache
+    pub(crate) fn read_raw(&self, offset: u64, buf: &mut [u8]) -> Result {
+        let data = self.storage.read_direct(offset, buf.len())?;
+        buf.copy_from_slice(&data);
+        Ok(())
+    }
+
+    /// Get the raw file length of the underlying storage
+    pub(crate) fn raw_len(&self) -> Result<u64> {
+        self.storage.raw_file_len()
+    }
+
     pub(crate) fn close(&self) -> Result {
         if !self.needs_recovery.load(Ordering::Acquire) && !thread::panicking() {
             let mut state = self.state.lock()?;

--- a/tests/basic_tests.rs
+++ b/tests/basic_tests.rs
@@ -1990,6 +1990,128 @@ fn char_type() {
     assert!(iter.next().is_none());
 }
 
+#[test]
+fn drain_range() {
+    let tmpfile = create_tempfile();
+    let db = Database::create(tmpfile.path()).unwrap();
+
+    let write_txn = db.begin_write().unwrap();
+    {
+        let mut table = write_txn.open_table(U64_TABLE).unwrap();
+        for i in 0..100 {
+            table.insert(&i, &(i * 10)).unwrap();
+        }
+    }
+    write_txn.commit().unwrap();
+
+    // Drain a subrange
+    let write_txn = db.begin_write().unwrap();
+    {
+        let mut table = write_txn.open_table(U64_TABLE).unwrap();
+        let removed = table.drain(50u64..80).unwrap();
+        assert_eq!(removed, 30);
+        assert_eq!(table.len().unwrap(), 70);
+    }
+    write_txn.commit().unwrap();
+
+    // Verify remaining keys
+    let read_txn = db.begin_read().unwrap();
+    let table = read_txn.open_table(U64_TABLE).unwrap();
+    assert_eq!(table.len().unwrap(), 70);
+    // Keys 0..50 should exist
+    for i in 0..50 {
+        assert!(table.get(&i).unwrap().is_some());
+    }
+    // Keys 50..80 should be gone
+    for i in 50..80 {
+        assert!(table.get(&i).unwrap().is_none());
+    }
+    // Keys 80..100 should exist
+    for i in 80..100 {
+        assert!(table.get(&i).unwrap().is_some());
+    }
+}
+
+#[test]
+fn drain_all() {
+    let tmpfile = create_tempfile();
+    let db = Database::create(tmpfile.path()).unwrap();
+
+    let write_txn = db.begin_write().unwrap();
+    {
+        let mut table = write_txn.open_table(U64_TABLE).unwrap();
+        for i in 0..50 {
+            table.insert(&i, &i).unwrap();
+        }
+    }
+    write_txn.commit().unwrap();
+
+    let write_txn = db.begin_write().unwrap();
+    {
+        let mut table = write_txn.open_table(U64_TABLE).unwrap();
+        let removed = table.drain_all().unwrap();
+        assert_eq!(removed, 50);
+        assert_eq!(table.len().unwrap(), 0);
+    }
+    write_txn.commit().unwrap();
+}
+
+#[cfg(not(target_os = "wasi"))]
+#[test]
+fn backup_and_restore() {
+    let tmpfile = create_tempfile();
+    let backup_file = create_tempfile();
+    let db = Database::create(tmpfile.path()).unwrap();
+
+    // Insert test data
+    let write_txn = db.begin_write().unwrap();
+    {
+        let mut table = write_txn.open_table(U64_TABLE).unwrap();
+        for i in 0..1000 {
+            table.insert(&i, &(i * 3)).unwrap();
+        }
+    }
+    write_txn.commit().unwrap();
+
+    // Create backup
+    db.backup(backup_file.path()).unwrap();
+
+    // Open backup with Database::open (handles quick repair on first open)
+    let backup_db = Database::open(backup_file.path()).unwrap();
+    let read_txn = backup_db.begin_read().unwrap();
+    let table = read_txn.open_table(U64_TABLE).unwrap();
+    assert_eq!(table.len().unwrap(), 1000);
+    for i in 0..1000 {
+        assert_eq!(table.get(&i).unwrap().unwrap().value(), i * 3);
+    }
+}
+
+#[cfg(not(target_os = "wasi"))]
+#[test]
+fn backup_while_reading() {
+    let tmpfile = create_tempfile();
+    let backup_file = create_tempfile();
+    let db = Database::create(tmpfile.path()).unwrap();
+
+    let write_txn = db.begin_write().unwrap();
+    {
+        let mut table = write_txn.open_table(U64_TABLE).unwrap();
+        for i in 0..100 {
+            table.insert(&i, &i).unwrap();
+        }
+    }
+    write_txn.commit().unwrap();
+
+    // Hold a read transaction while backing up
+    let _read_txn = db.begin_read().unwrap();
+    db.backup(backup_file.path()).unwrap();
+
+    let backup_db = Database::open(backup_file.path()).unwrap();
+    let read_txn = backup_db.begin_read().unwrap();
+    let table = read_txn.open_table(U64_TABLE).unwrap();
+    assert_eq!(table.len().unwrap(), 100);
+}
+
 // Test that &[u8; N] and [u8; N] are effectively the same
 #[test]
 fn u8_array_serialization() {

--- a/tests/multimap_tests.rs
+++ b/tests/multimap_tests.rs
@@ -417,3 +417,70 @@ fn multimap_signature_lifetimes() {
     }
     write_txn.commit().unwrap();
 }
+
+#[test]
+fn multimap_drain_range() {
+    let tmpfile = create_tempfile();
+    let db = Database::create(tmpfile.path()).unwrap();
+
+    let write_txn = db.begin_write().unwrap();
+    {
+        let mut table = write_txn.open_multimap_table(U64_TABLE).unwrap();
+        for i in 0..20u64 {
+            table.insert(&i, &(i * 10)).unwrap();
+            table.insert(&i, &(i * 10 + 1)).unwrap();
+        }
+    }
+    write_txn.commit().unwrap();
+
+    // Drain keys 5..15
+    let write_txn = db.begin_write().unwrap();
+    {
+        let mut table = write_txn.open_multimap_table(U64_TABLE).unwrap();
+        let removed_keys = table.drain(5u64..15).unwrap();
+        assert_eq!(removed_keys, 10);
+    }
+    write_txn.commit().unwrap();
+
+    // Verify remaining
+    let read_txn = db.begin_read().unwrap();
+    let table = read_txn.open_multimap_table(U64_TABLE).unwrap();
+    // 10 keys remain (0..5 and 15..20), each with 2 values
+    assert_eq!(table.len().unwrap(), 20);
+    for i in 0..5u64 {
+        let mut iter = table.get(&i).unwrap();
+        assert!(iter.next().is_some());
+    }
+    for i in 5..15u64 {
+        let mut iter = table.get(&i).unwrap();
+        assert!(iter.next().is_none());
+    }
+    for i in 15..20u64 {
+        let mut iter = table.get(&i).unwrap();
+        assert!(iter.next().is_some());
+    }
+}
+
+#[test]
+fn multimap_drain_all() {
+    let tmpfile = create_tempfile();
+    let db = Database::create(tmpfile.path()).unwrap();
+
+    let write_txn = db.begin_write().unwrap();
+    {
+        let mut table = write_txn.open_multimap_table(U64_TABLE).unwrap();
+        for i in 0..10u64 {
+            table.insert(&i, &i).unwrap();
+        }
+    }
+    write_txn.commit().unwrap();
+
+    let write_txn = db.begin_write().unwrap();
+    {
+        let mut table = write_txn.open_multimap_table(U64_TABLE).unwrap();
+        let removed = table.drain_all().unwrap();
+        assert_eq!(removed, 10);
+        assert_eq!(table.len().unwrap(), 0);
+    }
+    write_txn.commit().unwrap();
+}


### PR DESCRIPTION
## Summary

- **`Table::drain(range)`** — removes all key-value pairs in a range, returns count removed
- **`Table::drain_all()`** — convenience wrapper for `drain(..)`
- **`MultimapTable::drain(range)`** — removes all keys (and their values) in a range
- **`MultimapTable::drain_all()`** — convenience wrapper
- **`Database::backup(path)`** — creates a consistent snapshot backup using MVCC snapshot isolation (read txn pins pages, flushes pending writes, copies file in 1MB chunks)

Closes #8, closes #22

## Test plan
- [x] `drain_range` — insert 100 keys, drain 50..80, verify 70 remain with correct key distribution
- [x] `drain_all` — insert 50 keys, drain all, verify empty
- [x] `multimap_drain_range` — 20 keys × 2 values each, drain 5..15, verify 10 keys remain
- [x] `multimap_drain_all` — insert 10 keys, drain all, verify empty
- [x] `backup_and_restore` — insert 1000 entries, backup, open backup, verify all data matches
- [x] `backup_while_reading` — backup while a read transaction is active
- [x] Full test suite: 248 tests pass, clippy clean, fmt clean