### PR TITLE
feat: adaptive fractal vector index with self-organizing clusters

### DIFF
--- a/src/composite/query.rs
+++ b/src/composite/query.rs
@@ -1,6 +1,7 @@
 use crate::StorageError;
 use crate::blob_store::types::BlobId;
 use crate::compat::HashMap;
+use crate::fractal::{FractalSearchParams, ReadOnlyFractalIndex};
 use crate::ivfpq::{ReadOnlyIvfPqIndex, SearchParams};
 use crate::transactions::ReadTransaction;
 use alloc::collections::BinaryHeap;
@@ -34,10 +35,12 @@ use super::types::{
 pub struct CompositeQuery<'a> {
     txn: &'a ReadTransaction,
 
-    // Semantic signal
+    // Semantic signal (IVF-PQ or Fractal)
     vector_index: Option<&'a ReadOnlyIvfPqIndex>,
+    fractal_index: Option<&'a ReadOnlyFractalIndex>,
     query_vector: Option<&'a [f32]>,
     search_params: Option<SearchParams>,
+    fractal_search_params: Option<FractalSearchParams>,
     semantic_candidates: Option<usize>,
 
     // Temporal signal
@@ -62,8 +65,10 @@ impl<'a> CompositeQuery<'a> {
         Self {
             txn,
             vector_index: None,
+            fractal_index: None,
             query_vector: None,
             search_params: None,
+            fractal_search_params: None,
             semantic_candidates: None,
             time_range: None,
             causal_root: None,
@@ -103,6 +108,30 @@ impl<'a> CompositeQuery<'a> {
     #[must_use]
     pub fn semantic_candidates(mut self, n: usize) -> Self {
         self.semantic_candidates = Some(n);
+        self
+    }
+
+    /// Set the semantic signal using a fractal vector index.
+    ///
+    /// Alternative to [`semantic()`](Self::semantic) -- uses the adaptive
+    /// fractal index instead of IVF-PQ. If both are set, fractal takes priority.
+    #[must_use]
+    pub fn semantic_fractal(
+        mut self,
+        index: &'a ReadOnlyFractalIndex,
+        query: &'a [f32],
+        weight: f32,
+    ) -> Self {
+        self.fractal_index = Some(index);
+        self.query_vector = Some(query);
+        self.weights.semantic = weight.max(0.0);
+        self
+    }
+
+    /// Override fractal search parameters.
+    #[must_use]
+    pub fn fractal_search_params(mut self, params: FractalSearchParams) -> Self {
+        self.fractal_search_params = Some(params);
         self
     }
 
@@ -175,18 +204,31 @@ impl<'a> CompositeQuery<'a> {
         // Phase 1: Collect candidates
         let mut candidates: HashMap<BlobId, CandidateEntry> = HashMap::new();
 
-        // 1a: Semantic candidates
+        // 1a: Semantic candidates (fractal index takes priority over IVF-PQ)
         if sem_active {
-            let index = self.vector_index.unwrap();
             let query = self.query_vector.unwrap();
             let k = self.semantic_candidates.unwrap_or(self.top_k.max(1) * 5);
-            let params = self.search_params.unwrap_or(SearchParams {
-                nprobe: 16,
-                candidates: k * 2,
-                k,
-                rerank: true,
-            });
-            let results = index.search(self.txn, query, &params)?;
+
+            let results = if let Some(fi) = self.fractal_index {
+                let params = self.fractal_search_params.unwrap_or(FractalSearchParams {
+                    nprobe: 8,
+                    candidates: k * 2,
+                    k,
+                    rerank: true,
+                    min_hlc: 0,
+                });
+                fi.search(self.txn, query, &params)?
+            } else {
+                let index = self.vector_index.unwrap();
+                let params = self.search_params.unwrap_or(SearchParams {
+                    nprobe: 16,
+                    candidates: k * 2,
+                    k,
+                    rerank: true,
+                });
+                index.search(self.txn, query, &params)?
+            };
+
             for neighbor in &results {
                 if let Some((id, meta)) = self.txn.blob_by_sequence(neighbor.key)? {
                     let entry = candidates.entry(id).or_insert_with(|| CandidateEntry {
@@ -358,11 +400,17 @@ impl<'a> CompositeQuery<'a> {
                 "CompositeQuery: at least one signal must have weight > 0".to_string(),
             ));
         }
+        if self.weights.semantic > 0.0 && self.query_vector.is_none() {
+            return Err(StorageError::Corrupted(
+                "CompositeQuery: semantic signal requires a query vector".to_string(),
+            ));
+        }
         if self.weights.semantic > 0.0
-            && (self.vector_index.is_none() || self.query_vector.is_none())
+            && self.vector_index.is_none()
+            && self.fractal_index.is_none()
         {
             return Err(StorageError::Corrupted(
-                "CompositeQuery: semantic signal requires both index and query vector".to_string(),
+                "CompositeQuery: semantic signal requires an index (IVF-PQ or fractal)".to_string(),
             ));
         }
         if self.weights.causal > 0.0 && self.causal_root.is_none() {

--- a/src/fractal/cluster.rs
+++ b/src/fractal/cluster.rs
@@ -1,0 +1,712 @@
+use alloc::string::String;
+use alloc::vec::Vec;
+
+use crate::TableDefinition;
+use crate::error::StorageError;
+use crate::ivfpq::kmeans;
+use crate::ivfpq::pq::Codebooks;
+use crate::ivfpq::types::PostingKey;
+use crate::table::ReadableTable;
+use crate::transactions::WriteTransaction;
+
+use super::config::{FractalIndexConfig, NO_PARENT};
+use super::types::{ClusterMeta, HierarchyKey};
+
+/// Convert a `TableError` to `StorageError`.
+fn te(e: crate::error::TableError) -> StorageError {
+    e.into_storage_error_or_corrupted("fractal index internal table error")
+}
+
+// ---------------------------------------------------------------------------
+// Centroid update (Welford's online algorithm)
+// ---------------------------------------------------------------------------
+
+/// Add a vector to a cluster's running centroid.
+///
+/// Updates the f64 sum accumulator and recomputes the f32 centroid.
+/// Returns the new population count.
+#[allow(clippy::cast_possible_truncation)]
+pub(crate) fn centroid_add(
+    txn: &WriteTransaction,
+    centroid_sums_table: &str,
+    centroids_table: &str,
+    cluster_id: u32,
+    dim: usize,
+    vector: &[f32],
+    old_population: u32,
+) -> crate::Result<u32> {
+    let new_pop = old_population + 1;
+
+    let sums_def = TableDefinition::<u32, &[u8]>::new(centroid_sums_table);
+    let mut sums_tbl = txn.open_table(sums_def).map_err(te)?;
+
+    // Load or initialize f64 sums
+    let mut sums = Vec::with_capacity(dim);
+    if let Some(existing) = sums_tbl.get(cluster_id)? {
+        let bytes = existing.value();
+        for i in 0..dim {
+            let offset = i * 8;
+            sums.push(f64::from_le_bytes(
+                bytes[offset..offset + 8].try_into().unwrap(),
+            ));
+        }
+    } else {
+        sums.resize(dim, 0.0);
+    }
+
+    // Update sums
+    for (s, &v) in sums.iter_mut().zip(vector.iter()) {
+        *s += f64::from(v);
+    }
+
+    // Persist sums
+    let mut sum_bytes = Vec::with_capacity(dim * 8);
+    for &s in &sums {
+        sum_bytes.extend_from_slice(&s.to_le_bytes());
+    }
+    sums_tbl.insert(cluster_id, sum_bytes.as_slice())?;
+    drop(sums_tbl);
+
+    // Recompute centroid
+    let pop_f64 = f64::from(new_pop);
+    let mut centroid_bytes = Vec::with_capacity(dim * 4);
+    for &s in &sums {
+        centroid_bytes.extend_from_slice(&((s / pop_f64) as f32).to_le_bytes());
+    }
+
+    let centroids_def = TableDefinition::<u32, &[u8]>::new(centroids_table);
+    let mut cent_tbl = txn.open_table(centroids_def).map_err(te)?;
+    cent_tbl.insert(cluster_id, centroid_bytes.as_slice())?;
+
+    Ok(new_pop)
+}
+
+/// Remove a vector from a cluster's running centroid.
+///
+/// Returns the new population count. If population reaches 0, centroid is zeroed.
+#[allow(clippy::cast_possible_truncation)]
+pub(crate) fn centroid_remove(
+    txn: &WriteTransaction,
+    centroid_sums_table: &str,
+    centroids_table: &str,
+    cluster_id: u32,
+    dim: usize,
+    vector: &[f32],
+    old_population: u32,
+) -> crate::Result<u32> {
+    if old_population == 0 {
+        return Ok(0);
+    }
+    let new_pop = old_population - 1;
+
+    let sums_def = TableDefinition::<u32, &[u8]>::new(centroid_sums_table);
+    let mut sums_tbl = txn.open_table(sums_def).map_err(te)?;
+
+    let mut sums = Vec::with_capacity(dim);
+    if let Some(existing) = sums_tbl.get(cluster_id)? {
+        let bytes = existing.value();
+        for i in 0..dim {
+            let offset = i * 8;
+            sums.push(f64::from_le_bytes(
+                bytes[offset..offset + 8].try_into().unwrap(),
+            ));
+        }
+    } else {
+        sums.resize(dim, 0.0);
+    }
+
+    for (s, &v) in sums.iter_mut().zip(vector.iter()) {
+        *s -= f64::from(v);
+    }
+
+    let mut sum_bytes = Vec::with_capacity(dim * 8);
+    for &s in &sums {
+        sum_bytes.extend_from_slice(&s.to_le_bytes());
+    }
+    sums_tbl.insert(cluster_id, sum_bytes.as_slice())?;
+    drop(sums_tbl);
+
+    let centroids_def = TableDefinition::<u32, &[u8]>::new(centroids_table);
+    let mut cent_tbl = txn.open_table(centroids_def).map_err(te)?;
+
+    if new_pop == 0 {
+        let zeros = alloc::vec![0u8; dim * 4];
+        cent_tbl.insert(cluster_id, zeros.as_slice())?;
+    } else {
+        let pop_f64 = f64::from(new_pop);
+        let mut centroid_bytes = Vec::with_capacity(dim * 4);
+        for &s in &sums {
+            centroid_bytes.extend_from_slice(&((s / pop_f64) as f32).to_le_bytes());
+        }
+        cent_tbl.insert(cluster_id, centroid_bytes.as_slice())?;
+    }
+
+    Ok(new_pop)
+}
+
+// ---------------------------------------------------------------------------
+// Split
+// ---------------------------------------------------------------------------
+
+/// Split a leaf cluster into two children using 2-means.
+///
+/// The original cluster becomes an internal node with two leaf children.
+/// When `store_raw_vectors` is disabled, approximate vectors are reconstructed
+/// from PQ codes via the provided codebooks.
+/// Returns `(child_a_id, child_b_id)`.
+pub(crate) fn split_cluster(
+    txn: &WriteTransaction,
+    config: &mut FractalIndexConfig,
+    cluster_id: u32,
+    table_names: &TableNames,
+    codebooks: Option<&Codebooks>,
+) -> crate::Result<(u32, u32)> {
+    let dim = config.dim as usize;
+
+    // 1. Collect all vector IDs from the posting list
+    let postings_def = TableDefinition::<PostingKey, &[u8]>::new(&table_names.postings);
+    let vectors_def = TableDefinition::<u64, &[u8]>::new(&table_names.vectors);
+
+    let mut vector_ids: Vec<u64> = Vec::new();
+    let mut flat_vectors: Vec<f32> = Vec::new();
+
+    {
+        let tbl = txn.open_table(postings_def).map_err(te)?;
+        let range =
+            tbl.range(PostingKey::cluster_start(cluster_id)..=PostingKey::cluster_end(cluster_id))?;
+        for entry in range {
+            let (key, _pq_codes) = entry?;
+            let vid = key.value().vector_id;
+            vector_ids.push(vid);
+        }
+    }
+
+    // Load raw vectors from table if available
+    if config.store_raw_vectors {
+        let vtbl = txn.open_table(vectors_def).map_err(te)?;
+        for &vid in &vector_ids {
+            if let Some(raw) = vtbl.get(vid)? {
+                let bytes = raw.value();
+                for i in 0..dim {
+                    let offset = i * 4;
+                    flat_vectors.push(f32::from_le_bytes(
+                        bytes[offset..offset + 4].try_into().unwrap(),
+                    ));
+                }
+            }
+        }
+    }
+
+    // Fallback: reconstruct approximate vectors from PQ codes when raw vectors unavailable
+    if flat_vectors.is_empty()
+        && !vector_ids.is_empty()
+        && let Some(cb) = codebooks
+    {
+        let ptbl = txn.open_table(postings_def).map_err(te)?;
+        let sub_dim = cb.sub_dim;
+        for &vid in &vector_ids {
+            if let Some(pq_guard) = ptbl.get(PostingKey::new(cluster_id, vid))? {
+                let pq_codes = pq_guard.value();
+                for (m, &code) in pq_codes.iter().enumerate().take(cb.num_subvectors) {
+                    let base = m * 256 * sub_dim + (code as usize) * sub_dim;
+                    for d in 0..sub_dim {
+                        flat_vectors.push(cb.data[base + d]);
+                    }
+                }
+            }
+        }
+    }
+
+    if flat_vectors.len() / dim < 2 {
+        return Err(StorageError::Corrupted(
+            "fractal: cannot split cluster with fewer than 2 vectors".into(),
+        ));
+    }
+
+    // 2. Run 2-means
+    let centroids_flat = kmeans::kmeans(&flat_vectors, dim, 2, 10, config.metric);
+
+    // Assign each vector to one of the 2 clusters
+    let n = vector_ids.len();
+    let mut assignments = Vec::with_capacity(n);
+    for i in 0..n {
+        let vec_slice = &flat_vectors[i * dim..(i + 1) * dim];
+        let (cluster_idx, _) =
+            kmeans::assign_nearest(vec_slice, &centroids_flat, dim, 2, config.metric);
+        assignments.push(cluster_idx);
+    }
+
+    // 3. Allocate new cluster IDs
+    let child_a = config.alloc_cluster_id();
+    let child_b = config.alloc_cluster_id();
+
+    // 4. Compute per-child statistics
+    let mut pop_a: u32 = 0;
+    let mut pop_b: u32 = 0;
+    let mut sums_a = alloc::vec![0.0f64; dim];
+    let mut sums_b = alloc::vec![0.0f64; dim];
+
+    for (idx, &assignment) in assignments.iter().enumerate() {
+        let vec_start = idx * dim;
+        let vec_slice = &flat_vectors[vec_start..vec_start + dim];
+        if assignment == 0 {
+            pop_a += 1;
+            for (s, &v) in sums_a.iter_mut().zip(vec_slice.iter()) {
+                *s += f64::from(v);
+            }
+        } else {
+            pop_b += 1;
+            for (s, &v) in sums_b.iter_mut().zip(vec_slice.iter()) {
+                *s += f64::from(v);
+            }
+        }
+    }
+
+    // 5. Create child ClusterMetas
+    let mut meta_a = ClusterMeta::new(child_a, cluster_id, 0, false);
+    meta_a.set_population(pop_a);
+    let mut meta_b = ClusterMeta::new(child_b, cluster_id, 0, false);
+    meta_b.set_population(pop_b);
+
+    // 6. Persist child metadata
+    let clusters_def = TableDefinition::<u32, &[u8]>::new(&table_names.clusters);
+    {
+        let mut ctbl = txn.open_table(clusters_def).map_err(te)?;
+        ctbl.insert(child_a, meta_a.as_bytes().as_slice())?;
+        ctbl.insert(child_b, meta_b.as_bytes().as_slice())?;
+    }
+
+    // 7. Persist child centroids and sums
+    let centroids_def = TableDefinition::<u32, &[u8]>::new(&table_names.centroids);
+    let sums_def = TableDefinition::<u32, &[u8]>::new(&table_names.centroid_sums);
+    {
+        let mut cent_tbl = txn.open_table(centroids_def).map_err(te)?;
+        let centroid_a: Vec<u8> = centroids_flat[..dim]
+            .iter()
+            .flat_map(|f| f.to_le_bytes())
+            .collect();
+        let centroid_b: Vec<u8> = centroids_flat[dim..2 * dim]
+            .iter()
+            .flat_map(|f| f.to_le_bytes())
+            .collect();
+        cent_tbl.insert(child_a, centroid_a.as_slice())?;
+        cent_tbl.insert(child_b, centroid_b.as_slice())?;
+
+        let mut sum_tbl = txn.open_table(sums_def).map_err(te)?;
+        let sums_a_bytes: Vec<u8> = sums_a.iter().flat_map(|f| f.to_le_bytes()).collect();
+        let sums_b_bytes: Vec<u8> = sums_b.iter().flat_map(|f| f.to_le_bytes()).collect();
+        sum_tbl.insert(child_a, sums_a_bytes.as_slice())?;
+        sum_tbl.insert(child_b, sums_b_bytes.as_slice())?;
+    }
+
+    // 8. Move postings to children
+    {
+        let mut ptbl = txn.open_table(postings_def).map_err(te)?;
+        let mut atbl = txn
+            .open_table(TableDefinition::<u64, u32>::new(&table_names.assignments))
+            .map_err(te)?;
+
+        // First collect old postings to avoid borrow conflicts
+        let mut old_entries: Vec<(u64, Vec<u8>)> = Vec::new();
+        {
+            let range = ptbl.range(
+                PostingKey::cluster_start(cluster_id)..=PostingKey::cluster_end(cluster_id),
+            )?;
+            for entry in range {
+                let (key, val) = entry?;
+                let vid = key.value().vector_id;
+                old_entries.push((vid, val.value().to_vec()));
+            }
+        }
+
+        // Remove old entries and insert into children
+        for (idx, (vid, pq_codes)) in old_entries.iter().enumerate() {
+            ptbl.remove(PostingKey::new(cluster_id, *vid))?;
+            let target = if assignments[idx] == 0 {
+                child_a
+            } else {
+                child_b
+            };
+            ptbl.insert(PostingKey::new(target, *vid), pq_codes.as_slice())?;
+            atbl.insert(*vid, target)?;
+        }
+    }
+
+    // 9. Insert hierarchy edges
+    let hier_def = TableDefinition::<HierarchyKey, ()>::new(&table_names.hierarchy);
+    {
+        let mut htbl = txn.open_table(hier_def).map_err(te)?;
+        htbl.insert(HierarchyKey::new(cluster_id, child_a), ())?;
+        htbl.insert(HierarchyKey::new(cluster_id, child_b), ())?;
+    }
+
+    // 10. Convert original cluster to internal
+    {
+        let mut ctbl = txn.open_table(clusters_def).map_err(te)?;
+        let meta_opt = ctbl
+            .get(cluster_id)?
+            .map(|g| ClusterMeta::from_bytes(g.value()));
+        if let Some(mut meta) = meta_opt {
+            meta.set_level(1);
+            meta.set_num_children(2);
+            meta.set_population(0); // Vectors moved to children
+            meta.set_buffer_count(0);
+            ctbl.insert(cluster_id, meta.as_bytes().as_slice())?;
+        }
+    }
+
+    config.num_clusters += 2;
+
+    Ok((child_a, child_b))
+}
+
+// ---------------------------------------------------------------------------
+// Merge
+// ---------------------------------------------------------------------------
+
+/// Merge a leaf cluster into its nearest sibling.
+///
+/// Returns the surviving sibling's cluster ID.
+#[allow(clippy::cast_possible_truncation)]
+pub(crate) fn merge_cluster(
+    txn: &WriteTransaction,
+    config: &mut FractalIndexConfig,
+    cluster_id: u32,
+    table_names: &TableNames,
+) -> crate::Result<Option<u32>> {
+    let clusters_def = TableDefinition::<u32, &[u8]>::new(&table_names.clusters);
+    let dim = config.dim as usize;
+
+    // Load the cluster to merge
+    let meta = {
+        let ctbl = txn.open_table(clusters_def).map_err(te)?;
+        match ctbl.get(cluster_id)? {
+            Some(g) => ClusterMeta::from_bytes(g.value()),
+            None => return Ok(None),
+        }
+    };
+
+    let parent_id = meta.parent_id();
+    if parent_id == NO_PARENT {
+        // Can't merge the root
+        return Ok(None);
+    }
+
+    // Find siblings
+    let hier_def = TableDefinition::<HierarchyKey, ()>::new(&table_names.hierarchy);
+    let centroids_def = TableDefinition::<u32, &[u8]>::new(&table_names.centroids);
+
+    let mut siblings: Vec<u32> = Vec::new();
+    {
+        let htbl = txn.open_table(hier_def).map_err(te)?;
+        let range = htbl.range(
+            HierarchyKey::children_start(parent_id)..=HierarchyKey::children_end(parent_id),
+        )?;
+        for entry in range {
+            let (key, _) = entry?;
+            let cid = key.value().child_id;
+            if cid != cluster_id {
+                siblings.push(cid);
+            }
+        }
+    }
+
+    if siblings.is_empty() {
+        return Ok(None);
+    }
+
+    // Find nearest sibling by centroid distance
+    let my_centroid: Vec<f32> = {
+        let ctbl = txn.open_table(centroids_def).map_err(te)?;
+        match ctbl.get(cluster_id)? {
+            Some(g) => {
+                let bytes = g.value();
+                (0..dim)
+                    .map(|i| f32::from_le_bytes(bytes[i * 4..i * 4 + 4].try_into().unwrap()))
+                    .collect()
+            }
+            None => return Ok(None),
+        }
+    };
+
+    let mut best_sibling = siblings[0];
+    let mut best_dist = f32::MAX;
+    {
+        let ctbl = txn.open_table(centroids_def).map_err(te)?;
+        for &sib in &siblings {
+            if let Some(g) = ctbl.get(sib)? {
+                let bytes = g.value();
+                let sib_centroid: Vec<f32> = (0..dim)
+                    .map(|i| f32::from_le_bytes(bytes[i * 4..i * 4 + 4].try_into().unwrap()))
+                    .collect();
+                let dist = config.metric.compute(&my_centroid, &sib_centroid);
+                if dist < best_dist {
+                    best_dist = dist;
+                    best_sibling = sib;
+                }
+            }
+        }
+    }
+
+    // Check if combined population fits
+    let sibling_meta = {
+        let ctbl = txn.open_table(clusters_def).map_err(te)?;
+        match ctbl.get(best_sibling)? {
+            Some(g) => ClusterMeta::from_bytes(g.value()),
+            None => return Ok(None),
+        }
+    };
+
+    let combined_pop = meta.population() + sibling_meta.population();
+    if combined_pop > config.max_leaf_population {
+        return Ok(None);
+    }
+
+    // Move all postings from this cluster to the sibling
+    let postings_def = TableDefinition::<PostingKey, &[u8]>::new(&table_names.postings);
+    let assignments_def = TableDefinition::<u64, u32>::new(&table_names.assignments);
+    {
+        let mut ptbl = txn.open_table(postings_def).map_err(te)?;
+        let mut atbl = txn.open_table(assignments_def).map_err(te)?;
+
+        let mut entries: Vec<(u64, Vec<u8>)> = Vec::new();
+        {
+            let range = ptbl.range(
+                PostingKey::cluster_start(cluster_id)..=PostingKey::cluster_end(cluster_id),
+            )?;
+            for entry in range {
+                let (key, val) = entry?;
+                entries.push((key.value().vector_id, val.value().to_vec()));
+            }
+        }
+
+        for (vid, pq_codes) in &entries {
+            ptbl.remove(PostingKey::new(cluster_id, *vid))?;
+            ptbl.insert(PostingKey::new(best_sibling, *vid), pq_codes.as_slice())?;
+            atbl.insert(*vid, best_sibling)?;
+        }
+    }
+
+    // Update sibling metadata (weighted centroid merge via sums)
+    let sums_def = TableDefinition::<u32, &[u8]>::new(&table_names.centroid_sums);
+    {
+        let mut sum_tbl = txn.open_table(sums_def).map_err(te)?;
+
+        let my_sums: Vec<f64> = match sum_tbl.get(cluster_id)? {
+            Some(g) => {
+                let bytes = g.value();
+                (0..dim)
+                    .map(|i| f64::from_le_bytes(bytes[i * 8..i * 8 + 8].try_into().unwrap()))
+                    .collect()
+            }
+            None => alloc::vec![0.0; dim],
+        };
+
+        let sib_sums: Vec<f64> = match sum_tbl.get(best_sibling)? {
+            Some(g) => {
+                let bytes = g.value();
+                (0..dim)
+                    .map(|i| f64::from_le_bytes(bytes[i * 8..i * 8 + 8].try_into().unwrap()))
+                    .collect()
+            }
+            None => alloc::vec![0.0; dim],
+        };
+
+        let merged_sums: Vec<f64> = my_sums
+            .iter()
+            .zip(sib_sums.iter())
+            .map(|(a, b)| a + b)
+            .collect();
+        let merged_bytes: Vec<u8> = merged_sums.iter().flat_map(|f| f.to_le_bytes()).collect();
+        sum_tbl.insert(best_sibling, merged_bytes.as_slice())?;
+
+        // Remove merged cluster's sums
+        sum_tbl.remove(cluster_id)?;
+    }
+
+    // Recompute sibling centroid from merged sums
+    {
+        let sum_tbl = txn.open_table(sums_def).map_err(te)?;
+        let merged_sums: Vec<f64> = match sum_tbl.get(best_sibling)? {
+            Some(g) => {
+                let bytes = g.value();
+                (0..dim)
+                    .map(|i| f64::from_le_bytes(bytes[i * 8..i * 8 + 8].try_into().unwrap()))
+                    .collect()
+            }
+            None => alloc::vec![0.0; dim],
+        };
+        drop(sum_tbl);
+
+        let pop_f64 = f64::from(combined_pop);
+        let centroid_bytes: Vec<u8> = merged_sums
+            .iter()
+            .map(|s| (s / pop_f64) as f32)
+            .flat_map(|f| f.to_le_bytes())
+            .collect();
+
+        let mut cent_tbl = txn.open_table(centroids_def).map_err(te)?;
+        cent_tbl.insert(best_sibling, centroid_bytes.as_slice())?;
+    }
+
+    // Update sibling population
+    {
+        let mut ctbl = txn.open_table(clusters_def).map_err(te)?;
+        let sib_opt = ctbl
+            .get(best_sibling)?
+            .map(|g| ClusterMeta::from_bytes(g.value()));
+        if let Some(mut sib) = sib_opt {
+            sib.set_population(combined_pop);
+            ctbl.insert(best_sibling, sib.as_bytes().as_slice())?;
+        }
+    }
+
+    // Remove merged cluster from hierarchy and metadata
+    {
+        let mut htbl = txn.open_table(hier_def).map_err(te)?;
+        htbl.remove(HierarchyKey::new(parent_id, cluster_id))?;
+    }
+    {
+        let mut ctbl = txn.open_table(clusters_def).map_err(te)?;
+        ctbl.remove(cluster_id)?;
+    }
+    {
+        let mut cent_tbl = txn.open_table(centroids_def).map_err(te)?;
+        cent_tbl.remove(cluster_id)?;
+    }
+
+    // Update parent's children count
+    {
+        let mut ctbl = txn.open_table(clusters_def).map_err(te)?;
+        let parent_opt = ctbl
+            .get(parent_id)?
+            .map(|g| ClusterMeta::from_bytes(g.value()));
+        if let Some(mut parent_meta) = parent_opt {
+            let new_count = parent_meta.num_children().saturating_sub(1);
+            parent_meta.set_num_children(new_count);
+            ctbl.insert(parent_id, parent_meta.as_bytes().as_slice())?;
+        }
+    }
+
+    config.num_clusters -= 1;
+    Ok(Some(best_sibling))
+}
+
+// ---------------------------------------------------------------------------
+// Buffer cascade
+// ---------------------------------------------------------------------------
+
+/// Flush a leaf cluster's buffer: PQ-encode all buffered vectors and move
+/// them to the posting list.
+pub(crate) fn cascade_leaf_buffer(
+    txn: &WriteTransaction,
+    cluster_id: u32,
+    codebooks: &Codebooks,
+    config: &FractalIndexConfig,
+    table_names: &TableNames,
+) -> crate::Result<()> {
+    let dim = config.dim as usize;
+    let buffer_def = TableDefinition::<PostingKey, &[u8]>::new(&table_names.buffer);
+    let postings_def = TableDefinition::<PostingKey, &[u8]>::new(&table_names.postings);
+    let vectors_def = TableDefinition::<u64, &[u8]>::new(&table_names.vectors);
+
+    // Collect buffered entries
+    let mut entries: Vec<(u64, Vec<f32>)> = Vec::new();
+    {
+        let btbl = txn.open_table(buffer_def).map_err(te)?;
+        let range = btbl
+            .range(PostingKey::cluster_start(cluster_id)..=PostingKey::cluster_end(cluster_id))?;
+        for entry in range {
+            let (key, val) = entry?;
+            let vid = key.value().vector_id;
+            let bytes = val.value();
+            let vec: Vec<f32> = (0..dim)
+                .map(|i| f32::from_le_bytes(bytes[i * 4..i * 4 + 4].try_into().unwrap()))
+                .collect();
+            entries.push((vid, vec));
+        }
+    }
+
+    if entries.is_empty() {
+        return Ok(());
+    }
+
+    // PQ-encode and insert into posting list
+    {
+        let mut ptbl = txn.open_table(postings_def).map_err(te)?;
+        let mut vtbl_opt = if config.store_raw_vectors {
+            Some(txn.open_table(vectors_def).map_err(te)?)
+        } else {
+            None
+        };
+
+        for (vid, vec) in &entries {
+            let pq_codes = codebooks.encode(vec);
+            ptbl.insert(PostingKey::new(cluster_id, *vid), pq_codes.as_slice())?;
+
+            if let Some(ref mut vtbl) = vtbl_opt {
+                let raw_bytes: Vec<u8> = vec.iter().flat_map(|f| f.to_le_bytes()).collect();
+                vtbl.insert(*vid, raw_bytes.as_slice())?;
+            }
+        }
+    }
+
+    // Remove from buffer
+    {
+        let mut btbl = txn.open_table(buffer_def).map_err(te)?;
+        for (vid, _) in &entries {
+            btbl.remove(PostingKey::new(cluster_id, *vid))?;
+        }
+    }
+
+    // Update cluster meta buffer_count
+    let clusters_def = TableDefinition::<u32, &[u8]>::new(&table_names.clusters);
+    {
+        let mut ctbl = txn.open_table(clusters_def).map_err(te)?;
+        let meta_opt = ctbl
+            .get(cluster_id)?
+            .map(|g| ClusterMeta::from_bytes(g.value()));
+        if let Some(mut meta) = meta_opt {
+            meta.set_buffer_count(0);
+            ctbl.insert(cluster_id, meta.as_bytes().as_slice())?;
+        }
+    }
+
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// Table name helper
+// ---------------------------------------------------------------------------
+
+/// Pre-computed table names for a fractal index instance.
+#[derive(Clone)]
+pub(crate) struct TableNames {
+    pub meta: String,
+    pub clusters: String,
+    pub centroids: String,
+    pub centroid_sums: String,
+    pub hierarchy: String,
+    pub buffer: String,
+    pub postings: String,
+    pub assignments: String,
+    pub vectors: String,
+    pub codebooks: String,
+}
+
+impl TableNames {
+    pub fn new(name: &str) -> Self {
+        Self {
+            meta: alloc::format!("__fractal:{name}:meta"),
+            clusters: alloc::format!("__fractal:{name}:clusters"),
+            centroids: alloc::format!("__fractal:{name}:centroids"),
+            centroid_sums: alloc::format!("__fractal:{name}:centroid_sums"),
+            hierarchy: alloc::format!("__fractal:{name}:hierarchy"),
+            buffer: alloc::format!("__fractal:{name}:buffer"),
+            postings: alloc::format!("__fractal:{name}:postings"),
+            assignments: alloc::format!("__fractal:{name}:assignments"),
+            vectors: alloc::format!("__fractal:{name}:vectors"),
+            codebooks: alloc::format!("__fractal:{name}:codebooks"),
+        }
+    }
+}

--- a/src/fractal/config.rs
+++ b/src/fractal/config.rs
@@ -1,0 +1,330 @@
+use crate::vector_ops::DistanceMetric;
+use core::fmt;
+
+// ---------------------------------------------------------------------------
+// FractalIndexConfig -- persisted index configuration (96 bytes)
+// ---------------------------------------------------------------------------
+
+/// Training / operational states.
+pub const STATE_NEW: u8 = 0;
+pub const STATE_CODEBOOKS_TRAINED: u8 = 1;
+pub const STATE_OPERATIONAL: u8 = 2;
+
+/// Sentinel value for "no parent" in `ClusterMeta.parent_id`.
+pub const NO_PARENT: u32 = u32::MAX;
+
+/// Flag bit: cluster is the root of the tree.
+pub const FLAG_IS_ROOT: u8 = 0x01;
+
+/// On-disk size of [`FractalIndexConfig`].
+pub const FRACTAL_CONFIG_SIZE: usize = 96;
+
+/// Persisted configuration for a fractal vector index.
+#[derive(Clone, PartialEq)]
+pub struct FractalIndexConfig {
+    pub dim: u32,
+    pub num_subvectors: u32,
+    pub num_codewords: u16,
+    pub metric: DistanceMetric,
+    pub store_raw_vectors: bool,
+    pub default_nprobe: u32,
+    pub(crate) state: u8,
+    pub root_cluster_id: u32,
+    pub next_cluster_id: u32,
+    pub max_leaf_population: u32,
+    pub min_leaf_population: u32,
+    pub max_buffer_size: u32,
+    pub max_children: u32,
+    pub max_depth: u32,
+    pub num_vectors: u64,
+    pub num_clusters: u64,
+    pub variance_split_factor: f32,
+}
+
+impl FractalIndexConfig {
+    pub fn state(&self) -> u8 {
+        self.state
+    }
+
+    pub fn sub_dim(&self) -> usize {
+        self.dim as usize / self.num_subvectors as usize
+    }
+
+    pub fn metric_byte(&self) -> u8 {
+        match self.metric {
+            DistanceMetric::Cosine => 0,
+            DistanceMetric::EuclideanSq => 1,
+            DistanceMetric::DotProduct => 2,
+            DistanceMetric::Manhattan => 3,
+        }
+    }
+
+    /// Allocate a new cluster ID, advancing the counter.
+    pub fn alloc_cluster_id(&mut self) -> u32 {
+        let id = self.next_cluster_id;
+        self.next_cluster_id += 1;
+        self.num_clusters += 1;
+        id
+    }
+}
+
+impl fmt::Debug for FractalIndexConfig {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("FractalIndexConfig")
+            .field("dim", &self.dim)
+            .field("num_subvectors", &self.num_subvectors)
+            .field("metric", &self.metric)
+            .field("store_raw", &self.store_raw_vectors)
+            .field("nprobe", &self.default_nprobe)
+            .field("state", &self.state)
+            .field("root", &self.root_cluster_id)
+            .field("num_vectors", &self.num_vectors)
+            .field("num_clusters", &self.num_clusters)
+            .finish_non_exhaustive()
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Encode / Decode
+// ---------------------------------------------------------------------------
+
+pub fn encode_fractal_config(cfg: &FractalIndexConfig) -> [u8; FRACTAL_CONFIG_SIZE] {
+    let mut buf = [0u8; FRACTAL_CONFIG_SIZE];
+    buf[0..4].copy_from_slice(&cfg.dim.to_le_bytes());
+    buf[4..8].copy_from_slice(&cfg.num_subvectors.to_le_bytes());
+    buf[8..10].copy_from_slice(&cfg.num_codewords.to_le_bytes());
+    buf[10] = cfg.metric_byte();
+    buf[11] = u8::from(cfg.store_raw_vectors);
+    buf[12..16].copy_from_slice(&cfg.default_nprobe.to_le_bytes());
+    buf[16] = cfg.state;
+    // 17..20 padding
+    buf[20..24].copy_from_slice(&cfg.root_cluster_id.to_le_bytes());
+    buf[24..28].copy_from_slice(&cfg.next_cluster_id.to_le_bytes());
+    buf[28..32].copy_from_slice(&cfg.max_leaf_population.to_le_bytes());
+    buf[32..36].copy_from_slice(&cfg.min_leaf_population.to_le_bytes());
+    buf[36..40].copy_from_slice(&cfg.max_buffer_size.to_le_bytes());
+    buf[40..44].copy_from_slice(&cfg.max_children.to_le_bytes());
+    buf[44..48].copy_from_slice(&cfg.max_depth.to_le_bytes());
+    buf[48..56].copy_from_slice(&cfg.num_vectors.to_le_bytes());
+    buf[56..64].copy_from_slice(&cfg.num_clusters.to_le_bytes());
+    buf[64..68].copy_from_slice(&cfg.variance_split_factor.to_bits().to_le_bytes());
+    // 68..96 reserved
+    buf
+}
+
+pub fn decode_fractal_config(data: &[u8]) -> FractalIndexConfig {
+    let dim = u32::from_le_bytes(data[0..4].try_into().unwrap());
+    let num_subvectors = u32::from_le_bytes(data[4..8].try_into().unwrap());
+    let num_codewords = u16::from_le_bytes(data[8..10].try_into().unwrap());
+    let metric = match data[10] {
+        0 => DistanceMetric::Cosine,
+        2 => DistanceMetric::DotProduct,
+        3 => DistanceMetric::Manhattan,
+        _ => DistanceMetric::EuclideanSq,
+    };
+    let store_raw_vectors = data[11] != 0;
+    let default_nprobe = u32::from_le_bytes(data[12..16].try_into().unwrap());
+    let state = data[16];
+    let root_cluster_id = u32::from_le_bytes(data[20..24].try_into().unwrap());
+    let next_cluster_id = u32::from_le_bytes(data[24..28].try_into().unwrap());
+    let max_leaf_population = u32::from_le_bytes(data[28..32].try_into().unwrap());
+    let min_leaf_population = u32::from_le_bytes(data[32..36].try_into().unwrap());
+    let max_buffer_size = u32::from_le_bytes(data[36..40].try_into().unwrap());
+    let max_children = u32::from_le_bytes(data[40..44].try_into().unwrap());
+    let max_depth = u32::from_le_bytes(data[44..48].try_into().unwrap());
+    let num_vectors = u64::from_le_bytes(data[48..56].try_into().unwrap());
+    let num_clusters = u64::from_le_bytes(data[56..64].try_into().unwrap());
+    let variance_split_factor =
+        f32::from_bits(u32::from_le_bytes(data[64..68].try_into().unwrap()));
+
+    FractalIndexConfig {
+        dim,
+        num_subvectors,
+        num_codewords,
+        metric,
+        store_raw_vectors,
+        default_nprobe,
+        state,
+        root_cluster_id,
+        next_cluster_id,
+        max_leaf_population,
+        min_leaf_population,
+        max_buffer_size,
+        max_children,
+        max_depth,
+        num_vectors,
+        num_clusters,
+        variance_split_factor,
+    }
+}
+
+// ---------------------------------------------------------------------------
+// FractalSearchParams
+// ---------------------------------------------------------------------------
+
+/// Parameters for a single fractal index search query.
+#[derive(Debug, Clone)]
+pub struct FractalSearchParams {
+    /// Number of children to probe at each internal level.
+    pub nprobe: u32,
+    /// Number of PQ-distance candidates to shortlist before re-ranking.
+    pub candidates: usize,
+    /// Number of final results to return.
+    pub k: usize,
+    /// Re-rank top candidates with exact distances from raw vectors.
+    pub rerank: bool,
+    /// Optional: only consider clusters with data newer than this HLC value.
+    /// Set to 0 to disable temporal filtering.
+    pub min_hlc: u64,
+}
+
+impl FractalSearchParams {
+    pub fn top_k(k: usize) -> Self {
+        Self {
+            nprobe: 8,
+            candidates: k.saturating_mul(10).max(100),
+            k,
+            rerank: true,
+            min_hlc: 0,
+        }
+    }
+
+    /// Set the per-level probe count.
+    #[must_use]
+    pub const fn with_nprobe(mut self, nprobe: u32) -> Self {
+        self.nprobe = nprobe;
+        self
+    }
+
+    /// Only search clusters containing data newer than this HLC timestamp.
+    #[must_use]
+    pub const fn with_min_hlc(mut self, min_hlc: u64) -> Self {
+        self.min_hlc = min_hlc;
+        self
+    }
+}
+
+// ---------------------------------------------------------------------------
+// FractalIndexDefinition -- user-facing index declaration
+// ---------------------------------------------------------------------------
+
+/// Definition for a fractal vector index.
+///
+/// Analogous to [`crate::TableDefinition`] -- a compile-time description of an
+/// index that is passed to `open_fractal_index()` to create or open it.
+pub struct FractalIndexDefinition {
+    name: &'static str,
+    dim: u32,
+    num_subvectors: u32,
+    metric: DistanceMetric,
+    store_raw_vectors: bool,
+    default_nprobe: u32,
+    max_leaf_population: u32,
+    min_leaf_population: u32,
+    max_buffer_size: u32,
+    max_children: u32,
+    max_depth: u32,
+    variance_split_factor: f32,
+}
+
+impl FractalIndexDefinition {
+    /// Create a new fractal index definition.
+    ///
+    /// `dim` must be divisible by `num_subvectors`.
+    pub const fn new(
+        name: &'static str,
+        dim: u32,
+        num_subvectors: u32,
+        metric: DistanceMetric,
+    ) -> Self {
+        Self {
+            name,
+            dim,
+            num_subvectors,
+            metric,
+            store_raw_vectors: false,
+            default_nprobe: 8,
+            max_leaf_population: 1000,
+            min_leaf_population: 50,
+            max_buffer_size: 128,
+            max_children: 64,
+            max_depth: 8,
+            // f32 can't be used in const context easily, so we store the bits
+            // and decode later. 2.0f32.to_bits() = 0x4000_0000
+            variance_split_factor: 2.0,
+        }
+    }
+
+    /// Enable storage of full-precision vectors for re-ranking.
+    #[must_use]
+    pub const fn with_raw_vectors(mut self) -> Self {
+        self.store_raw_vectors = true;
+        self
+    }
+
+    /// Set the default per-level probe count for search.
+    #[must_use]
+    pub const fn with_nprobe(mut self, nprobe: u32) -> Self {
+        self.default_nprobe = nprobe;
+        self
+    }
+
+    /// Set the maximum leaf cluster population before split.
+    #[must_use]
+    pub const fn with_max_leaf_population(mut self, max: u32) -> Self {
+        self.max_leaf_population = max;
+        self
+    }
+
+    /// Set the minimum leaf cluster population before merge.
+    #[must_use]
+    pub const fn with_min_leaf_population(mut self, min: u32) -> Self {
+        self.min_leaf_population = min;
+        self
+    }
+
+    /// Set the write buffer size per cluster (cascade threshold).
+    #[must_use]
+    pub const fn with_max_buffer_size(mut self, size: u32) -> Self {
+        self.max_buffer_size = size;
+        self
+    }
+
+    /// Returns the index name.
+    pub const fn name(&self) -> &'static str {
+        self.name
+    }
+
+    /// Convert to a full [`FractalIndexConfig`] with default state.
+    pub fn to_config(&self) -> FractalIndexConfig {
+        FractalIndexConfig {
+            dim: self.dim,
+            num_subvectors: self.num_subvectors,
+            num_codewords: 256,
+            metric: self.metric,
+            store_raw_vectors: self.store_raw_vectors,
+            default_nprobe: self.default_nprobe,
+            state: STATE_NEW,
+            root_cluster_id: 0,
+            next_cluster_id: 0,
+            max_leaf_population: self.max_leaf_population,
+            min_leaf_population: self.min_leaf_population,
+            max_buffer_size: self.max_buffer_size,
+            max_children: self.max_children,
+            max_depth: self.max_depth,
+            num_vectors: 0,
+            num_clusters: 0,
+            variance_split_factor: self.variance_split_factor,
+        }
+    }
+}
+
+impl fmt::Debug for FractalIndexDefinition {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "FractalIndexDefinition({:?}, dim={}, subvecs={}, {:?})",
+            self.name, self.dim, self.num_subvectors, self.metric,
+        )
+    }
+}

--- a/src/fractal/index.rs
+++ b/src/fractal/index.rs
@@ -1,0 +1,916 @@
+use alloc::string::ToString;
+use alloc::vec::Vec;
+
+use crate::TableDefinition;
+use crate::error::{StorageError, TableError};
+use crate::table::ReadableTable;
+use crate::transactions::{ReadTransaction, WriteTransaction};
+use crate::vector_ops::{DistanceMetric, Neighbor, l2_normalize};
+
+use crate::ivfpq::pq::{self, Codebooks};
+use crate::ivfpq::types::PostingKey;
+
+use super::cluster::{
+    TableNames, cascade_leaf_buffer, centroid_add, centroid_remove, merge_cluster, split_cluster,
+};
+use super::config::{
+    FractalIndexConfig, FractalIndexDefinition, FractalSearchParams, NO_PARENT,
+    STATE_CODEBOOKS_TRAINED, STATE_NEW, STATE_OPERATIONAL, decode_fractal_config,
+    encode_fractal_config,
+};
+use super::search;
+use super::types::{ClusterMeta, HierarchyKey};
+
+/// Convert a `TableError` to `StorageError`.
+fn te(e: TableError) -> StorageError {
+    e.into_storage_error_or_corrupted("fractal index internal table error")
+}
+
+/// Validate that a fractal index configuration is internally consistent.
+fn validate_config(config: &FractalIndexConfig) -> crate::Result<()> {
+    if config.num_subvectors == 0 {
+        return Err(StorageError::Corrupted(
+            "fractal: num_subvectors must be > 0".to_string(),
+        ));
+    }
+    if config.dim == 0 {
+        return Err(StorageError::Corrupted(
+            "fractal: dim must be > 0".to_string(),
+        ));
+    }
+    if config.dim as usize % config.num_subvectors as usize != 0 {
+        return Err(StorageError::Corrupted(alloc::format!(
+            "fractal: dim ({}) must be divisible by num_subvectors ({})",
+            config.dim,
+            config.num_subvectors,
+        )));
+    }
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// FractalIndex -- writable index handle
+// ---------------------------------------------------------------------------
+
+/// A writable fractal vector index bound to a [`WriteTransaction`].
+///
+/// Obtained via [`WriteTransaction::open_fractal_index`].
+pub struct FractalIndex<'txn> {
+    pub(crate) txn: &'txn WriteTransaction,
+    pub(crate) config: FractalIndexConfig,
+    pub(crate) names: TableNames,
+    pub(crate) codebooks: Option<Codebooks>,
+    config_dirty: bool,
+}
+
+impl<'txn> FractalIndex<'txn> {
+    /// Open or create. Called by `WriteTransaction::open_fractal_index`.
+    pub(crate) fn open(
+        txn: &'txn WriteTransaction,
+        def: &FractalIndexDefinition,
+    ) -> Result<Self, TableError> {
+        let names = TableNames::new(def.name());
+
+        // Open or create meta table
+        let meta_def = TableDefinition::<&str, &[u8]>::new(&names.meta);
+        let mut meta_tbl = txn.open_table(meta_def)?;
+
+        let config = if let Some(guard) = meta_tbl.get("config")? {
+            let data = guard.value();
+            decode_fractal_config(data)
+        } else {
+            let cfg = def.to_config();
+            let encoded = encode_fractal_config(&cfg);
+            meta_tbl.insert("config", encoded.as_slice())?;
+            cfg
+        };
+        drop(meta_tbl);
+
+        validate_config(&config).map_err(TableError::Storage)?;
+
+        // Ensure all tables exist by opening them
+        let _ = txn.open_table(TableDefinition::<u32, &[u8]>::new(&names.clusters))?;
+        let _ = txn.open_table(TableDefinition::<u32, &[u8]>::new(&names.centroids))?;
+        let _ = txn.open_table(TableDefinition::<u32, &[u8]>::new(&names.centroid_sums))?;
+        let _ = txn.open_table(TableDefinition::<HierarchyKey, ()>::new(&names.hierarchy))?;
+        let _ = txn.open_table(TableDefinition::<PostingKey, &[u8]>::new(&names.buffer))?;
+        let _ = txn.open_table(TableDefinition::<PostingKey, &[u8]>::new(&names.postings))?;
+        let _ = txn.open_table(TableDefinition::<u64, u32>::new(&names.assignments))?;
+        if config.store_raw_vectors {
+            let _ = txn.open_table(TableDefinition::<u64, &[u8]>::new(&names.vectors))?;
+        }
+        let _ = txn.open_table(TableDefinition::<u32, &[u8]>::new(&names.codebooks))?;
+
+        Ok(Self {
+            txn,
+            config,
+            names,
+            codebooks: None,
+            config_dirty: false,
+        })
+    }
+
+    /// Persist the config to the meta table.
+    pub fn flush(&mut self) -> crate::Result<()> {
+        if self.config_dirty {
+            let meta_def = TableDefinition::<&str, &[u8]>::new(&self.names.meta);
+            let mut meta_tbl = self.txn.open_table(meta_def).map_err(te)?;
+            let encoded = encode_fractal_config(&self.config);
+            meta_tbl.insert("config", encoded.as_slice())?;
+            self.config_dirty = false;
+        }
+        Ok(())
+    }
+
+    #[allow(clippy::cast_possible_truncation)]
+    fn ensure_codebooks(&mut self) -> crate::Result<()> {
+        if self.codebooks.is_some() {
+            return Ok(());
+        }
+        if self.config.state == STATE_NEW {
+            return Err(StorageError::Corrupted(
+                "fractal: index has not been trained yet".to_string(),
+            ));
+        }
+        let cb_def = TableDefinition::<u32, &[u8]>::new(&self.names.codebooks);
+        let tbl = self.txn.open_table(cb_def).map_err(te)?;
+        let num_sub = self.config.num_subvectors as usize;
+        let sub_dim = self.config.sub_dim();
+        let mut data = alloc::vec![0.0f32; num_sub * 256 * sub_dim];
+        for m in 0..num_sub {
+            if let Some(guard) = tbl.get(m as u32)? {
+                let bytes = guard.value();
+                for k in 0..256 {
+                    for d in 0..sub_dim {
+                        let offset = (k * sub_dim + d) * 4;
+                        data[m * 256 * sub_dim + k * sub_dim + d] =
+                            f32::from_le_bytes(bytes[offset..offset + 4].try_into().unwrap());
+                    }
+                }
+            }
+        }
+        self.codebooks = Some(Codebooks {
+            data,
+            num_subvectors: num_sub,
+            sub_dim,
+        });
+        Ok(())
+    }
+
+    /// Train PQ codebooks from training data.
+    ///
+    /// This initializes the index: trains codebooks, creates the root cluster,
+    /// bulk-inserts training vectors, and recursively splits until all leaf
+    /// clusters are below `max_leaf_population`.
+    #[allow(clippy::cast_possible_truncation, clippy::cast_precision_loss)]
+    pub fn train_codebooks<I>(&mut self, vectors: I, max_iter: usize) -> crate::Result<()>
+    where
+        I: Iterator<Item = (u64, Vec<f32>)>,
+    {
+        let dim = self.config.dim as usize;
+        let num_sub = self.config.num_subvectors as usize;
+
+        // Collect training data
+        let mut ids: Vec<u64> = Vec::new();
+        let mut flat: Vec<f32> = Vec::new();
+        for (id, vec) in vectors {
+            if vec.len() != dim {
+                return Err(StorageError::Corrupted(alloc::format!(
+                    "fractal: training vector dim mismatch: expected {dim}, got {}",
+                    vec.len(),
+                )));
+            }
+            ids.push(id);
+            if self.config.metric == DistanceMetric::Cosine {
+                let mut normalized = vec;
+                l2_normalize(&mut normalized);
+                flat.extend_from_slice(&normalized);
+            } else {
+                flat.extend_from_slice(&vec);
+            }
+        }
+
+        let n = ids.len();
+        if n == 0 {
+            return Err(StorageError::Corrupted(
+                "fractal: need at least 1 training vector".to_string(),
+            ));
+        }
+
+        // Train PQ codebooks
+        let codebooks = pq::train_codebooks(&flat, dim, num_sub, max_iter, self.config.metric);
+
+        // Persist codebooks
+        let cb_def = TableDefinition::<u32, &[u8]>::new(&self.names.codebooks);
+        let mut cb_tbl = self.txn.open_table(cb_def).map_err(te)?;
+        let sub_dim = codebooks.sub_dim;
+        for m in 0..num_sub {
+            let mut bytes = Vec::with_capacity(256 * sub_dim * 4);
+            for k in 0..256 {
+                for d in 0..sub_dim {
+                    bytes.extend_from_slice(
+                        &codebooks.data[m * 256 * sub_dim + k * sub_dim + d].to_le_bytes(),
+                    );
+                }
+            }
+            cb_tbl.insert(m as u32, bytes.as_slice())?;
+        }
+        drop(cb_tbl);
+
+        self.config.state = STATE_CODEBOOKS_TRAINED;
+        self.codebooks = Some(codebooks);
+
+        // Create root cluster
+        let root_id = self.config.alloc_cluster_id();
+        self.config.root_cluster_id = root_id;
+
+        // Compute root centroid from all training data
+        let mut sums = alloc::vec![0.0f64; dim];
+        for i in 0..n {
+            for d in 0..dim {
+                sums[d] += f64::from(flat[i * dim + d]);
+            }
+        }
+        let pop_f64 = n as f64;
+        let centroid: Vec<f32> = sums.iter().map(|s| (*s / pop_f64) as f32).collect();
+
+        // Persist root cluster metadata
+        let mut root_meta = ClusterMeta::new(root_id, NO_PARENT, 0, true);
+        root_meta.set_population(0); // Will be incremented during insert
+
+        let clusters_def = TableDefinition::<u32, &[u8]>::new(&self.names.clusters);
+        let centroids_def = TableDefinition::<u32, &[u8]>::new(&self.names.centroids);
+        let sums_def = TableDefinition::<u32, &[u8]>::new(&self.names.centroid_sums);
+        {
+            let mut ctbl = self.txn.open_table(clusters_def).map_err(te)?;
+            ctbl.insert(root_id, root_meta.as_bytes().as_slice())?;
+
+            let mut cent_tbl = self.txn.open_table(centroids_def).map_err(te)?;
+            let centroid_bytes: Vec<u8> = centroid.iter().flat_map(|f| f.to_le_bytes()).collect();
+            cent_tbl.insert(root_id, centroid_bytes.as_slice())?;
+
+            let mut sum_tbl = self.txn.open_table(sums_def).map_err(te)?;
+            let sum_bytes: Vec<u8> = sums.iter().flat_map(|f| f.to_le_bytes()).collect();
+            sum_tbl.insert(root_id, sum_bytes.as_slice())?;
+        }
+
+        // Bulk-insert all training vectors into root cluster
+        let codebooks_ref = self.codebooks.as_ref().unwrap();
+        let postings_def = TableDefinition::<PostingKey, &[u8]>::new(&self.names.postings);
+        let assignments_def = TableDefinition::<u64, u32>::new(&self.names.assignments);
+        let vectors_def = TableDefinition::<u64, &[u8]>::new(&self.names.vectors);
+        {
+            let mut ptbl = self.txn.open_table(postings_def).map_err(te)?;
+            let mut atbl = self.txn.open_table(assignments_def).map_err(te)?;
+            let mut vtbl_opt = if self.config.store_raw_vectors {
+                Some(self.txn.open_table(vectors_def).map_err(te)?)
+            } else {
+                None
+            };
+
+            for i in 0..n {
+                let vid = ids[i];
+                let vec_slice = &flat[i * dim..(i + 1) * dim];
+                let pq_codes = codebooks_ref.encode(vec_slice);
+                ptbl.insert(PostingKey::new(root_id, vid), pq_codes.as_slice())?;
+                atbl.insert(vid, root_id)?;
+
+                if let Some(ref mut vtbl) = vtbl_opt {
+                    let raw_bytes: Vec<u8> =
+                        vec_slice.iter().flat_map(|f| f.to_le_bytes()).collect();
+                    vtbl.insert(vid, raw_bytes.as_slice())?;
+                }
+            }
+        }
+
+        // Update root population
+        {
+            let mut ctbl = self.txn.open_table(clusters_def).map_err(te)?;
+            root_meta.set_population(n as u32);
+            ctbl.insert(root_id, root_meta.as_bytes().as_slice())?;
+        }
+
+        self.config.num_vectors = n as u64;
+        self.config.state = STATE_OPERATIONAL;
+
+        // Recursively split overflowing clusters
+        self.split_overflowing_clusters()?;
+
+        self.config_dirty = true;
+        self.flush()?;
+
+        Ok(())
+    }
+
+    /// Recursively split any leaf cluster that exceeds `max_leaf_population`.
+    fn split_overflowing_clusters(&mut self) -> crate::Result<()> {
+        loop {
+            // Find a leaf cluster that needs splitting
+            let clusters_def = TableDefinition::<u32, &[u8]>::new(&self.names.clusters);
+            let mut to_split: Option<u32> = None;
+
+            {
+                let ctbl = self.txn.open_table(clusters_def).map_err(te)?;
+                let range = ctbl.range::<u32>(..)?;
+                for entry in range {
+                    let (key, val) = entry?;
+                    let meta = ClusterMeta::from_bytes(val.value());
+                    if meta.is_leaf()
+                        && meta.population() > self.config.max_leaf_population
+                        && meta.population() >= 2 * self.config.min_leaf_population
+                    {
+                        to_split = Some(key.value());
+                        break;
+                    }
+                }
+            }
+
+            match to_split {
+                Some(cid) => {
+                    self.ensure_codebooks()?;
+                    split_cluster(
+                        self.txn,
+                        &mut self.config,
+                        cid,
+                        &self.names,
+                        self.codebooks.as_ref(),
+                    )?;
+                }
+                None => break,
+            }
+        }
+        Ok(())
+    }
+
+    /// Insert a single vector with associated temporal metadata.
+    ///
+    /// `hlc` and `wall_ns` are used to maintain per-cluster temporal ranges,
+    /// enabling time-window pruning during search. Pass 0 for both if temporal
+    /// filtering is not needed.
+    pub fn insert_with_time(
+        &mut self,
+        vector_id: u64,
+        vector: &[f32],
+        hlc: u64,
+        wall_ns: u64,
+    ) -> crate::Result<()> {
+        let dim = self.config.dim as usize;
+        if vector.len() != dim {
+            return Err(StorageError::Corrupted(alloc::format!(
+                "fractal: expected dim={dim}, got {}",
+                vector.len(),
+            )));
+        }
+
+        // Validate finite
+        for &v in vector {
+            if !v.is_finite() {
+                return Err(StorageError::Corrupted(
+                    "fractal: vector contains NaN or Inf".to_string(),
+                ));
+            }
+        }
+
+        if self.config.state != STATE_OPERATIONAL {
+            return Err(StorageError::Corrupted(
+                "fractal: index not operational (train codebooks first)".to_string(),
+            ));
+        }
+
+        let vec_ref: Vec<f32> = if self.config.metric == DistanceMetric::Cosine {
+            let mut v = vector.to_vec();
+            l2_normalize(&mut v);
+            v
+        } else {
+            vector.to_vec()
+        };
+
+        // Remove old entry if it exists (upsert)
+        let assignments_def = TableDefinition::<u64, u32>::new(&self.names.assignments);
+        let old_cluster = {
+            let atbl = self.txn.open_table(assignments_def).map_err(te)?;
+            atbl.get(vector_id)?.map(|g| g.value())
+        };
+        if let Some(old_cid) = old_cluster {
+            // Load the OLD vector for correct centroid removal (not the new one)
+            let old_vec = self.load_vector_any(vector_id, old_cid, dim)?;
+            if let Some(ref ov) = old_vec {
+                self.remove_from_cluster(vector_id, old_cid, ov)?;
+            } else {
+                // No raw vector available: remove from posting list, decrement population
+                let postings_def = TableDefinition::<PostingKey, &[u8]>::new(&self.names.postings);
+                {
+                    let mut ptbl = self.txn.open_table(postings_def).map_err(te)?;
+                    ptbl.remove(PostingKey::new(old_cid, vector_id))?;
+                }
+                // Also remove from buffer
+                let buffer_def = TableDefinition::<PostingKey, &[u8]>::new(&self.names.buffer);
+                {
+                    let mut btbl = self.txn.open_table(buffer_def).map_err(te)?;
+                    btbl.remove(PostingKey::new(old_cid, vector_id))?;
+                }
+                // Decrement population without centroid update
+                let clusters_def = TableDefinition::<u32, &[u8]>::new(&self.names.clusters);
+                let mut ctbl = self.txn.open_table(clusters_def).map_err(te)?;
+                let meta_opt = ctbl
+                    .get(old_cid)?
+                    .map(|g| ClusterMeta::from_bytes(g.value()));
+                if let Some(mut meta) = meta_opt {
+                    meta.set_population(meta.population().saturating_sub(1));
+                    ctbl.insert(old_cid, meta.as_bytes().as_slice())?;
+                }
+            }
+        }
+
+        // Walk tree to find target leaf cluster
+        let leaf_id = self.find_nearest_leaf(self.config.root_cluster_id, &vec_ref)?;
+
+        // Insert into leaf's buffer
+        let buffer_def = TableDefinition::<PostingKey, &[u8]>::new(&self.names.buffer);
+        {
+            let mut btbl = self.txn.open_table(buffer_def).map_err(te)?;
+            let raw_bytes: Vec<u8> = vec_ref.iter().flat_map(|f| f.to_le_bytes()).collect();
+            btbl.insert(PostingKey::new(leaf_id, vector_id), raw_bytes.as_slice())?;
+        }
+
+        // Update centroid incrementally
+        let clusters_def = TableDefinition::<u32, &[u8]>::new(&self.names.clusters);
+        let old_pop = {
+            let ctbl = self.txn.open_table(clusters_def).map_err(te)?;
+            match ctbl.get(leaf_id)? {
+                Some(g) => ClusterMeta::from_bytes(g.value()).population(),
+                None => 0,
+            }
+        };
+
+        let new_pop = centroid_add(
+            self.txn,
+            &self.names.centroid_sums,
+            &self.names.centroids,
+            leaf_id,
+            dim,
+            &vec_ref,
+            old_pop,
+        )?;
+
+        // Update cluster meta (population, buffer count, temporal range)
+        {
+            let mut ctbl = self.txn.open_table(clusters_def).map_err(te)?;
+            let meta_opt = ctbl
+                .get(leaf_id)?
+                .map(|g| ClusterMeta::from_bytes(g.value()));
+            if let Some(mut meta) = meta_opt {
+                meta.set_population(new_pop);
+                meta.set_buffer_count(meta.buffer_count() + 1);
+                // Update temporal range
+                if hlc > 0 {
+                    if meta.oldest_hlc() == 0 || hlc < meta.oldest_hlc() {
+                        meta.set_oldest_hlc(hlc);
+                    }
+                    if hlc > meta.newest_hlc() {
+                        meta.set_newest_hlc(hlc);
+                    }
+                }
+                if wall_ns > 0 {
+                    if meta.oldest_wall_ns() == 0 || wall_ns < meta.oldest_wall_ns() {
+                        meta.set_oldest_wall_ns(wall_ns);
+                    }
+                    if wall_ns > meta.newest_wall_ns() {
+                        meta.set_newest_wall_ns(wall_ns);
+                    }
+                }
+                ctbl.insert(leaf_id, meta.as_bytes().as_slice())?;
+            }
+        }
+
+        // Update assignments
+        {
+            let mut atbl = self.txn.open_table(assignments_def).map_err(te)?;
+            atbl.insert(vector_id, leaf_id)?;
+        }
+
+        // Cascade buffer if full
+        let buffer_count = {
+            let ctbl = self.txn.open_table(clusters_def).map_err(te)?;
+            match ctbl.get(leaf_id)? {
+                Some(g) => ClusterMeta::from_bytes(g.value()).buffer_count(),
+                None => 0,
+            }
+        };
+
+        if buffer_count >= self.config.max_buffer_size {
+            self.ensure_codebooks()?;
+            cascade_leaf_buffer(
+                self.txn,
+                leaf_id,
+                self.codebooks.as_ref().unwrap(),
+                &self.config,
+                &self.names,
+            )?;
+        }
+
+        // Split if overflowing
+        if new_pop > self.config.max_leaf_population
+            && new_pop >= 2 * self.config.min_leaf_population
+        {
+            // Must cascade buffer first before splitting
+            self.ensure_codebooks()?;
+            cascade_leaf_buffer(
+                self.txn,
+                leaf_id,
+                self.codebooks.as_ref().unwrap(),
+                &self.config,
+                &self.names,
+            )?;
+            split_cluster(
+                self.txn,
+                &mut self.config,
+                leaf_id,
+                &self.names,
+                self.codebooks.as_ref(),
+            )?;
+        }
+
+        if old_cluster.is_none() {
+            self.config.num_vectors += 1;
+        }
+        self.config_dirty = true;
+
+        Ok(())
+    }
+
+    /// Insert a single vector into the index (no temporal metadata).
+    pub fn insert(&mut self, vector_id: u64, vector: &[f32]) -> crate::Result<()> {
+        self.insert_with_time(vector_id, vector, 0, 0)
+    }
+
+    /// Insert multiple vectors in a batch.
+    pub fn insert_batch<I>(&mut self, vectors: I) -> crate::Result<()>
+    where
+        I: Iterator<Item = (u64, Vec<f32>)>,
+    {
+        for (vid, vec) in vectors {
+            self.insert(vid, &vec)?;
+        }
+        Ok(())
+    }
+
+    /// Remove a vector from the index.
+    pub fn remove(&mut self, vector_id: u64) -> crate::Result<bool> {
+        let assignments_def = TableDefinition::<u64, u32>::new(&self.names.assignments);
+        let cluster_id = {
+            let atbl = self.txn.open_table(assignments_def).map_err(te)?;
+            match atbl.get(vector_id)? {
+                Some(g) => g.value(),
+                None => return Ok(false),
+            }
+        };
+
+        let dim = self.config.dim as usize;
+
+        // Check if vector is in the buffer before removal (for buffer_count tracking)
+        let in_buffer = {
+            let buffer_def = TableDefinition::<PostingKey, &[u8]>::new(&self.names.buffer);
+            let btbl = self.txn.open_table(buffer_def).map_err(te)?;
+            btbl.get(PostingKey::new(cluster_id, vector_id))?.is_some()
+        };
+
+        // Try to load vector from any source for centroid update
+        let raw_vec = self.load_vector_any(vector_id, cluster_id, dim)?;
+
+        if let Some(ref vec) = raw_vec {
+            self.remove_from_cluster(vector_id, cluster_id, vec)?;
+        } else {
+            // Remove from posting list without centroid update
+            let postings_def = TableDefinition::<PostingKey, &[u8]>::new(&self.names.postings);
+            let mut ptbl = self.txn.open_table(postings_def).map_err(te)?;
+            ptbl.remove(PostingKey::new(cluster_id, vector_id))?;
+
+            // Still decrement population even without centroid update
+            let clusters_def = TableDefinition::<u32, &[u8]>::new(&self.names.clusters);
+            let mut ctbl = self.txn.open_table(clusters_def).map_err(te)?;
+            let meta_opt = ctbl
+                .get(cluster_id)?
+                .map(|g| ClusterMeta::from_bytes(g.value()));
+            if let Some(mut meta) = meta_opt {
+                meta.set_population(meta.population().saturating_sub(1));
+                ctbl.insert(cluster_id, meta.as_bytes().as_slice())?;
+            }
+        }
+
+        // Remove from buffer
+        {
+            let buffer_def = TableDefinition::<PostingKey, &[u8]>::new(&self.names.buffer);
+            let mut btbl = self.txn.open_table(buffer_def).map_err(te)?;
+            btbl.remove(PostingKey::new(cluster_id, vector_id))?;
+        }
+
+        // Decrement buffer_count if the vector was in the buffer
+        if in_buffer {
+            let clusters_def = TableDefinition::<u32, &[u8]>::new(&self.names.clusters);
+            let mut ctbl = self.txn.open_table(clusters_def).map_err(te)?;
+            let meta_opt = ctbl
+                .get(cluster_id)?
+                .map(|g| ClusterMeta::from_bytes(g.value()));
+            if let Some(mut meta) = meta_opt {
+                meta.set_buffer_count(meta.buffer_count().saturating_sub(1));
+                ctbl.insert(cluster_id, meta.as_bytes().as_slice())?;
+            }
+        }
+
+        // Remove assignment
+        {
+            let mut atbl = self.txn.open_table(assignments_def).map_err(te)?;
+            atbl.remove(vector_id)?;
+        }
+
+        // Remove raw vector
+        if self.config.store_raw_vectors {
+            let vectors_def = TableDefinition::<u64, &[u8]>::new(&self.names.vectors);
+            let mut vtbl = self.txn.open_table(vectors_def).map_err(te)?;
+            vtbl.remove(vector_id)?;
+        }
+
+        self.config.num_vectors -= 1;
+        self.config_dirty = true;
+
+        // Check merge condition
+        let clusters_def = TableDefinition::<u32, &[u8]>::new(&self.names.clusters);
+        let pop = {
+            let ctbl = self.txn.open_table(clusters_def).map_err(te)?;
+            match ctbl.get(cluster_id)? {
+                Some(g) => ClusterMeta::from_bytes(g.value()).population(),
+                None => 0,
+            }
+        };
+
+        if pop < self.config.min_leaf_population && pop > 0 {
+            merge_cluster(self.txn, &mut self.config, cluster_id, &self.names)?;
+        }
+
+        Ok(true)
+    }
+
+    /// Search the index for nearest neighbors.
+    pub fn search(
+        &mut self,
+        query: &[f32],
+        params: &FractalSearchParams,
+    ) -> crate::Result<Vec<Neighbor<u64>>> {
+        self.ensure_codebooks()?;
+        self.flush()?;
+        search::search_write(self, query, params)
+    }
+
+    // -----------------------------------------------------------------------
+    // Internal helpers
+    // -----------------------------------------------------------------------
+
+    /// Walk from a cluster node to the nearest leaf.
+    fn find_nearest_leaf(&self, start: u32, vector: &[f32]) -> crate::Result<u32> {
+        let dim = self.config.dim as usize;
+        let clusters_def = TableDefinition::<u32, &[u8]>::new(&self.names.clusters);
+        let centroids_def = TableDefinition::<u32, &[u8]>::new(&self.names.centroids);
+        let hier_def = TableDefinition::<HierarchyKey, ()>::new(&self.names.hierarchy);
+
+        let mut current = start;
+        loop {
+            let meta = {
+                let ctbl = self.txn.open_table(clusters_def).map_err(te)?;
+                match ctbl.get(current)? {
+                    Some(g) => ClusterMeta::from_bytes(g.value()),
+                    None => {
+                        return Err(StorageError::Corrupted(alloc::format!(
+                            "fractal: cluster {current} not found"
+                        )));
+                    }
+                }
+            };
+
+            if meta.is_leaf() {
+                return Ok(current);
+            }
+
+            // Internal node: find nearest child
+            let htbl = self.txn.open_table(hier_def).map_err(te)?;
+            let ctbl = self.txn.open_table(centroids_def).map_err(te)?;
+
+            let mut best_child = current;
+            let mut best_dist = f32::MAX;
+
+            let range = htbl.range(
+                HierarchyKey::children_start(current)..=HierarchyKey::children_end(current),
+            )?;
+
+            for entry in range {
+                let (key, _) = entry?;
+                let child_id = key.value().child_id;
+
+                if let Some(cg) = ctbl.get(child_id)? {
+                    let bytes = cg.value();
+                    let child_centroid: Vec<f32> = (0..dim)
+                        .map(|i| f32::from_le_bytes(bytes[i * 4..i * 4 + 4].try_into().unwrap()))
+                        .collect();
+                    let dist = self.config.metric.compute(vector, &child_centroid);
+                    if dist < best_dist {
+                        best_dist = dist;
+                        best_child = child_id;
+                    }
+                }
+            }
+
+            if best_child == current {
+                // No children found -- shouldn't happen for internal nodes
+                return Err(StorageError::Corrupted(alloc::format!(
+                    "fractal: internal cluster {current} has no children"
+                )));
+            }
+
+            current = best_child;
+        }
+    }
+
+    fn remove_from_cluster(
+        &self,
+        vector_id: u64,
+        cluster_id: u32,
+        vector: &[f32],
+    ) -> crate::Result<()> {
+        let dim = self.config.dim as usize;
+
+        // Remove from posting list
+        let postings_def = TableDefinition::<PostingKey, &[u8]>::new(&self.names.postings);
+        {
+            let mut ptbl = self.txn.open_table(postings_def).map_err(te)?;
+            ptbl.remove(PostingKey::new(cluster_id, vector_id))?;
+        }
+
+        // Update centroid
+        let clusters_def = TableDefinition::<u32, &[u8]>::new(&self.names.clusters);
+        let old_pop = {
+            let ctbl = self.txn.open_table(clusters_def).map_err(te)?;
+            match ctbl.get(cluster_id)? {
+                Some(g) => ClusterMeta::from_bytes(g.value()).population(),
+                None => 0,
+            }
+        };
+
+        let new_pop = centroid_remove(
+            self.txn,
+            &self.names.centroid_sums,
+            &self.names.centroids,
+            cluster_id,
+            dim,
+            vector,
+            old_pop,
+        )?;
+
+        {
+            let mut ctbl = self.txn.open_table(clusters_def).map_err(te)?;
+            let meta_opt = ctbl
+                .get(cluster_id)?
+                .map(|g| ClusterMeta::from_bytes(g.value()));
+            if let Some(mut meta) = meta_opt {
+                meta.set_population(new_pop);
+                ctbl.insert(cluster_id, meta.as_bytes().as_slice())?;
+            }
+        }
+
+        Ok(())
+    }
+
+    fn load_raw_vector(&self, vector_id: u64, dim: usize) -> crate::Result<Option<Vec<f32>>> {
+        if !self.config.store_raw_vectors {
+            return Ok(None);
+        }
+        let vectors_def = TableDefinition::<u64, &[u8]>::new(&self.names.vectors);
+        let vtbl = self.txn.open_table(vectors_def).map_err(te)?;
+        match vtbl.get(vector_id)? {
+            Some(g) => {
+                let bytes = g.value();
+                let vec: Vec<f32> = (0..dim)
+                    .map(|i| f32::from_le_bytes(bytes[i * 4..i * 4 + 4].try_into().unwrap()))
+                    .collect();
+                Ok(Some(vec))
+            }
+            None => Ok(None),
+        }
+    }
+
+    /// Try to load a vector from raw vectors table, then buffer table.
+    fn load_vector_any(
+        &self,
+        vector_id: u64,
+        cluster_id: u32,
+        dim: usize,
+    ) -> crate::Result<Option<Vec<f32>>> {
+        // Try raw vectors table first
+        if let Some(vec) = self.load_raw_vector(vector_id, dim)? {
+            return Ok(Some(vec));
+        }
+        // Try buffer table (vector may not yet be cascaded)
+        let buffer_def = TableDefinition::<PostingKey, &[u8]>::new(&self.names.buffer);
+        let btbl = self.txn.open_table(buffer_def).map_err(te)?;
+        if let Some(g) = btbl.get(PostingKey::new(cluster_id, vector_id))? {
+            let bytes = g.value();
+            let vec: Vec<f32> = (0..dim)
+                .map(|i| f32::from_le_bytes(bytes[i * 4..i * 4 + 4].try_into().unwrap()))
+                .collect();
+            return Ok(Some(vec));
+        }
+        Ok(None)
+    }
+
+    /// Returns the current config (for testing).
+    pub fn config(&self) -> &FractalIndexConfig {
+        &self.config
+    }
+}
+
+impl Drop for FractalIndex<'_> {
+    fn drop(&mut self) {
+        let _ = self.flush();
+    }
+}
+
+// ---------------------------------------------------------------------------
+// ReadOnlyFractalIndex -- read-only index handle
+// ---------------------------------------------------------------------------
+
+/// A read-only fractal vector index for search within a [`ReadTransaction`].
+///
+/// Obtained via [`ReadTransaction::open_fractal_index`].
+pub struct ReadOnlyFractalIndex {
+    pub(crate) config: FractalIndexConfig,
+    pub(crate) names: TableNames,
+    pub(crate) codebooks: Codebooks,
+}
+
+impl ReadOnlyFractalIndex {
+    /// Open a fractal index for reading.
+    #[allow(clippy::cast_possible_truncation)]
+    pub(crate) fn open(
+        txn: &ReadTransaction,
+        def: &FractalIndexDefinition,
+    ) -> Result<Self, TableError> {
+        let names = TableNames::new(def.name());
+
+        let meta_def = TableDefinition::<&str, &[u8]>::new(&names.meta);
+        let meta_tbl = txn.open_table(meta_def)?;
+        let config = match meta_tbl.get("config")? {
+            Some(guard) => decode_fractal_config(guard.value()),
+            None => {
+                return Err(TableError::TableDoesNotExist(def.name().to_string()));
+            }
+        };
+        drop(meta_tbl);
+
+        validate_config(&config).map_err(TableError::Storage)?;
+
+        // Eagerly load codebooks
+        let cb_def = TableDefinition::<u32, &[u8]>::new(&names.codebooks);
+        let cb_tbl = txn.open_table(cb_def)?;
+        let num_sub = config.num_subvectors as usize;
+        let sub_dim = config.sub_dim();
+        let mut data = alloc::vec![0.0f32; num_sub * 256 * sub_dim];
+        for m in 0..num_sub {
+            if let Some(guard) = cb_tbl.get(m as u32)? {
+                let bytes = guard.value();
+                for k in 0..256 {
+                    for d in 0..sub_dim {
+                        let offset = (k * sub_dim + d) * 4;
+                        data[m * 256 * sub_dim + k * sub_dim + d] =
+                            f32::from_le_bytes(bytes[offset..offset + 4].try_into().unwrap());
+                    }
+                }
+            }
+        }
+
+        let codebooks = Codebooks {
+            data,
+            num_subvectors: num_sub,
+            sub_dim,
+        };
+
+        Ok(Self {
+            config,
+            names,
+            codebooks,
+        })
+    }
+
+    /// Search the index for nearest neighbors.
+    pub fn search(
+        &self,
+        txn: &ReadTransaction,
+        query: &[f32],
+        params: &FractalSearchParams,
+    ) -> crate::Result<Vec<Neighbor<u64>>> {
+        search::search_read(self, txn, query, params)
+    }
+
+    /// Returns the current config (for testing).
+    pub fn config(&self) -> &FractalIndexConfig {
+        &self.config
+    }
+}

--- a/src/fractal/mod.rs
+++ b/src/fractal/mod.rs
@@ -1,0 +1,53 @@
+//! Adaptive fractal vector index -- self-organizing hierarchical clustering.
+//!
+//! This module implements a fractal vector index that replaces static IVF-PQ
+//! centroids with a self-organizing cluster tree. Clusters maintain running
+//! centroids, split when population exceeds a threshold, and merge when
+//! population drops. Write-buffered cascading amortizes structural changes.
+//!
+//! # Architecture
+//!
+//! - **Hierarchical cluster tree**: Internal nodes route queries; leaf nodes
+//!   own posting lists with PQ-compressed vectors.
+//! - **Write buffers**: New vectors are buffered at leaf clusters. When the
+//!   buffer fills, vectors are PQ-encoded and moved to the posting list.
+//! - **Incremental centroids**: Welford's online algorithm with f64 sum
+//!   accumulators for precision across millions of updates.
+//! - **Global PQ codebooks**: Trained once, shared across all clusters.
+//! - **Temporal awareness**: Each cluster tracks its temporal range.
+//!   Search can skip clusters outside a query's time window.
+//!
+//! All data is stored in regular B-tree tables, fully ACID and crash-safe.
+//!
+//! # Example
+//!
+//! ```rust,ignore
+//! use shodh_redb::{Database, DistanceMetric, FractalIndexDefinition, FractalSearchParams};
+//!
+//! const INDEX: FractalIndexDefinition = FractalIndexDefinition::new(
+//!     "memory", 384, 48, DistanceMetric::Cosine,
+//! ).with_raw_vectors();
+//!
+//! let db = Database::create("memory.redb")?;
+//!
+//! // Train codebooks + insert
+//! let write_txn = db.begin_write()?;
+//! let mut idx = write_txn.open_fractal_index(&INDEX)?;
+//! idx.train_codebooks(training_data.into_iter(), 25)?;
+//! idx.insert(1, &embedding)?;
+//! write_txn.commit()?;
+//!
+//! // Search
+//! let read_txn = db.begin_read()?;
+//! let idx = read_txn.open_fractal_index(&INDEX)?;
+//! let results = idx.search(&read_txn, &query, &FractalSearchParams::top_k(10))?;
+//! ```
+
+pub(crate) mod cluster;
+pub mod config;
+pub(crate) mod index;
+pub(crate) mod search;
+pub(crate) mod types;
+
+pub use config::{FractalIndexConfig, FractalIndexDefinition, FractalSearchParams};
+pub use index::{FractalIndex, ReadOnlyFractalIndex};

--- a/src/fractal/search.rs
+++ b/src/fractal/search.rs
@@ -1,0 +1,518 @@
+use alloc::collections::BinaryHeap;
+use alloc::vec::Vec;
+use core::cmp::Ordering as CmpOrdering;
+
+use crate::TableDefinition;
+use crate::error::StorageError;
+use crate::table::ReadableTable;
+use crate::transactions::{ReadTransaction, WriteTransaction};
+use crate::vector_ops::{DistanceMetric, Neighbor, l2_normalize};
+
+use crate::ivfpq::adc::AdcTable;
+use crate::ivfpq::types::PostingKey;
+
+use super::cluster::TableNames;
+use super::config::FractalSearchParams;
+use super::index::{FractalIndex, ReadOnlyFractalIndex};
+use super::types::{ClusterMeta, HierarchyKey};
+
+/// Convert a `TableError` to `StorageError`.
+fn te(e: crate::error::TableError) -> StorageError {
+    e.into_storage_error_or_corrupted("fractal search internal table error")
+}
+
+// ---------------------------------------------------------------------------
+// CandidateHeap -- fixed-capacity max-heap for top-K selection
+// ---------------------------------------------------------------------------
+
+struct CandidateEntry {
+    vector_id: u64,
+    distance: f32,
+}
+
+impl PartialEq for CandidateEntry {
+    fn eq(&self, other: &Self) -> bool {
+        self.distance == other.distance
+    }
+}
+
+impl Eq for CandidateEntry {}
+
+impl PartialOrd for CandidateEntry {
+    fn partial_cmp(&self, other: &Self) -> Option<CmpOrdering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl Ord for CandidateEntry {
+    fn cmp(&self, other: &Self) -> CmpOrdering {
+        // Max-heap: worst (largest) distance at top for eviction
+        self.distance
+            .partial_cmp(&other.distance)
+            .unwrap_or(CmpOrdering::Equal)
+    }
+}
+
+struct CandidateHeap {
+    capacity: usize,
+    heap: BinaryHeap<CandidateEntry>,
+}
+
+impl CandidateHeap {
+    fn new(capacity: usize) -> Self {
+        Self {
+            capacity,
+            heap: BinaryHeap::with_capacity(capacity + 1),
+        }
+    }
+
+    fn push(&mut self, vector_id: u64, distance: f32) {
+        if self.heap.len() < self.capacity {
+            self.heap.push(CandidateEntry {
+                vector_id,
+                distance,
+            });
+        } else if let Some(worst) = self.heap.peek()
+            && distance < worst.distance
+        {
+            self.heap.pop();
+            self.heap.push(CandidateEntry {
+                vector_id,
+                distance,
+            });
+        }
+    }
+
+    fn into_sorted(self, k: usize) -> Vec<Neighbor<u64>> {
+        let mut entries: Vec<_> = self.heap.into_vec();
+        entries.sort_by(|a, b| {
+            a.distance
+                .partial_cmp(&b.distance)
+                .unwrap_or(CmpOrdering::Equal)
+        });
+        entries
+            .into_iter()
+            .take(k)
+            .map(|e| Neighbor {
+                key: e.vector_id,
+                distance: e.distance,
+            })
+            .collect()
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Search implementation -- write transaction path
+// ---------------------------------------------------------------------------
+
+pub(crate) fn search_write(
+    idx: &mut FractalIndex<'_>,
+    query: &[f32],
+    params: &FractalSearchParams,
+) -> crate::Result<Vec<Neighbor<u64>>> {
+    let dim = idx.config.dim as usize;
+    if query.len() != dim {
+        return Err(StorageError::Corrupted(alloc::format!(
+            "fractal: search query dim mismatch: expected {dim}, got {}",
+            query.len(),
+        )));
+    }
+
+    let q = if idx.config.metric == DistanceMetric::Cosine {
+        let mut v = query.to_vec();
+        l2_normalize(&mut v);
+        v
+    } else {
+        query.to_vec()
+    };
+
+    let codebooks = idx.codebooks.as_ref().unwrap();
+    let adc = AdcTable::build(&q, codebooks, idx.config.metric);
+    let nprobe = params.nprobe.max(1);
+    let heap_cap = if params.rerank {
+        params.candidates
+    } else {
+        params.k
+    };
+    let mut heap = CandidateHeap::new(heap_cap);
+
+    // Collect leaf clusters to scan via beam search
+    let leaves = beam_search_leaves_write(
+        idx.txn,
+        &idx.names,
+        &idx.config,
+        idx.config.root_cluster_id,
+        &q,
+        nprobe,
+        params.min_hlc,
+    )?;
+
+    // Scan posting lists and buffers of selected leaves
+    let postings_def = TableDefinition::<PostingKey, &[u8]>::new(&idx.names.postings);
+    let buffer_def = TableDefinition::<PostingKey, &[u8]>::new(&idx.names.buffer);
+
+    let ptbl = idx.txn.open_table(postings_def).map_err(te)?;
+    let btbl = idx.txn.open_table(buffer_def).map_err(te)?;
+
+    for leaf_id in &leaves {
+        // Scan posting list with ADC
+        let range =
+            ptbl.range(PostingKey::cluster_start(*leaf_id)..=PostingKey::cluster_end(*leaf_id))?;
+        for entry in range {
+            let (key, val) = entry?;
+            let vid = key.value().vector_id;
+            let pq_codes = val.value();
+            let dist = adc.approximate_distance(pq_codes);
+            heap.push(vid, dist);
+        }
+
+        // Scan buffer with exact distance
+        let brange =
+            btbl.range(PostingKey::cluster_start(*leaf_id)..=PostingKey::cluster_end(*leaf_id))?;
+        for entry in brange {
+            let (key, val) = entry?;
+            let vid = key.value().vector_id;
+            let bytes = val.value();
+            let vec: Vec<f32> = (0..dim)
+                .map(|i| f32::from_le_bytes(bytes[i * 4..i * 4 + 4].try_into().unwrap()))
+                .collect();
+            let dist = idx.config.metric.compute(&q, &vec);
+            heap.push(vid, dist);
+        }
+    }
+
+    drop(ptbl);
+    drop(btbl);
+
+    // Rerank with raw vectors if available
+    if params.rerank && idx.config.store_raw_vectors {
+        let candidates = heap.into_sorted(params.candidates);
+        let vectors_def = TableDefinition::<u64, &[u8]>::new(&idx.names.vectors);
+        let vtbl = idx.txn.open_table(vectors_def).map_err(te)?;
+
+        let mut reranked: Vec<Neighbor<u64>> = Vec::with_capacity(candidates.len());
+        for c in &candidates {
+            if let Some(g) = vtbl.get(c.key)? {
+                let bytes = g.value();
+                let vec: Vec<f32> = (0..dim)
+                    .map(|i| f32::from_le_bytes(bytes[i * 4..i * 4 + 4].try_into().unwrap()))
+                    .collect();
+                let dist = idx.config.metric.compute(&q, &vec);
+                reranked.push(Neighbor {
+                    key: c.key,
+                    distance: dist,
+                });
+            } else {
+                reranked.push(Neighbor {
+                    key: c.key,
+                    distance: c.distance,
+                });
+            }
+        }
+        reranked.sort_by(|a, b| {
+            a.distance
+                .partial_cmp(&b.distance)
+                .unwrap_or(CmpOrdering::Equal)
+        });
+        reranked.truncate(params.k);
+        Ok(reranked)
+    } else {
+        Ok(heap.into_sorted(params.k))
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Search implementation -- read transaction path
+// ---------------------------------------------------------------------------
+
+pub(crate) fn search_read(
+    idx: &ReadOnlyFractalIndex,
+    txn: &ReadTransaction,
+    query: &[f32],
+    params: &FractalSearchParams,
+) -> crate::Result<Vec<Neighbor<u64>>> {
+    let dim = idx.config.dim as usize;
+    if query.len() != dim {
+        return Err(StorageError::Corrupted(alloc::format!(
+            "fractal: search query dim mismatch: expected {dim}, got {}",
+            query.len(),
+        )));
+    }
+
+    let q = if idx.config.metric == DistanceMetric::Cosine {
+        let mut v = query.to_vec();
+        l2_normalize(&mut v);
+        v
+    } else {
+        query.to_vec()
+    };
+
+    let adc = AdcTable::build(&q, &idx.codebooks, idx.config.metric);
+    let nprobe = params.nprobe.max(1);
+    let heap_cap = if params.rerank {
+        params.candidates
+    } else {
+        params.k
+    };
+    let mut heap = CandidateHeap::new(heap_cap);
+
+    let leaves = beam_search_leaves_read(
+        txn,
+        &idx.names,
+        &idx.config,
+        idx.config.root_cluster_id,
+        &q,
+        nprobe,
+        params.min_hlc,
+    )?;
+
+    let postings_def = TableDefinition::<PostingKey, &[u8]>::new(&idx.names.postings);
+    let buffer_def = TableDefinition::<PostingKey, &[u8]>::new(&idx.names.buffer);
+
+    let ptbl = txn.open_table(postings_def).map_err(te)?;
+    let btbl = txn.open_table(buffer_def).map_err(te)?;
+
+    for leaf_id in &leaves {
+        let range =
+            ptbl.range(PostingKey::cluster_start(*leaf_id)..=PostingKey::cluster_end(*leaf_id))?;
+        for entry in range {
+            let (key, val) = entry?;
+            let vid = key.value().vector_id;
+            let pq_codes = val.value();
+            let dist = adc.approximate_distance(pq_codes);
+            heap.push(vid, dist);
+        }
+
+        let brange =
+            btbl.range(PostingKey::cluster_start(*leaf_id)..=PostingKey::cluster_end(*leaf_id))?;
+        for entry in brange {
+            let (key, val) = entry?;
+            let vid = key.value().vector_id;
+            let bytes = val.value();
+            let vec: Vec<f32> = (0..dim)
+                .map(|i| f32::from_le_bytes(bytes[i * 4..i * 4 + 4].try_into().unwrap()))
+                .collect();
+            let dist = idx.config.metric.compute(&q, &vec);
+            heap.push(vid, dist);
+        }
+    }
+
+    drop(ptbl);
+    drop(btbl);
+
+    if params.rerank && idx.config.store_raw_vectors {
+        let candidates = heap.into_sorted(params.candidates);
+        let vectors_def = TableDefinition::<u64, &[u8]>::new(&idx.names.vectors);
+        let vtbl = txn.open_table(vectors_def).map_err(te)?;
+
+        let mut reranked: Vec<Neighbor<u64>> = Vec::with_capacity(candidates.len());
+        for c in &candidates {
+            if let Some(g) = vtbl.get(c.key)? {
+                let bytes = g.value();
+                let vec: Vec<f32> = (0..dim)
+                    .map(|i| f32::from_le_bytes(bytes[i * 4..i * 4 + 4].try_into().unwrap()))
+                    .collect();
+                let dist = idx.config.metric.compute(&q, &vec);
+                reranked.push(Neighbor {
+                    key: c.key,
+                    distance: dist,
+                });
+            } else {
+                reranked.push(Neighbor {
+                    key: c.key,
+                    distance: c.distance,
+                });
+            }
+        }
+        reranked.sort_by(|a, b| {
+            a.distance
+                .partial_cmp(&b.distance)
+                .unwrap_or(CmpOrdering::Equal)
+        });
+        reranked.truncate(params.k);
+        Ok(reranked)
+    } else {
+        Ok(heap.into_sorted(params.k))
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Beam search helpers
+// ---------------------------------------------------------------------------
+
+/// Beam search: walk the cluster tree from root to leaves, selecting the
+/// best `nprobe` children at each internal level.
+fn beam_search_leaves_write(
+    txn: &WriteTransaction,
+    names: &TableNames,
+    config: &super::config::FractalIndexConfig,
+    root: u32,
+    query: &[f32],
+    nprobe: u32,
+    min_hlc: u64,
+) -> crate::Result<Vec<u32>> {
+    let dim = config.dim as usize;
+    let clusters_def = TableDefinition::<u32, &[u8]>::new(&names.clusters);
+    let centroids_def = TableDefinition::<u32, &[u8]>::new(&names.centroids);
+    let hier_def = TableDefinition::<HierarchyKey, ()>::new(&names.hierarchy);
+
+    let mut current_level = alloc::vec![root];
+    let mut leaves: Vec<u32> = Vec::new();
+
+    loop {
+        let mut next_level: Vec<(u32, f32)> = Vec::new();
+
+        for &node_id in &current_level {
+            let meta = {
+                let ctbl = txn.open_table(clusters_def).map_err(te)?;
+                match ctbl.get(node_id)? {
+                    Some(g) => ClusterMeta::from_bytes(g.value()),
+                    None => continue,
+                }
+            };
+
+            if meta.is_leaf() {
+                // Apply temporal filter
+                if min_hlc > 0 && meta.newest_hlc() > 0 && meta.newest_hlc() < min_hlc {
+                    continue;
+                }
+                leaves.push(node_id);
+                continue;
+            }
+
+            // Internal: collect children with distances
+            let htbl = txn.open_table(hier_def).map_err(te)?;
+            let ctbl = txn.open_table(centroids_def).map_err(te)?;
+            let cltbl = txn.open_table(clusters_def).map_err(te)?;
+
+            let range = htbl.range(
+                HierarchyKey::children_start(node_id)..=HierarchyKey::children_end(node_id),
+            )?;
+
+            for entry in range {
+                let (key, _) = entry?;
+                let child_id = key.value().child_id;
+
+                // Temporal filter on child
+                if min_hlc > 0
+                    && let Some(cg) = cltbl.get(child_id)?
+                {
+                    let child_meta = ClusterMeta::from_bytes(cg.value());
+                    if child_meta.newest_hlc() > 0 && child_meta.newest_hlc() < min_hlc {
+                        continue;
+                    }
+                }
+
+                if let Some(cg) = ctbl.get(child_id)? {
+                    let bytes = cg.value();
+                    let centroid: Vec<f32> = (0..dim)
+                        .map(|i| f32::from_le_bytes(bytes[i * 4..i * 4 + 4].try_into().unwrap()))
+                        .collect();
+                    let dist = config.metric.compute(query, &centroid);
+                    next_level.push((child_id, dist));
+                }
+            }
+        }
+
+        if next_level.is_empty() {
+            break;
+        }
+
+        // Sort by distance, keep top nprobe
+        next_level.sort_by(|a, b| a.1.partial_cmp(&b.1).unwrap_or(CmpOrdering::Equal));
+        let nprobe_usize = nprobe as usize;
+        if next_level.len() > nprobe_usize {
+            next_level.truncate(nprobe_usize);
+        }
+
+        current_level = next_level.iter().map(|(id, _)| *id).collect();
+    }
+
+    Ok(leaves)
+}
+
+/// Beam search for read transactions (same logic, different table access).
+fn beam_search_leaves_read(
+    txn: &ReadTransaction,
+    names: &TableNames,
+    config: &super::config::FractalIndexConfig,
+    root: u32,
+    query: &[f32],
+    nprobe: u32,
+    min_hlc: u64,
+) -> crate::Result<Vec<u32>> {
+    let dim = config.dim as usize;
+    let clusters_def = TableDefinition::<u32, &[u8]>::new(&names.clusters);
+    let centroids_def = TableDefinition::<u32, &[u8]>::new(&names.centroids);
+    let hier_def = TableDefinition::<HierarchyKey, ()>::new(&names.hierarchy);
+
+    let mut current_level = alloc::vec![root];
+    let mut leaves: Vec<u32> = Vec::new();
+
+    loop {
+        let mut next_level: Vec<(u32, f32)> = Vec::new();
+
+        for &node_id in &current_level {
+            let meta = {
+                let ctbl = txn.open_table(clusters_def).map_err(te)?;
+                match ctbl.get(node_id)? {
+                    Some(g) => ClusterMeta::from_bytes(g.value()),
+                    None => continue,
+                }
+            };
+
+            if meta.is_leaf() {
+                if min_hlc > 0 && meta.newest_hlc() > 0 && meta.newest_hlc() < min_hlc {
+                    continue;
+                }
+                leaves.push(node_id);
+                continue;
+            }
+
+            let htbl = txn.open_table(hier_def).map_err(te)?;
+            let ctbl = txn.open_table(centroids_def).map_err(te)?;
+            let cltbl = txn.open_table(clusters_def).map_err(te)?;
+
+            let range = htbl.range(
+                HierarchyKey::children_start(node_id)..=HierarchyKey::children_end(node_id),
+            )?;
+
+            for entry in range {
+                let (key, _) = entry?;
+                let child_id = key.value().child_id;
+
+                if min_hlc > 0
+                    && let Some(cg) = cltbl.get(child_id)?
+                {
+                    let child_meta = ClusterMeta::from_bytes(cg.value());
+                    if child_meta.newest_hlc() > 0 && child_meta.newest_hlc() < min_hlc {
+                        continue;
+                    }
+                }
+
+                if let Some(cg) = ctbl.get(child_id)? {
+                    let bytes = cg.value();
+                    let centroid: Vec<f32> = (0..dim)
+                        .map(|i| f32::from_le_bytes(bytes[i * 4..i * 4 + 4].try_into().unwrap()))
+                        .collect();
+                    let dist = config.metric.compute(query, &centroid);
+                    next_level.push((child_id, dist));
+                }
+            }
+        }
+
+        if next_level.is_empty() {
+            break;
+        }
+
+        next_level.sort_by(|a, b| a.1.partial_cmp(&b.1).unwrap_or(CmpOrdering::Equal));
+        let nprobe_usize = nprobe as usize;
+        if next_level.len() > nprobe_usize {
+            next_level.truncate(nprobe_usize);
+        }
+
+        current_level = next_level.iter().map(|(id, _)| *id).collect();
+    }
+
+    Ok(leaves)
+}

--- a/src/fractal/types.rs
+++ b/src/fractal/types.rs
@@ -1,0 +1,398 @@
+use crate::types::{Key, TypeName, Value};
+use core::cmp::Ordering;
+use core::fmt;
+
+use super::config::{FLAG_IS_ROOT, NO_PARENT};
+
+// ---------------------------------------------------------------------------
+// ClusterMeta -- per-cluster metadata (128 bytes fixed)
+// ---------------------------------------------------------------------------
+
+/// Metadata for a single cluster node in the fractal tree.
+///
+/// Layout (128 bytes, all little-endian):
+/// ```text
+/// [cluster_id:4][parent_id:4][level:1][flags:1][num_children:2]
+/// [population:4][buffer_count:4][_pad:4]
+/// [sum_variance:8(f64)][oldest_hlc:8][newest_hlc:8]
+/// [oldest_wall_ns:8][newest_wall_ns:8][_reserved:64]
+/// ```
+pub const CLUSTER_META_SIZE: usize = 128;
+
+#[derive(Clone)]
+pub struct ClusterMeta {
+    data: [u8; CLUSTER_META_SIZE],
+}
+
+#[allow(dead_code)]
+impl ClusterMeta {
+    pub fn new(cluster_id: u32, parent_id: u32, level: u8, is_root: bool) -> Self {
+        let mut data = [0u8; CLUSTER_META_SIZE];
+        data[0..4].copy_from_slice(&cluster_id.to_le_bytes());
+        data[4..8].copy_from_slice(&parent_id.to_le_bytes());
+        data[8] = level;
+        data[9] = if is_root { FLAG_IS_ROOT } else { 0 };
+        Self { data }
+    }
+
+    pub fn cluster_id(&self) -> u32 {
+        u32::from_le_bytes(self.data[0..4].try_into().unwrap())
+    }
+
+    pub fn parent_id(&self) -> u32 {
+        u32::from_le_bytes(self.data[4..8].try_into().unwrap())
+    }
+
+    pub fn level(&self) -> u8 {
+        self.data[8]
+    }
+
+    pub fn set_level(&mut self, level: u8) {
+        self.data[8] = level;
+    }
+
+    pub fn flags(&self) -> u8 {
+        self.data[9]
+    }
+
+    pub fn is_root(&self) -> bool {
+        self.data[9] & FLAG_IS_ROOT != 0
+    }
+
+    pub fn is_leaf(&self) -> bool {
+        self.level() == 0
+    }
+
+    pub fn num_children(&self) -> u16 {
+        u16::from_le_bytes(self.data[10..12].try_into().unwrap())
+    }
+
+    pub fn set_num_children(&mut self, n: u16) {
+        self.data[10..12].copy_from_slice(&n.to_le_bytes());
+    }
+
+    pub fn population(&self) -> u32 {
+        u32::from_le_bytes(self.data[12..16].try_into().unwrap())
+    }
+
+    pub fn set_population(&mut self, n: u32) {
+        self.data[12..16].copy_from_slice(&n.to_le_bytes());
+    }
+
+    pub fn buffer_count(&self) -> u32 {
+        u32::from_le_bytes(self.data[16..20].try_into().unwrap())
+    }
+
+    pub fn set_buffer_count(&mut self, n: u32) {
+        self.data[16..20].copy_from_slice(&n.to_le_bytes());
+    }
+
+    pub fn sum_variance(&self) -> f64 {
+        f64::from_le_bytes(self.data[24..32].try_into().unwrap())
+    }
+
+    pub fn set_sum_variance(&mut self, v: f64) {
+        self.data[24..32].copy_from_slice(&v.to_le_bytes());
+    }
+
+    pub fn oldest_hlc(&self) -> u64 {
+        u64::from_le_bytes(self.data[32..40].try_into().unwrap())
+    }
+
+    pub fn set_oldest_hlc(&mut self, v: u64) {
+        self.data[32..40].copy_from_slice(&v.to_le_bytes());
+    }
+
+    pub fn newest_hlc(&self) -> u64 {
+        u64::from_le_bytes(self.data[40..48].try_into().unwrap())
+    }
+
+    pub fn set_newest_hlc(&mut self, v: u64) {
+        self.data[40..48].copy_from_slice(&v.to_le_bytes());
+    }
+
+    pub fn oldest_wall_ns(&self) -> u64 {
+        u64::from_le_bytes(self.data[48..56].try_into().unwrap())
+    }
+
+    pub fn set_oldest_wall_ns(&mut self, v: u64) {
+        self.data[48..56].copy_from_slice(&v.to_le_bytes());
+    }
+
+    pub fn newest_wall_ns(&self) -> u64 {
+        u64::from_le_bytes(self.data[56..64].try_into().unwrap())
+    }
+
+    pub fn set_newest_wall_ns(&mut self, v: u64) {
+        self.data[56..64].copy_from_slice(&v.to_le_bytes());
+    }
+
+    pub fn set_parent_id(&mut self, parent_id: u32) {
+        self.data[4..8].copy_from_slice(&parent_id.to_le_bytes());
+    }
+
+    pub fn set_flags(&mut self, flags: u8) {
+        self.data[9] = flags;
+    }
+
+    /// Check if this cluster has no parent (is the root).
+    pub fn has_no_parent(&self) -> bool {
+        self.parent_id() == NO_PARENT
+    }
+
+    /// Returns the raw byte representation.
+    pub fn as_bytes(&self) -> &[u8; CLUSTER_META_SIZE] {
+        &self.data
+    }
+
+    /// Construct from raw bytes.
+    pub fn from_bytes(data: &[u8]) -> Self {
+        let mut buf = [0u8; CLUSTER_META_SIZE];
+        buf.copy_from_slice(&data[..CLUSTER_META_SIZE]);
+        Self { data: buf }
+    }
+}
+
+impl fmt::Debug for ClusterMeta {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("ClusterMeta")
+            .field("id", &self.cluster_id())
+            .field("parent", &self.parent_id())
+            .field("level", &self.level())
+            .field("children", &self.num_children())
+            .field("pop", &self.population())
+            .field("buf", &self.buffer_count())
+            .finish()
+    }
+}
+
+// ---------------------------------------------------------------------------
+// HierarchyKey -- composite key for parent-child cluster relationships
+// ---------------------------------------------------------------------------
+
+/// Composite key `(parent_id, child_id)` for the cluster hierarchy table.
+///
+/// Serialized as **big-endian** so that range scans over a parent's children
+/// are contiguous in the B-tree.
+///
+/// Fixed width: 8 bytes.
+#[derive(Clone, Copy, PartialEq, Eq, Hash)]
+pub struct HierarchyKey {
+    pub parent_id: u32,
+    pub child_id: u32,
+}
+
+impl HierarchyKey {
+    pub const SERIALIZED_SIZE: usize = 8;
+
+    pub const fn new(parent_id: u32, child_id: u32) -> Self {
+        Self {
+            parent_id,
+            child_id,
+        }
+    }
+
+    /// First possible key for the given parent (inclusive lower bound).
+    pub const fn children_start(parent_id: u32) -> Self {
+        Self {
+            parent_id,
+            child_id: 0,
+        }
+    }
+
+    /// Last possible key for the given parent (inclusive upper bound).
+    pub const fn children_end(parent_id: u32) -> Self {
+        Self {
+            parent_id,
+            child_id: u32::MAX,
+        }
+    }
+
+    #[allow(clippy::big_endian_bytes)]
+    pub fn to_be_bytes(self) -> [u8; Self::SERIALIZED_SIZE] {
+        let mut buf = [0u8; Self::SERIALIZED_SIZE];
+        buf[..4].copy_from_slice(&self.parent_id.to_be_bytes());
+        buf[4..8].copy_from_slice(&self.child_id.to_be_bytes());
+        buf
+    }
+
+    #[allow(clippy::big_endian_bytes)]
+    pub fn from_be_bytes(data: &[u8]) -> Self {
+        let parent_id = u32::from_be_bytes(data[..4].try_into().unwrap());
+        let child_id = u32::from_be_bytes(data[4..8].try_into().unwrap());
+        Self {
+            parent_id,
+            child_id,
+        }
+    }
+}
+
+impl PartialOrd for HierarchyKey {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl Ord for HierarchyKey {
+    fn cmp(&self, other: &Self) -> Ordering {
+        self.parent_id
+            .cmp(&other.parent_id)
+            .then(self.child_id.cmp(&other.child_id))
+    }
+}
+
+impl fmt::Debug for HierarchyKey {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "HierarchyKey(parent={}, child={})",
+            self.parent_id, self.child_id
+        )
+    }
+}
+
+impl Value for HierarchyKey {
+    type SelfType<'a>
+        = HierarchyKey
+    where
+        Self: 'a;
+    type AsBytes<'a>
+        = [u8; HierarchyKey::SERIALIZED_SIZE]
+    where
+        Self: 'a;
+
+    fn fixed_width() -> Option<usize> {
+        Some(Self::SERIALIZED_SIZE)
+    }
+
+    fn from_bytes<'a>(data: &'a [u8]) -> Self::SelfType<'a>
+    where
+        Self: 'a,
+    {
+        Self::from_be_bytes(data)
+    }
+
+    fn as_bytes<'a, 'b: 'a>(value: &'a Self::SelfType<'b>) -> Self::AsBytes<'a>
+    where
+        Self: 'b,
+    {
+        value.to_be_bytes()
+    }
+
+    fn type_name() -> TypeName {
+        TypeName::internal("shodh_redb::fractal::HierarchyKey")
+    }
+}
+
+impl Key for HierarchyKey {
+    fn compare(data1: &[u8], data2: &[u8]) -> Ordering {
+        // Big-endian serialization means raw byte comparison is correct.
+        data1[..Self::SERIALIZED_SIZE].cmp(&data2[..Self::SERIALIZED_SIZE])
+    }
+}
+
+// ---------------------------------------------------------------------------
+// ClusterMetaValue -- Value impl for ClusterMeta
+// ---------------------------------------------------------------------------
+
+/// Marker type for `ClusterMeta` as a B-tree value.
+#[derive(Debug)]
+pub struct ClusterMetaValue;
+
+impl Value for ClusterMetaValue {
+    type SelfType<'a>
+        = ClusterMeta
+    where
+        Self: 'a;
+    type AsBytes<'a>
+        = [u8; CLUSTER_META_SIZE]
+    where
+        Self: 'a;
+
+    fn fixed_width() -> Option<usize> {
+        Some(CLUSTER_META_SIZE)
+    }
+
+    fn from_bytes<'a>(data: &'a [u8]) -> Self::SelfType<'a>
+    where
+        Self: 'a,
+    {
+        ClusterMeta::from_bytes(data)
+    }
+
+    fn as_bytes<'a, 'b: 'a>(value: &'a Self::SelfType<'b>) -> Self::AsBytes<'a>
+    where
+        Self: 'b,
+    {
+        *value.as_bytes()
+    }
+
+    fn type_name() -> TypeName {
+        TypeName::internal("shodh_redb::fractal::ClusterMeta")
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn cluster_meta_roundtrip() {
+        let mut meta = ClusterMeta::new(42, NO_PARENT, 0, true);
+        meta.set_population(500);
+        meta.set_buffer_count(64);
+        meta.set_sum_variance(1.5);
+        meta.set_oldest_hlc(100);
+        meta.set_newest_hlc(200);
+        meta.set_oldest_wall_ns(1000);
+        meta.set_newest_wall_ns(2000);
+        meta.set_num_children(3);
+
+        let bytes = meta.as_bytes();
+        let restored = ClusterMeta::from_bytes(bytes);
+
+        assert_eq!(restored.cluster_id(), 42);
+        assert_eq!(restored.parent_id(), NO_PARENT);
+        assert_eq!(restored.level(), 0);
+        assert!(restored.is_root());
+        assert!(restored.is_leaf());
+        assert_eq!(restored.num_children(), 3);
+        assert_eq!(restored.population(), 500);
+        assert_eq!(restored.buffer_count(), 64);
+        assert!((restored.sum_variance() - 1.5).abs() < f64::EPSILON);
+        assert_eq!(restored.oldest_hlc(), 100);
+        assert_eq!(restored.newest_hlc(), 200);
+        assert_eq!(restored.oldest_wall_ns(), 1000);
+        assert_eq!(restored.newest_wall_ns(), 2000);
+    }
+
+    #[test]
+    fn hierarchy_key_ordering() {
+        let a = HierarchyKey::new(1, 10);
+        let b = HierarchyKey::new(1, 20);
+        let c = HierarchyKey::new(2, 5);
+
+        assert!(a < b);
+        assert!(b < c);
+
+        // Byte comparison must match logical comparison
+        let ab = a.to_be_bytes();
+        let bb = b.to_be_bytes();
+        let cb = c.to_be_bytes();
+        assert!(ab < bb);
+        assert!(bb < cb);
+    }
+
+    #[test]
+    fn hierarchy_key_roundtrip() {
+        let key = HierarchyKey::new(0xDEAD_BEEF, 0xCAFE_BABE);
+        let bytes = key.to_be_bytes();
+        let restored = HierarchyKey::from_be_bytes(&bytes);
+        assert_eq!(restored.parent_id, key.parent_id);
+        assert_eq!(restored.child_id, key.child_id);
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -114,6 +114,10 @@ pub use blob_store::{
 };
 pub use cdc::{CdcConfig, ChangeOp, ChangeStream};
 pub use composite::{CompositeQuery, ScoredBlob, SignalScores, SignalWeights};
+pub use fractal::{
+    FractalIndex, FractalIndexConfig, FractalIndexDefinition, FractalSearchParams,
+    ReadOnlyFractalIndex,
+};
 pub use ivfpq::{
     Codebooks, IndexConfig, IvfPqIndex, IvfPqIndexDefinition, ReadOnlyIvfPqIndex, SearchParams,
 };
@@ -142,6 +146,7 @@ mod complex_types;
 pub mod composite;
 mod db;
 pub mod error;
+pub mod fractal;
 #[cfg(feature = "std")]
 pub mod group_commit;
 pub mod ivfpq;

--- a/src/transactions.rs
+++ b/src/transactions.rs
@@ -1474,6 +1474,14 @@ impl WriteTransaction {
         crate::ivfpq::index::IvfPqIndex::open(self, definition)
     }
 
+    /// Open or create a fractal vector index for writing.
+    pub fn open_fractal_index(
+        &self,
+        definition: &crate::fractal::config::FractalIndexDefinition,
+    ) -> Result<crate::fractal::index::FractalIndex<'_>, TableError> {
+        crate::fractal::index::FractalIndex::open(self, definition)
+    }
+
     /// Open the given table
     ///
     /// The table will be created if it does not exist
@@ -3248,6 +3256,14 @@ impl ReadTransaction {
         definition: &crate::ivfpq::config::IvfPqIndexDefinition,
     ) -> Result<crate::ivfpq::index::ReadOnlyIvfPqIndex, TableError> {
         crate::ivfpq::index::ReadOnlyIvfPqIndex::open(self, definition)
+    }
+
+    /// Open a fractal vector index for reading.
+    pub fn open_fractal_index(
+        &self,
+        definition: &crate::fractal::config::FractalIndexDefinition,
+    ) -> Result<crate::fractal::index::ReadOnlyFractalIndex, TableError> {
+        crate::fractal::index::ReadOnlyFractalIndex::open(self, definition)
     }
 
     /// Open the given table without a type

--- a/tests/fractal_tests.rs
+++ b/tests/fractal_tests.rs
@@ -1,0 +1,483 @@
+use shodh_redb::{
+    Database, DistanceMetric, FractalIndexDefinition, FractalSearchParams, ReadableDatabase,
+};
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+fn create_tempfile() -> tempfile::NamedTempFile {
+    if cfg!(target_os = "wasi") {
+        tempfile::NamedTempFile::new_in("/tmp").unwrap()
+    } else {
+        tempfile::NamedTempFile::new().unwrap()
+    }
+}
+
+/// Deterministic pseudo-random f32 vector from a seed.
+fn random_vector(seed: u64, dim: usize) -> Vec<f32> {
+    let mut state = seed.wrapping_mul(0x9e37_79b9_7f4a_7c15) | 1;
+    (0..dim)
+        .map(|_| {
+            state ^= state << 13;
+            state ^= state >> 7;
+            state ^= state << 17;
+            ((state as f64) / (u64::MAX as f64) * 2.0 - 1.0) as f32
+        })
+        .collect()
+}
+
+/// Brute-force k-nearest neighbors.
+fn brute_force_knn(
+    query: &[f32],
+    vectors: &[(u64, Vec<f32>)],
+    k: usize,
+    metric: DistanceMetric,
+) -> Vec<u64> {
+    let mut dists: Vec<(u64, f32)> = vectors
+        .iter()
+        .map(|(id, v)| (*id, metric.compute(query, v)))
+        .collect();
+    dists.sort_by(|a, b| a.1.partial_cmp(&b.1).unwrap());
+    dists.into_iter().take(k).map(|(id, _)| id).collect()
+}
+
+// ---------------------------------------------------------------------------
+// Index definitions
+// ---------------------------------------------------------------------------
+
+const FRACTAL_8D: FractalIndexDefinition = FractalIndexDefinition::new(
+    "test_fractal_8d",
+    8, // dim
+    2, // subvectors (sub_dim = 4)
+    DistanceMetric::EuclideanSq,
+)
+.with_raw_vectors()
+.with_max_leaf_population(20)
+.with_min_leaf_population(2)
+.with_max_buffer_size(4);
+
+const FRACTAL_32D: FractalIndexDefinition = FractalIndexDefinition::new(
+    "test_fractal_32d",
+    32, // dim
+    4,  // subvectors (sub_dim = 8)
+    DistanceMetric::EuclideanSq,
+)
+.with_raw_vectors()
+.with_max_leaf_population(50)
+.with_min_leaf_population(5)
+.with_max_buffer_size(8);
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[test]
+fn train_insert_search_basic() {
+    let tmpfile = create_tempfile();
+    let db = Database::create(tmpfile.path()).unwrap();
+
+    let training: Vec<(u64, Vec<f32>)> = (0..30).map(|i| (i, random_vector(i + 100, 8))).collect();
+
+    let write_txn = db.begin_write().unwrap();
+    {
+        let mut idx = write_txn.open_fractal_index(&FRACTAL_8D).unwrap();
+        idx.train_codebooks(training.iter().map(|(id, v)| (*id, v.clone())), 15)
+            .unwrap();
+    }
+    write_txn.commit().unwrap();
+
+    // Search from a read transaction
+    let read_txn = db.begin_read().unwrap();
+    let idx = read_txn.open_fractal_index(&FRACTAL_8D).unwrap();
+
+    let results = idx
+        .search(&read_txn, &training[0].1, &FractalSearchParams::top_k(5))
+        .unwrap();
+
+    assert!(!results.is_empty(), "search should return results");
+    // The query vector itself should be the top result (distance ~0)
+    assert_eq!(
+        results[0].key, 0,
+        "closest result should be the query vector itself"
+    );
+    assert!(
+        results[0].distance < 0.01,
+        "self-distance should be near zero, got {}",
+        results[0].distance
+    );
+}
+
+#[test]
+fn split_on_overflow() {
+    let tmpfile = create_tempfile();
+    let db = Database::create(tmpfile.path()).unwrap();
+
+    // Use small max_leaf_population to force splits
+    let def = FractalIndexDefinition::new("split_test", 8, 2, DistanceMetric::EuclideanSq)
+        .with_raw_vectors()
+        .with_max_leaf_population(10)
+        .with_min_leaf_population(2)
+        .with_max_buffer_size(4);
+
+    let training: Vec<(u64, Vec<f32>)> = (0..40).map(|i| (i, random_vector(i + 200, 8))).collect();
+
+    let write_txn = db.begin_write().unwrap();
+    {
+        let mut idx = write_txn.open_fractal_index(&def).unwrap();
+        idx.train_codebooks(training.iter().map(|(id, v)| (*id, v.clone())), 10)
+            .unwrap();
+
+        let config = idx.config();
+        assert!(
+            config.num_clusters > 1,
+            "with 40 vectors and max_leaf=10, tree should have split. clusters={}",
+            config.num_clusters
+        );
+    }
+    write_txn.commit().unwrap();
+}
+
+#[test]
+fn buffer_cascade() {
+    let tmpfile = create_tempfile();
+    let db = Database::create(tmpfile.path()).unwrap();
+
+    // max_buffer_size=4, so every 4 inserts should cascade
+    let def = FractalIndexDefinition::new("buffer_test", 8, 2, DistanceMetric::EuclideanSq)
+        .with_raw_vectors()
+        .with_max_leaf_population(1000) // high to avoid splits
+        .with_min_leaf_population(2)
+        .with_max_buffer_size(4);
+
+    // Train with initial data
+    let training: Vec<(u64, Vec<f32>)> = (0..10).map(|i| (i, random_vector(i + 300, 8))).collect();
+
+    let write_txn = db.begin_write().unwrap();
+    {
+        let mut idx = write_txn.open_fractal_index(&def).unwrap();
+        idx.train_codebooks(training.iter().map(|(id, v)| (*id, v.clone())), 10)
+            .unwrap();
+
+        // Insert more vectors beyond buffer threshold
+        for i in 10..20 {
+            idx.insert(i, &random_vector(i + 300, 8)).unwrap();
+        }
+
+        assert_eq!(idx.config().num_vectors, 20);
+    }
+    write_txn.commit().unwrap();
+
+    // Verify search still works after cascade
+    let read_txn = db.begin_read().unwrap();
+    let idx = read_txn.open_fractal_index(&def).unwrap();
+    let results = idx
+        .search(&read_txn, &training[0].1, &FractalSearchParams::top_k(5))
+        .unwrap();
+    assert!(!results.is_empty());
+}
+
+#[test]
+fn persistence_reopen() {
+    let tmpfile = create_tempfile();
+    let path = tmpfile.path().to_path_buf();
+
+    // Create and populate
+    {
+        let db = Database::create(&path).unwrap();
+        let training: Vec<(u64, Vec<f32>)> =
+            (0..20).map(|i| (i, random_vector(i + 400, 8))).collect();
+
+        let write_txn = db.begin_write().unwrap();
+        {
+            let mut idx = write_txn.open_fractal_index(&FRACTAL_8D).unwrap();
+            idx.train_codebooks(training.iter().map(|(id, v)| (*id, v.clone())), 10)
+                .unwrap();
+        }
+        write_txn.commit().unwrap();
+    }
+
+    // Reopen and search
+    {
+        let db = Database::open(&path).unwrap();
+        let read_txn = db.begin_read().unwrap();
+        let idx = read_txn.open_fractal_index(&FRACTAL_8D).unwrap();
+
+        let query = random_vector(400, 8); // same seed as vector 0
+        let results = idx
+            .search(&read_txn, &query, &FractalSearchParams::top_k(5))
+            .unwrap();
+        assert!(
+            !results.is_empty(),
+            "search should return results after reopen"
+        );
+    }
+}
+
+#[test]
+fn upsert_semantics() {
+    let tmpfile = create_tempfile();
+    let db = Database::create(tmpfile.path()).unwrap();
+
+    let training: Vec<(u64, Vec<f32>)> = (0..20).map(|i| (i, random_vector(i + 500, 8))).collect();
+
+    let write_txn = db.begin_write().unwrap();
+    {
+        let mut idx = write_txn.open_fractal_index(&FRACTAL_8D).unwrap();
+        idx.train_codebooks(training.iter().map(|(id, v)| (*id, v.clone())), 10)
+            .unwrap();
+
+        // Insert vector_id=0 with a different vector (upsert)
+        let new_vec = random_vector(9999, 8);
+        idx.insert(0, &new_vec).unwrap();
+
+        // Count should not increase (upsert replaces)
+        assert_eq!(idx.config().num_vectors, 20);
+    }
+    write_txn.commit().unwrap();
+}
+
+#[test]
+fn remove_vector() {
+    let tmpfile = create_tempfile();
+    let db = Database::create(tmpfile.path()).unwrap();
+
+    let training: Vec<(u64, Vec<f32>)> = (0..20).map(|i| (i, random_vector(i + 600, 8))).collect();
+
+    let write_txn = db.begin_write().unwrap();
+    {
+        let mut idx = write_txn.open_fractal_index(&FRACTAL_8D).unwrap();
+        idx.train_codebooks(training.iter().map(|(id, v)| (*id, v.clone())), 10)
+            .unwrap();
+
+        // Remove vector 5
+        let removed = idx.remove(5).unwrap();
+        assert!(removed, "vector 5 should have been found and removed");
+        assert_eq!(idx.config().num_vectors, 19);
+
+        // Removing again should return false
+        let removed_again = idx.remove(5).unwrap();
+        assert!(!removed_again, "vector 5 already removed");
+
+        // Search: vector 5 should not appear in results
+        let results = idx
+            .search(&training[5].1, &FractalSearchParams::top_k(20))
+            .unwrap();
+        for r in &results {
+            assert_ne!(
+                r.key, 5,
+                "removed vector should not appear in search results"
+            );
+        }
+    }
+    write_txn.commit().unwrap();
+}
+
+#[test]
+fn multi_metric_euclidean() {
+    let tmpfile = create_tempfile();
+    let db = Database::create(tmpfile.path()).unwrap();
+
+    let def = FractalIndexDefinition::new("metric_eucl", 8, 2, DistanceMetric::EuclideanSq)
+        .with_raw_vectors()
+        .with_max_leaf_population(100)
+        .with_max_buffer_size(8);
+
+    let training: Vec<(u64, Vec<f32>)> = (0..30).map(|i| (i, random_vector(i + 700, 8))).collect();
+
+    let write_txn = db.begin_write().unwrap();
+    {
+        let mut idx = write_txn.open_fractal_index(&def).unwrap();
+        idx.train_codebooks(training.iter().map(|(id, v)| (*id, v.clone())), 10)
+            .unwrap();
+    }
+    write_txn.commit().unwrap();
+
+    let read_txn = db.begin_read().unwrap();
+    let idx = read_txn.open_fractal_index(&def).unwrap();
+    let results = idx
+        .search(&read_txn, &training[0].1, &FractalSearchParams::top_k(3))
+        .unwrap();
+    assert!(!results.is_empty());
+    assert_eq!(results[0].key, 0);
+}
+
+#[test]
+fn multi_metric_cosine() {
+    let tmpfile = create_tempfile();
+    let db = Database::create(tmpfile.path()).unwrap();
+
+    let def = FractalIndexDefinition::new("metric_cos", 8, 2, DistanceMetric::Cosine)
+        .with_raw_vectors()
+        .with_max_leaf_population(100)
+        .with_max_buffer_size(8);
+
+    let training: Vec<(u64, Vec<f32>)> = (0..30).map(|i| (i, random_vector(i + 800, 8))).collect();
+
+    let write_txn = db.begin_write().unwrap();
+    {
+        let mut idx = write_txn.open_fractal_index(&def).unwrap();
+        idx.train_codebooks(training.iter().map(|(id, v)| (*id, v.clone())), 10)
+            .unwrap();
+    }
+    write_txn.commit().unwrap();
+
+    let read_txn = db.begin_read().unwrap();
+    let idx = read_txn.open_fractal_index(&def).unwrap();
+    let results = idx
+        .search(&read_txn, &training[0].1, &FractalSearchParams::top_k(3))
+        .unwrap();
+    assert!(!results.is_empty());
+    assert_eq!(results[0].key, 0);
+}
+
+#[test]
+fn multi_metric_dotproduct() {
+    let tmpfile = create_tempfile();
+    let db = Database::create(tmpfile.path()).unwrap();
+
+    let def = FractalIndexDefinition::new("metric_dot", 8, 2, DistanceMetric::DotProduct)
+        .with_raw_vectors()
+        .with_max_leaf_population(100)
+        .with_max_buffer_size(8);
+
+    let training: Vec<(u64, Vec<f32>)> = (0..30).map(|i| (i, random_vector(i + 900, 8))).collect();
+
+    let write_txn = db.begin_write().unwrap();
+    {
+        let mut idx = write_txn.open_fractal_index(&def).unwrap();
+        idx.train_codebooks(training.iter().map(|(id, v)| (*id, v.clone())), 10)
+            .unwrap();
+    }
+    write_txn.commit().unwrap();
+
+    let read_txn = db.begin_read().unwrap();
+    let idx = read_txn.open_fractal_index(&def).unwrap();
+    let results = idx
+        .search(&read_txn, &training[0].1, &FractalSearchParams::top_k(3))
+        .unwrap();
+    assert!(!results.is_empty());
+}
+
+#[test]
+fn multi_metric_manhattan() {
+    let tmpfile = create_tempfile();
+    let db = Database::create(tmpfile.path()).unwrap();
+
+    let def = FractalIndexDefinition::new("metric_man", 8, 2, DistanceMetric::Manhattan)
+        .with_raw_vectors()
+        .with_max_leaf_population(100)
+        .with_max_buffer_size(8);
+
+    let training: Vec<(u64, Vec<f32>)> = (0..30).map(|i| (i, random_vector(i + 1000, 8))).collect();
+
+    let write_txn = db.begin_write().unwrap();
+    {
+        let mut idx = write_txn.open_fractal_index(&def).unwrap();
+        idx.train_codebooks(training.iter().map(|(id, v)| (*id, v.clone())), 10)
+            .unwrap();
+    }
+    write_txn.commit().unwrap();
+
+    let read_txn = db.begin_read().unwrap();
+    let idx = read_txn.open_fractal_index(&def).unwrap();
+    let results = idx
+        .search(&read_txn, &training[0].1, &FractalSearchParams::top_k(3))
+        .unwrap();
+    assert!(!results.is_empty());
+}
+
+#[test]
+fn recall_benchmark_32d() {
+    let tmpfile = create_tempfile();
+    let db = Database::create(tmpfile.path()).unwrap();
+
+    let n = 200;
+    let dim = 32;
+    let k = 10;
+    let vectors: Vec<(u64, Vec<f32>)> = (0..n)
+        .map(|i| (i as u64, random_vector(i as u64 + 1100, dim)))
+        .collect();
+
+    let write_txn = db.begin_write().unwrap();
+    {
+        let mut idx = write_txn.open_fractal_index(&FRACTAL_32D).unwrap();
+        idx.train_codebooks(vectors.iter().map(|(id, v)| (*id, v.clone())), 20)
+            .unwrap();
+    }
+    write_txn.commit().unwrap();
+
+    // Benchmark recall@10 across several queries
+    let read_txn = db.begin_read().unwrap();
+    let idx = read_txn.open_fractal_index(&FRACTAL_32D).unwrap();
+
+    let num_queries = 10;
+    let mut total_recall = 0.0f64;
+
+    for qi in 0..num_queries {
+        let query = random_vector(qi as u64 + 2000, dim);
+        let gt = brute_force_knn(&query, &vectors, k, DistanceMetric::EuclideanSq);
+        let results = idx
+            .search(
+                &read_txn,
+                &query,
+                &FractalSearchParams {
+                    nprobe: 16,
+                    candidates: 100,
+                    k,
+                    rerank: true,
+                    min_hlc: 0,
+                },
+            )
+            .unwrap();
+
+        let result_ids: Vec<u64> = results.iter().map(|r| r.key).collect();
+        let hits = gt.iter().filter(|id| result_ids.contains(id)).count();
+        total_recall += hits as f64 / k as f64;
+    }
+
+    let avg_recall = total_recall / num_queries as f64;
+    assert!(
+        avg_recall >= 0.5,
+        "recall@{k} should be >= 0.5, got {avg_recall:.3} (200 vectors, 32d)"
+    );
+}
+
+#[test]
+fn insert_batch() {
+    let tmpfile = create_tempfile();
+    let db = Database::create(tmpfile.path()).unwrap();
+
+    let training: Vec<(u64, Vec<f32>)> = (0..10).map(|i| (i, random_vector(i + 1200, 8))).collect();
+
+    let write_txn = db.begin_write().unwrap();
+    {
+        let mut idx = write_txn.open_fractal_index(&FRACTAL_8D).unwrap();
+        idx.train_codebooks(training.iter().map(|(id, v)| (*id, v.clone())), 10)
+            .unwrap();
+
+        // Batch insert additional vectors
+        let batch: Vec<(u64, Vec<f32>)> = (100..120)
+            .map(|i| (i, random_vector(i + 1200, 8)))
+            .collect();
+        idx.insert_batch(batch.into_iter()).unwrap();
+
+        assert_eq!(idx.config().num_vectors, 30); // 10 training + 20 batch
+    }
+    write_txn.commit().unwrap();
+}
+
+#[test]
+fn empty_search_before_training() {
+    let tmpfile = create_tempfile();
+    let db = Database::create(tmpfile.path()).unwrap();
+
+    let write_txn = db.begin_write().unwrap();
+    {
+        let mut idx = write_txn.open_fractal_index(&FRACTAL_8D).unwrap();
+        // Search without training should error
+        let result = idx.search(&random_vector(0, 8), &FractalSearchParams::top_k(5));
+        assert!(result.is_err(), "search before training should fail");
+    }
+    // Don't commit -- just testing the error
+}


### PR DESCRIPTION
## Summary

- Adds a write-optimized hierarchical vector index inspired by fractal tree indexes (TokuDB/BetrFS) that self-organizes under mutation — clusters split, merge, and maintain centroids incrementally without batch retraining
- Write-buffered cascade amortizes PQ encoding; Welford's online algorithm with f64 accumulators maintains centroid precision; beam search supports temporal-aware cluster pruning via per-cluster HLC/wall-clock ranges
- Integrates with composite query API via `semantic_fractal()` for weighted multi-signal fusion (vector similarity + temporal recency + causal proximity)

## Architecture

| Component | Description |
|-----------|-------------|
| `FractalIndexConfig` (96B) | Fixed-width index metadata: dim, subvectors, metric, thresholds, state |
| `ClusterMeta` (128B) | Per-cluster: population, buffer count, temporal range, variance |
| `HierarchyKey` (8B BE) | Parent→child tree edges for contiguous range scans |
| 10 redb tables/index | meta, clusters, centroids, centroid_sums, hierarchy, buffer, postings, assignments, vectors, codebooks |

**Key algorithms:**
- **Insert**: tree walk → buffer insert → Welford centroid update → cascade on buffer full → 2-means split on overflow
- **Split**: PQ reconstruction fallback when raw vectors not stored; promotes leaf to internal with two children
- **Merge**: nearest-centroid sibling selection; weighted sum merge; parent collapse on single child
- **Search**: beam search top-down with temporal pruning, buffer scan at leaves, optional rerank

## New Files (3,539 lines)

| File | Lines | Purpose |
|------|-------|---------|
| `src/fractal/config.rs` | 331 | Config, definition builder, search params |
| `src/fractal/types.rs` | 402 | ClusterMeta, HierarchyKey with Key/Value impls |
| `src/fractal/index.rs` | 923 | FractalIndex (write) + ReadOnlyFractalIndex (read) |
| `src/fractal/cluster.rs` | 717 | Split, merge, cascade, centroid maintenance |
| `src/fractal/search.rs` | 524 | Beam search, temporal probing, buffer scan |
| `src/fractal/mod.rs` | 53 | Module root + re-exports |
| `tests/fractal_tests.rs` | 506 | 13 integration tests |

## Modified Files

- `src/lib.rs` — `pub mod fractal` + public re-exports
- `src/transactions.rs` — `open_fractal_index()` on WriteTransaction + ReadTransaction
- `src/composite/query.rs` — `semantic_fractal()` + `fractal_search_params()` builder methods

## Test plan

- [x] `cargo check --all-features` — clean
- [x] `cargo clippy --all-targets --all-features` — clean (1 expected dead_code warning)
- [x] `cargo test --all-features` — 567 passed, 0 failed
- [x] 13 fractal integration tests: train/insert/search, split on overflow, buffer cascade, persistence reopen, upsert semantics, remove vector, 4 distance metrics, recall@10 benchmark, insert batch, empty search guard