### PR TITLE
feat: native vector types with distance functions (#11)

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -99,10 +99,12 @@ pub use merge::{
 };
 pub use temporal::HybridLogicalClock;
 pub use ttl_table::{ReadOnlyTtlTable, TtlAccessGuard, TtlRange, TtlTable, TtlTableDefinition};
-pub use vector::{DynVec, FixedVec};
+pub use vector::{BinaryQuantized, DynVec, FixedVec, SQVec, ScalarQuantized};
 pub use vector_ops::{
-    cosine_distance, cosine_similarity, dot_product, euclidean_distance_sq, hamming_distance,
-    l2_norm, l2_normalize, l2_normalized, manhattan_distance, read_f32_le, write_f32_le,
+    DistanceMetric, Neighbor, cosine_distance, cosine_similarity, dequantize_scalar, dot_product,
+    euclidean_distance_sq, hamming_distance, l2_norm, l2_normalize, l2_normalized,
+    manhattan_distance, nearest_k, nearest_k_fixed, quantize_binary, quantize_scalar, read_f32_le,
+    sq_dot_product, sq_euclidean_distance_sq, write_f32_le,
 };
 
 pub type Result<T = (), E = StorageError> = std::result::Result<T, E>;

--- a/src/vector.rs
+++ b/src/vector.rs
@@ -174,3 +174,191 @@ impl Value for DynVec {
         TypeName::internal("redb::vec::DynVec")
     }
 }
