### PR TITLE
fix: add missing String import for wasm32 no_std

### DIFF
--- a/src/tree_store/btree.rs
+++ b/src/tree_store/btree.rs
@@ -17,6 +17,7 @@ use crate::tree_store::{
 use crate::types::{Key, MutInPlaceValue, Value};
 use crate::{AccessGuard, Result, StorageError};
 use alloc::format;
+use alloc::string::String;
 #[cfg(feature = "std")]
 use alloc::string::ToString;
 use alloc::sync::Arc;


### PR DESCRIPTION
## Summary
Adds `use alloc::string::String;` to `btree.rs` for wasm32-unknown-unknown compilation. The M3 audit changes introduced `String::from()` calls without the import.

## Test plan
- [x] `cargo check` / `cargo clippy` / `cargo fmt` clean locally
- [ ] CI wasm32 compilation