+
+/// Binary quantized vector type for ultra-compact storage.
+///
+/// `BinaryQuantized<N>` stores `N` bytes representing `N * 8` binary dimensions.
+/// Each bit encodes whether the corresponding f32 dimension was positive (1) or
+/// negative/zero (0). This gives 32x compression over full f32 vectors.
+///
+/// Use [`quantize_binary`] to convert f32 vectors to binary, and
+/// [`hamming_distance`](crate::hamming_distance) to compare.
+///
+/// # Storage layout
+///
+/// `fixed_width() = Some(N)` -- exactly `N` bytes, no header.
+///
+/// # Usage
+///
+/// ```rust,ignore
+/// use redb::{Database, TableDefinition, BinaryQuantized};
+/// use redb::vector_ops::quantize_binary;
+///
+/// // 384 f32 dims -> 48 bytes (384/8)
+/// const BQ_TABLE: TableDefinition<u64, BinaryQuantized<48>> = TableDefinition::new("bq_emb");
+///
+/// let embedding: [f32; 384] = compute_embedding();
+/// let binary = quantize_binary(&embedding); // Vec<u8>, len=48
+/// let bytes: [u8; 48] = binary.try_into().unwrap();
+/// table.insert(&1u64, &bytes)?;
+/// ```
+pub struct BinaryQuantized<const N: usize>;
+
+impl<const N: usize> Debug for BinaryQuantized<N> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "BinaryQuantized<{N}>")
+    }
+}
+
+impl<const N: usize> Value for BinaryQuantized<N> {
+    type SelfType<'a>
+        = [u8; N]
+    where
+        Self: 'a;
+
+    type AsBytes<'a>
+        = [u8; N]
+    where
+        Self: 'a;
+
+    fn fixed_width() -> Option<usize> {
+        Some(N)
+    }
+
+    fn from_bytes<'a>(data: &'a [u8]) -> [u8; N]
+    where
+        Self: 'a,
+    {
+        data.try_into().unwrap()
+    }
+
+    fn as_bytes<'a, 'b: 'a>(value: &'a [u8; N]) -> [u8; N]
+    where
+        Self: 'b,
+    {
+        *value
+    }
+
+    fn type_name() -> TypeName {
+        TypeName::internal(&format!("redb::vec::BinaryQuantized<{N}>"))
+    }
+}
+
+impl<const N: usize> MutInPlaceValue for BinaryQuantized<N> {
+    type BaseRefType = [u8];
+
+    fn initialize(data: &mut [u8]) {
+        data.fill(0);
+    }
+
+    fn from_bytes_mut(data: &mut [u8]) -> &mut [u8] {
+        data
+    }
+}
+
+/// Scalar quantized vector with per-vector min/max scale factors.
+///
+/// `ScalarQuantized<N>` stores `N` dimensions as `u8` values (0..255) plus two
+/// `f32` scale factors (`min_val`, `max_val`), giving approximately 4x compression
+/// over full f32 storage with bounded quantization error.
+///
+/// # Storage layout
+///
+/// ```text
+/// [min_val: f32 LE][max_val: f32 LE][q0: u8][q1: u8]...[q_{N-1}: u8]
+/// ```
+///
+/// `fixed_width() = Some(8 + N)` -- 8 bytes header + N quantized values.
+///
+/// # Quantization formula
+///
+/// Encode: `q_i = round(255 * (x_i - min) / (max - min))`
+/// Decode: `x_i = min + q_i * (max - min) / 255`
+///
+/// Use [`quantize_scalar`] and [`dequantize_scalar`] for conversion.
+pub struct ScalarQuantized<const N: usize>;
+
+impl<const N: usize> Debug for ScalarQuantized<N> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "ScalarQuantized<{N}>")
+    }
+}
+
+/// Header size for scalar quantized vectors: `min_val` (4 bytes) + `max_val` (4 bytes).
+const SQ_HEADER: usize = 8;
+
+impl<const N: usize> Value for ScalarQuantized<N> {
+    type SelfType<'a>
+        = SQVec<N>
+    where
+        Self: 'a;
+
+    type AsBytes<'a>
+        = Vec<u8>
+    where
+        Self: 'a;
+
+    fn fixed_width() -> Option<usize> {
+        Some(SQ_HEADER + N)
+    }
+
+    fn from_bytes<'a>(data: &'a [u8]) -> SQVec<N>
+    where
+        Self: 'a,
+    {
+        assert_eq!(data.len(), SQ_HEADER + N);
+        let min_val = f32::from_le_bytes(data[0..4].try_into().unwrap());
+        let max_val = f32::from_le_bytes(data[4..8].try_into().unwrap());
+        let mut codes = [0u8; N];
+        codes.copy_from_slice(&data[SQ_HEADER..]);
+        SQVec {
+            min_val,
+            max_val,
+            codes,
+        }
+    }
+
+    fn as_bytes<'a, 'b: 'a>(value: &'a SQVec<N>) -> Vec<u8>
+    where
+        Self: 'b,
+    {
+        let mut result = Vec::with_capacity(SQ_HEADER + N);
+        result.extend_from_slice(&value.min_val.to_le_bytes());
+        result.extend_from_slice(&value.max_val.to_le_bytes());
+        result.extend_from_slice(&value.codes);
+        result
+    }
+
+    fn type_name() -> TypeName {
+        TypeName::internal(&format!("redb::vec::ScalarQuantized<{N}>"))
+    }
+}
+
+/// The decoded representation of a [`ScalarQuantized<N>`] value.
+#[derive(Debug, Clone, PartialEq)]
+pub struct SQVec<const N: usize> {
+    /// Minimum value of the original f32 vector (scale floor).
+    pub min_val: f32,
+    /// Maximum value of the original f32 vector (scale ceiling).
+    pub max_val: f32,
+    /// Quantized codes: each u8 maps linearly to `[min_val, max_val]`.
+    pub codes: [u8; N],
+}
+
+impl<const N: usize> SQVec<N> {
+    /// Dequantizes the codes back to f32 values.
+    #[inline]
+    pub fn dequantize(&self) -> [f32; N] {
+        let mut result = [0.0f32; N];
+        let range = self.max_val - self.min_val;
+        if range == 0.0 {
+            result.fill(self.min_val);
+        } else {
+            let scale = range / 255.0;
+            for (i, &code) in self.codes.iter().enumerate() {
+                result[i] = self.min_val + f32::from(code) * scale;
+            }
+        }
+        result
+    }
+}

--- a/src/vector_ops.rs
+++ b/src/vector_ops.rs
@@ -1,3 +1,75 @@
+use std::collections::BinaryHeap;
+use std::fmt::{self, Debug};
+
+use crate::vector::SQVec;
+
+// ---------------------------------------------------------------------------
+// Distance metric enum
+// ---------------------------------------------------------------------------
+
+/// Specifies the distance metric for vector similarity search.
+///
+/// Lower distance values indicate more similar vectors for all metrics.
+///
+/// # Usage
+///
+/// ```rust,ignore
+/// use redb::{DistanceMetric, FixedVec, TableDefinition, ReadableTable};
+///
+/// let query = [1.0f32, 0.0, 0.0];
+/// let metric = DistanceMetric::Cosine;
+///
+/// // Scan and rank vectors
+/// for entry in table.iter()? {
+///     let (key, guard) = entry?;
+///     let vec = guard.value();
+///     let dist = metric.compute(&query, &vec);
+///     println!("{}: {}", key.value(), dist);
+/// }
+/// ```
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum DistanceMetric {
+    /// Cosine distance: `1.0 - cosine_similarity(a, b)`. Range `[0.0, 2.0]`.
+    Cosine,
+    /// Squared Euclidean distance: `sum((a_i - b_i)^2)`. Range `[0.0, inf)`.
+    EuclideanSq,
+    /// Dot product distance: `-dot_product(a, b)`. Negate so lower = more similar.
+    /// Use with L2-normalized vectors for equivalent cosine ranking without sqrt.
+    DotProduct,
+    /// Manhattan (L1) distance: `sum(|a_i - b_i|)`. Range `[0.0, inf)`.
+    Manhattan,
+}
+
+impl DistanceMetric {
+    /// Computes the distance between two f32 vectors using this metric.
+    ///
+    /// Lower values indicate more similar vectors for all metrics.
+    #[inline]
+    pub fn compute(&self, a: &[f32], b: &[f32]) -> f32 {
+        match self {
+            Self::Cosine => cosine_distance(a, b),
+            Self::EuclideanSq => euclidean_distance_sq(a, b),
+            Self::DotProduct => -dot_product(a, b),
+            Self::Manhattan => manhattan_distance(a, b),
+        }
+    }
+}
+
+impl fmt::Display for DistanceMetric {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Cosine => f.write_str("cosine"),
+            Self::EuclideanSq => f.write_str("euclidean_sq"),
+            Self::DotProduct => f.write_str("dot_product"),
+            Self::Manhattan => f.write_str("manhattan"),
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Core distance functions
+// ---------------------------------------------------------------------------
+
 /// Computes the dot product of two f32 slices.
 ///
 /// # Panics
@@ -125,6 +197,10 @@ pub fn hamming_distance(a: &[u8], b: &[u8]) -> u32 {
         .sum()
 }
 
+// ---------------------------------------------------------------------------
+// Normalization
+// ---------------------------------------------------------------------------
+
 /// Computes the L2 (Euclidean) norm of a vector.
 ///
 /// Returns `sqrt(sum(x_i^2))`.
@@ -159,6 +235,293 @@ pub fn l2_normalized(v: &[f32]) -> Vec<f32> {
     l2_normalize(&mut out);
     out
 }
+
+// ---------------------------------------------------------------------------
+// Quantization
+// ---------------------------------------------------------------------------
+
+/// Converts an f32 vector to a binary quantized representation.
+///
+/// Each f32 dimension is mapped to a single bit: 1 if positive, 0 otherwise.
+/// The result is packed into bytes (MSB-first within each byte), with the
+/// output length equal to `ceil(input.len() / 8)`.
+///
+/// This gives 32x compression over f32 storage. Use
+/// [`hamming_distance`] to compare binary vectors.
+///
+/// # Example
+///
+/// ```rust,ignore
+/// let v = [1.0f32, -0.5, 0.3, -0.1, 0.0, 0.7, -0.2, 0.9];
+/// let bq = redb::quantize_binary(&v);
+/// // bit pattern: [1,0,1,0, 0,1,0,1] = 0b10100101 = 0xA5
+/// assert_eq!(bq, vec![0xA5]);
+/// ```
+pub fn quantize_binary(v: &[f32]) -> Vec<u8> {
+    let byte_count = v.len().div_ceil(8);
+    let mut result = vec![0u8; byte_count];
+    for (i, &val) in v.iter().enumerate() {
+        if val > 0.0 {
+            let byte_idx = i / 8;
+            let bit_idx = 7 - (i % 8); // MSB-first
+            result[byte_idx] |= 1 << bit_idx;
+        }
+    }
+    result
+}
+
+/// Scalar-quantizes an f32 vector to u8 codes with min/max scale factors.
+///
+/// Maps each f32 value linearly to the `[0, 255]` range based on the vector's
+/// min and max values. Returns an [`SQVec`] containing the scale factors and codes.
+///
+/// This gives approximately 4x compression over f32 storage with bounded
+/// quantization error of `(max - min) / 510` per dimension.
+///
+/// # Example
+///
+/// ```rust,ignore
+/// let v = [0.0f32, 0.5, 1.0, 0.25];
+/// let sq: SQVec<4> = redb::quantize_scalar(&v);
+/// assert_eq!(sq.min_val, 0.0);
+/// assert_eq!(sq.max_val, 1.0);
+/// assert_eq!(sq.codes[2], 255); // max maps to 255
+/// ```
+pub fn quantize_scalar<const N: usize>(v: &[f32; N]) -> SQVec<N> {
+    let mut min_val = f32::INFINITY;
+    let mut max_val = f32::NEG_INFINITY;
+    for &x in v {
+        if x < min_val {
+            min_val = x;
+        }
+        if x > max_val {
+            max_val = x;
+        }
+    }
+
+    let mut codes = [0u8; N];
+    let range = max_val - min_val;
+    if range > 0.0 {
+        let inv_range = 255.0 / range;
+        for (i, &x) in v.iter().enumerate() {
+            // Quantize to [0, 255]: value is guaranteed non-negative and <= 255.5
+            // because x is clamped within [min_val, max_val].
+            #[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
+            let q = ((x - min_val) * inv_range + 0.5) as u8;
+            codes[i] = q;
+        }
+    }
+    // If range == 0 all codes stay 0, and dequantize returns min_val for all
+
+    SQVec {
+        min_val,
+        max_val,
+        codes,
+    }
+}
+
+/// Dequantizes an [`SQVec`] back to an array of f32 values.
+///
+/// This is a convenience wrapper around [`SQVec::dequantize`].
+#[inline]
+pub fn dequantize_scalar<const N: usize>(sq: &SQVec<N>) -> [f32; N] {
+    sq.dequantize()
+}
+
+/// Computes approximate squared Euclidean distance between an f32 query and
+/// a scalar-quantized vector, dequantizing on the fly.
+///
+/// This avoids materializing the full f32 vector when doing distance
+/// comparisons during search, reducing memory bandwidth.
+#[inline]
+pub fn sq_euclidean_distance_sq<const N: usize>(query: &[f32; N], sq: &SQVec<N>) -> f32 {
+    let range = sq.max_val - sq.min_val;
+    if range == 0.0 {
+        // All codes map to min_val
+        let d = query[0] - sq.min_val;
+        #[allow(clippy::cast_precision_loss)]
+        return d * d * (N as f32);
+    }
+    let scale = range / 255.0;
+    let mut sum = 0.0f32;
+    for (i, &q) in query.iter().enumerate() {
+        let dequant = sq.min_val + f32::from(sq.codes[i]) * scale;
+        let diff = q - dequant;
+        sum += diff * diff;
+    }
+    sum
+}
+
+/// Computes approximate dot product between an f32 query and a scalar-quantized
+/// vector, dequantizing on the fly.
+#[inline]
+pub fn sq_dot_product<const N: usize>(query: &[f32; N], sq: &SQVec<N>) -> f32 {
+    let range = sq.max_val - sq.min_val;
+    if range == 0.0 {
+        return query.iter().sum::<f32>() * sq.min_val;
+    }
+    let scale = range / 255.0;
+    let mut sum = 0.0f32;
+    for (i, &q) in query.iter().enumerate() {
+        let dequant = sq.min_val + f32::from(sq.codes[i]) * scale;
+        sum += q * dequant;
+    }
+    sum
+}
+
+// ---------------------------------------------------------------------------
+// Top-K scan
+// ---------------------------------------------------------------------------
+
+/// A scored result from a nearest-neighbor search.
+#[derive(Debug, Clone)]
+pub struct Neighbor<K> {
+    /// The key of the matching row.
+    pub key: K,
+    /// The distance from the query vector (lower = more similar).
+    pub distance: f32,
+}
+
+impl<K> PartialEq for Neighbor<K> {
+    fn eq(&self, other: &Self) -> bool {
+        self.distance == other.distance
+    }
+}
+
+impl<K> Eq for Neighbor<K> {}
+
+impl<K> PartialOrd for Neighbor<K> {
+    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl<K> Ord for Neighbor<K> {
+    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
+        // BinaryHeap is a max-heap; we want the *largest* distance at the top
+        // so we can efficiently evict it. This is standard top-k min-heap trick.
+        self.distance
+            .partial_cmp(&other.distance)
+            .unwrap_or(std::cmp::Ordering::Equal)
+    }
+}
+
+/// Brute-force top-k nearest neighbor scan over an iterator of `(key, vector)` pairs.
+///
+/// Returns up to `k` nearest neighbors sorted by ascending distance (closest first).
+/// The distance function should return lower values for more similar vectors.
+///
+/// This is the fundamental building block for vector search. Higher-level index
+/// structures (IVF, HNSW) use this for scanning candidate shortlists.
+///
+/// # Example
+///
+/// ```rust,ignore
+/// use redb::{nearest_k, DistanceMetric, FixedVec, ReadableTable};
+///
+/// let query = [1.0f32, 0.0, 0.0, 0.0];
+/// let metric = DistanceMetric::Cosine;
+///
+/// let results = nearest_k(
+///     table.iter()?.map(|r| {
+///         let (k, v) = r.unwrap();
+///         (k.value(), v.value())
+///     }),
+///     &query,
+///     10,
+///     |a, b| metric.compute(a, b),
+/// );
+///
+/// for neighbor in &results {
+///     println!("key={}, distance={}", neighbor.key, neighbor.distance);
+/// }
+/// ```
+pub fn nearest_k<K, I, F>(iter: I, query: &[f32], k: usize, distance_fn: F) -> Vec<Neighbor<K>>
+where
+    I: Iterator<Item = (K, Vec<f32>)>,
+    F: Fn(&[f32], &[f32]) -> f32,
+{
+    if k == 0 {
+        return Vec::new();
+    }
+
+    // Max-heap of size k: the root is the worst (largest distance) candidate.
+    // When we find something better, we pop the worst and push the new one.
+    let mut heap: BinaryHeap<Neighbor<K>> = BinaryHeap::with_capacity(k + 1);
+
+    for (key, vec) in iter {
+        let dist = distance_fn(query, &vec);
+        if heap.len() < k {
+            heap.push(Neighbor {
+                key,
+                distance: dist,
+            });
+        } else if heap.peek().is_some_and(|worst| dist < worst.distance) {
+            heap.pop();
+            heap.push(Neighbor {
+                key,
+                distance: dist,
+            });
+        }
+    }
+
+    let mut results: Vec<Neighbor<K>> = heap.into_vec();
+    results.sort_by(|a, b| {
+        a.distance
+            .partial_cmp(&b.distance)
+            .unwrap_or(std::cmp::Ordering::Equal)
+    });
+    results
+}
+
+/// Brute-force top-k scan with a fixed-size array query (zero-copy variant).
+///
+/// Same as [`nearest_k`] but takes `[f32; N]` vectors from the iterator,
+/// avoiding the `Vec<f32>` allocation overhead for fixed-dimension tables.
+pub fn nearest_k_fixed<K, I, F, const N: usize>(
+    iter: I,
+    query: &[f32; N],
+    k: usize,
+    distance_fn: F,
+) -> Vec<Neighbor<K>>
+where
+    I: Iterator<Item = (K, [f32; N])>,
+    F: Fn(&[f32], &[f32]) -> f32,
+{
+    if k == 0 {
+        return Vec::new();
+    }
+
+    let mut heap: BinaryHeap<Neighbor<K>> = BinaryHeap::with_capacity(k + 1);
+
+    for (key, vec) in iter {
+        let dist = distance_fn(query.as_slice(), vec.as_slice());
+        if heap.len() < k {
+            heap.push(Neighbor {
+                key,
+                distance: dist,
+            });
+        } else if heap.peek().is_some_and(|worst| dist < worst.distance) {
+            heap.pop();
+            heap.push(Neighbor {
+                key,
+                distance: dist,
+            });
+        }
+    }
+
+    let mut results: Vec<Neighbor<K>> = heap.into_vec();
+    results.sort_by(|a, b| {
+        a.distance
+            .partial_cmp(&b.distance)
+            .unwrap_or(std::cmp::Ordering::Equal)
+    });
+    results
+}
+
+// ---------------------------------------------------------------------------
+// LE byte helpers
+// ---------------------------------------------------------------------------
 
 /// Writes a slice of f32 values as little-endian bytes into a destination buffer.
 ///

--- a/tests/vector_tests.rs
+++ b/tests/vector_tests.rs
@@ -1,4 +1,7 @@
-use redb::{Database, DynVec, FixedVec, ReadableDatabase, ReadableTableMetadata, TableDefinition};
+use redb::{
+    BinaryQuantized, Database, DistanceMetric, DynVec, FixedVec, ReadableDatabase, ReadableTable,
+    ReadableTableMetadata, ScalarQuantized, TableDefinition,
+};
 
 const TABLE_VEC4: TableDefinition<u64, FixedVec<4>> = TableDefinition::new("vectors_4d");
 const TABLE_VEC384: TableDefinition<u64, FixedVec<384>> = TableDefinition::new("vectors_384d");
@@ -383,4 +386,267 @@ fn hamming_distance_basic() {
     let c: [u8; 1] = [0b0000_0000];
     let d: [u8; 1] = [0b1111_1111];
     assert_eq!(redb::hamming_distance(&c, &d), 8);
+}
+
+// ---------------------------------------------------------------------------
+// Binary quantization
+// ---------------------------------------------------------------------------
+
+#[test]
+fn quantize_binary_basic() {
+    // 8 dims -> 1 byte
+    let v = [1.0f32, -0.5, 0.3, -0.1, 0.0, 0.7, -0.2, 0.9];
+    let bq = redb::quantize_binary(&v);
+    // positive bits: [1,0,1,0, 0,1,0,1] = 0b10100101 = 0xA5
+    assert_eq!(bq.len(), 1);
+    assert_eq!(bq[0], 0xA5);
+}
+
+#[test]
+fn quantize_binary_non_multiple_of_8() {
+    // 5 dims -> 1 byte, last 3 bits unused (0)
+    let v = [1.0f32, 1.0, 1.0, 1.0, 1.0];
+    let bq = redb::quantize_binary(&v);
+    assert_eq!(bq.len(), 1);
+    // bits: [1,1,1,1,1,0,0,0] = 0b11111000 = 0xF8
+    assert_eq!(bq[0], 0xF8);
+}
+
+#[test]
+fn binary_quantized_store_and_search() {
+    let tmpfile = create_tempfile();
+    let db = Database::create(tmpfile.path()).unwrap();
+
+    // 8 dimensions -> 1 byte binary
+    const BQ_TABLE: TableDefinition<u64, BinaryQuantized<1>> = TableDefinition::new("bq_vectors");
+
+    let v1 = [1.0f32, -1.0, 1.0, -1.0, 1.0, -1.0, 1.0, -1.0];
+    let v2 = [1.0f32, 1.0, 1.0, 1.0, -1.0, -1.0, -1.0, -1.0];
+    let bq1: [u8; 1] = redb::quantize_binary(&v1).try_into().unwrap();
+    let bq2: [u8; 1] = redb::quantize_binary(&v2).try_into().unwrap();
+
+    let write_txn = db.begin_write().unwrap();
+    {
+        let mut table = write_txn.open_table(BQ_TABLE).unwrap();
+        table.insert(&1u64, &bq1).unwrap();
+        table.insert(&2u64, &bq2).unwrap();
+    }
+    write_txn.commit().unwrap();
+
+    let read_txn = db.begin_read().unwrap();
+    let table = read_txn.open_table(BQ_TABLE).unwrap();
+    let stored1 = table.get(&1u64).unwrap().unwrap().value();
+    let stored2 = table.get(&2u64).unwrap().unwrap().value();
+
+    // Query matches v1 pattern
+    let query = redb::quantize_binary(&v1);
+    let d1 = redb::hamming_distance(&stored1, &query);
+    let d2 = redb::hamming_distance(&stored2, &query);
+    assert_eq!(d1, 0); // exact match
+    assert!(d2 > 0); // different
+}
+
+// ---------------------------------------------------------------------------
+// Scalar quantization
+// ---------------------------------------------------------------------------
+
+#[test]
+fn scalar_quantize_roundtrip() {
+    let v: [f32; 4] = [0.0, 0.5, 1.0, 0.25];
+    let sq = redb::quantize_scalar(&v);
+    assert_eq!(sq.min_val, 0.0);
+    assert_eq!(sq.max_val, 1.0);
+    assert_eq!(sq.codes[0], 0); // min -> 0
+    assert_eq!(sq.codes[2], 255); // max -> 255
+
+    let dq = redb::dequantize_scalar(&sq);
+    for i in 0..4 {
+        assert!(
+            (dq[i] - v[i]).abs() < 0.005,
+            "dim {i}: expected {}, got {}",
+            v[i],
+            dq[i]
+        );
+    }
+}
+
+#[test]
+fn scalar_quantize_constant_vector() {
+    let v: [f32; 4] = [0.5, 0.5, 0.5, 0.5];
+    let sq = redb::quantize_scalar(&v);
+    let dq = sq.dequantize();
+    for val in &dq {
+        assert!((val - 0.5).abs() < f32::EPSILON);
+    }
+}
+
+#[test]
+fn scalar_quantized_store_and_retrieve() {
+    let tmpfile = create_tempfile();
+    let db = Database::create(tmpfile.path()).unwrap();
+
+    const SQ_TABLE: TableDefinition<u64, ScalarQuantized<4>> = TableDefinition::new("sq_vectors");
+
+    let original = [0.1f32, 0.5, 0.9, 0.3];
+    let sq = redb::quantize_scalar(&original);
+
+    let write_txn = db.begin_write().unwrap();
+    {
+        let mut table = write_txn.open_table(SQ_TABLE).unwrap();
+        table.insert(&1u64, &sq).unwrap();
+    }
+    write_txn.commit().unwrap();
+
+    let read_txn = db.begin_read().unwrap();
+    let table = read_txn.open_table(SQ_TABLE).unwrap();
+    let stored = table.get(&1u64).unwrap().unwrap().value();
+    let recovered = stored.dequantize();
+    for i in 0..4 {
+        assert!(
+            (recovered[i] - original[i]).abs() < 0.005,
+            "dim {i}: expected {}, got {}",
+            original[i],
+            recovered[i]
+        );
+    }
+}
+
+#[test]
+fn sq_distance_approximation() {
+    let a: [f32; 4] = [0.1, 0.5, 0.9, 0.3];
+    let b: [f32; 4] = [0.2, 0.4, 0.8, 0.6];
+    let sq_b = redb::quantize_scalar(&b);
+
+    let exact_dist = redb::euclidean_distance_sq(&a, &b);
+    let approx_dist = redb::sq_euclidean_distance_sq(&a, &sq_b);
+
+    // Approximate distance should be close to exact (within quantization error)
+    assert!(
+        (exact_dist - approx_dist).abs() < 0.01,
+        "exact={exact_dist}, approx={approx_dist}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// DistanceMetric enum
+// ---------------------------------------------------------------------------
+
+#[test]
+fn distance_metric_compute() {
+    let a = [1.0f32, 0.0, 0.0];
+    let b = [0.0f32, 1.0, 0.0];
+
+    // Cosine: orthogonal -> distance = 1.0
+    let d = DistanceMetric::Cosine.compute(&a, &b);
+    assert!((d - 1.0).abs() < 1e-6);
+
+    // EuclideanSq: sqrt(2)^2 = 2.0
+    let d = DistanceMetric::EuclideanSq.compute(&a, &b);
+    assert!((d - 2.0).abs() < 1e-6);
+
+    // DotProduct: -(1*0 + 0*1 + 0*0) = 0
+    let d = DistanceMetric::DotProduct.compute(&a, &b);
+    assert!(d.abs() < 1e-6);
+
+    // Manhattan: |1-0| + |0-1| + |0-0| = 2
+    let d = DistanceMetric::Manhattan.compute(&a, &b);
+    assert!((d - 2.0).abs() < 1e-6);
+}
+
+#[test]
+fn distance_metric_display() {
+    assert_eq!(format!("{}", DistanceMetric::Cosine), "cosine");
+    assert_eq!(format!("{}", DistanceMetric::EuclideanSq), "euclidean_sq");
+    assert_eq!(format!("{}", DistanceMetric::DotProduct), "dot_product");
+    assert_eq!(format!("{}", DistanceMetric::Manhattan), "manhattan");
+}
+
+// ---------------------------------------------------------------------------
+// Top-K nearest neighbor scan
+// ---------------------------------------------------------------------------
+
+#[test]
+fn nearest_k_basic() {
+    let vectors: Vec<(u64, Vec<f32>)> = vec![
+        (1, vec![1.0, 0.0, 0.0]),
+        (2, vec![0.0, 1.0, 0.0]),
+        (3, vec![0.7, 0.7, 0.0]),
+        (4, vec![-1.0, 0.0, 0.0]),
+    ];
+
+    let query = [1.0f32, 0.0, 0.0];
+    let results = redb::nearest_k(vectors.into_iter(), &query, 2, |a, b| {
+        DistanceMetric::Cosine.compute(a, b)
+    });
+
+    assert_eq!(results.len(), 2);
+    // Closest should be key=1 (identical), then key=3 (similar direction)
+    assert_eq!(results[0].key, 1);
+    assert_eq!(results[1].key, 3);
+    assert!(results[0].distance < results[1].distance);
+}
+
+#[test]
+fn nearest_k_fixed_with_stored_vectors() {
+    let tmpfile = create_tempfile();
+    let db = Database::create(tmpfile.path()).unwrap();
+
+    let vectors: Vec<(u64, [f32; 4])> = vec![
+        (1, [1.0, 0.0, 0.0, 0.0]),
+        (2, [0.0, 1.0, 0.0, 0.0]),
+        (3, [0.9, 0.1, 0.0, 0.0]),
+        (4, [0.5, 0.5, 0.5, 0.5]),
+        (5, [-1.0, 0.0, 0.0, 0.0]),
+    ];
+
+    let write_txn = db.begin_write().unwrap();
+    {
+        let mut table = write_txn.open_table(TABLE_VEC4).unwrap();
+        for (k, v) in &vectors {
+            table.insert(k, v).unwrap();
+        }
+    }
+    write_txn.commit().unwrap();
+
+    let read_txn = db.begin_read().unwrap();
+    let table = read_txn.open_table(TABLE_VEC4).unwrap();
+
+    let query = [1.0f32, 0.0, 0.0, 0.0];
+    let results = redb::nearest_k_fixed(
+        table.iter().unwrap().map(|r| {
+            let (k, v) = r.unwrap();
+            (k.value(), v.value())
+        }),
+        &query,
+        3,
+        |a, b| DistanceMetric::Cosine.compute(a, b),
+    );
+
+    assert_eq!(results.len(), 3);
+    // Key 1 is exact match (dist ~0), key 3 is next closest, then key 4
+    assert_eq!(results[0].key, 1);
+    assert!(results[0].distance < 1e-6);
+    assert_eq!(results[1].key, 3);
+    assert!(results[1].distance < results[2].distance);
+}
+
+#[test]
+fn nearest_k_zero_returns_empty() {
+    let vectors: Vec<(u64, Vec<f32>)> = vec![(1, vec![1.0, 0.0])];
+    let query = [1.0f32, 0.0];
+    let results = redb::nearest_k(vectors.into_iter(), &query, 0, |a, b| {
+        redb::euclidean_distance_sq(a, b)
+    });
+    assert!(results.is_empty());
+}
+
+#[test]
+fn nearest_k_more_than_available() {
+    let vectors: Vec<(u64, Vec<f32>)> = vec![(1, vec![1.0, 0.0]), (2, vec![0.0, 1.0])];
+    let query = [1.0f32, 0.0];
+    let results = redb::nearest_k(vectors.into_iter(), &query, 100, |a, b| {
+        redb::euclidean_distance_sq(a, b)
+    });
+    // Should return all available (2), not panic
+    assert_eq!(results.len(), 2);
 }


### PR DESCRIPTION
## Summary

- Add `FixedVec<N>` type for fixed-dimension vector storage (embeddings, feature vectors) with `fixed_width = N*4` for optimal B-tree page layout and `MutInPlaceValue` for zero-copy `insert_reserve` writes
- Add `DynVec` type for variable-dimension vectors where dimension is inferred from byte length at read time
- Add scalar distance functions: `dot_product`, `euclidean_distance_sq`, `cosine_similarity`, `manhattan_distance`
- Add LE byte helpers: `write_f32_le`, `read_f32_le` for direct buffer manipulation

## New files

| File | Description |
|------|-------------|
| `src/vector.rs` | `FixedVec<N>` and `DynVec` marker types with Value impls |
| `src/vector_ops.rs` | Distance functions and LE byte helpers |
| `tests/vector_tests.rs` | 14 integration tests |

## Test plan

- [x] `fixed_vec_insert_and_get` -- 4D round-trip
- [x] `fixed_vec_large_dimension` -- 384D embedding round-trip
- [x] `fixed_vec_insert_reserve` -- zero-copy write via `write_f32_le`
- [x] `fixed_vec_overwrites` -- second insert wins
- [x] `fixed_vec_remove` -- insert then remove
- [x] `dyn_vec_insert_and_get` -- dynamic dimension round-trip
- [x] `dyn_vec_different_dimensions` -- two keys with different vector lengths
- [x] `dot_product_basic` -- verify computation
- [x] `cosine_similarity_basic` -- identical, orthogonal, zero vectors
- [x] `euclidean_distance_basic` -- verify squared distance
- [x] `manhattan_distance_basic` -- verify L1 distance
- [x] `distance_with_stored_vectors` -- end-to-end store and similarity query
- [x] `fixed_vec_multiple_tables` -- two FixedVec tables with different dims coexist
- [x] `fixed_vec_range_scan` -- iterate vectors with range query