### PR TITLE
fix: harden IVF-PQ and fractal index against corrupted data panics

### DIFF
--- a/src/fractal/cluster.rs
+++ b/src/fractal/cluster.rs
@@ -222,9 +222,13 @@ pub(crate) fn split_cluster(
             if let Some(pq_guard) = ptbl.get(PostingKey::new(cluster_id, vid))? {
                 let pq_codes = pq_guard.value();
                 for (m, &code) in pq_codes.iter().enumerate().take(cb.num_subvectors) {
-                    let base = m * 256 * sub_dim + (code as usize) * sub_dim;
-                    for d in 0..sub_dim {
-                        flat_vectors.push(cb.data[base + d]);
+                    if let Some(base) = (m.checked_mul(256))
+                        .and_then(|v| v.checked_add(code as usize))
+                        .and_then(|v| v.checked_mul(sub_dim))
+                    {
+                        for d in 0..sub_dim {
+                            flat_vectors.push(cb.data.get(base + d).copied().unwrap_or(0.0));
+                        }
                     }
                 }
             }
@@ -251,8 +255,8 @@ pub(crate) fn split_cluster(
     }
 
     // 3. Allocate new cluster IDs
-    let child_a = config.alloc_cluster_id();
-    let child_b = config.alloc_cluster_id();
+    let child_a = config.alloc_cluster_id()?;
+    let child_b = config.alloc_cluster_id()?;
 
     // 4. Compute per-child statistics
     let mut pop_a: u32 = 0;
@@ -264,12 +268,12 @@ pub(crate) fn split_cluster(
         let vec_start = idx * dim;
         let vec_slice = &flat_vectors[vec_start..vec_start + dim];
         if assignment == 0 {
-            pop_a += 1;
+            pop_a = pop_a.saturating_add(1);
             for (s, &v) in sums_a.iter_mut().zip(vec_slice.iter()) {
                 *s += f64::from(v);
             }
         } else {
-            pop_b += 1;
+            pop_b = pop_b.saturating_add(1);
             for (s, &v) in sums_b.iter_mut().zip(vec_slice.iter()) {
                 *s += f64::from(v);
             }
@@ -580,12 +584,16 @@ pub(crate) fn merge_cluster(
         };
         drop(sum_tbl);
 
-        let pop_f64 = f64::from(combined_pop);
-        let centroid_bytes: Vec<u8> = merged_sums
-            .iter()
-            .map(|s| (s / pop_f64) as f32)
-            .flat_map(|f| f.to_le_bytes())
-            .collect();
+        let centroid_bytes: Vec<u8> = if combined_pop > 0 {
+            let pop_f64 = f64::from(combined_pop);
+            merged_sums
+                .iter()
+                .map(|s| (s / pop_f64) as f32)
+                .flat_map(|f| f.to_le_bytes())
+                .collect()
+        } else {
+            alloc::vec![0u8; dim * 4]
+        };
 
         let mut cent_tbl = txn.open_table(centroids_def).map_err(te)?;
         cent_tbl.insert(best_sibling, centroid_bytes.as_slice())?;

--- a/src/fractal/config.rs
+++ b/src/fractal/config.rs
@@ -67,10 +67,15 @@ impl FractalIndexConfig {
     ///
     /// Callers are responsible for updating `num_clusters` to reflect the
     /// net change in live clusters (splits add, merges subtract).
-    pub fn alloc_cluster_id(&mut self) -> u32 {
+    pub fn alloc_cluster_id(&mut self) -> crate::Result<u32> {
+        if self.next_cluster_id == u32::MAX {
+            return Err(crate::StorageError::Corrupted(alloc::string::String::from(
+                "fractal: cluster ID space exhausted (u32::MAX)",
+            )));
+        }
         let id = self.next_cluster_id;
-        self.next_cluster_id = self.next_cluster_id.saturating_add(1);
-        id
+        self.next_cluster_id += 1;
+        Ok(id)
     }
 }
 

--- a/src/fractal/index.rs
+++ b/src/fractal/index.rs
@@ -230,7 +230,7 @@ impl<'txn> FractalIndex<'txn> {
         self.codebooks = Some(codebooks);
 
         // Create root cluster
-        let root_id = self.config.alloc_cluster_id();
+        let root_id = self.config.alloc_cluster_id()?;
         self.config.root_cluster_id = root_id;
         self.config.num_clusters += 1;
 

--- a/src/fractal/types.rs
+++ b/src/fractal/types.rs
@@ -146,9 +146,12 @@ impl ClusterMeta {
     }
 
     /// Construct from raw bytes.
+    ///
+    /// If `data` is shorter than `CLUSTER_META_SIZE`, missing bytes are zero-filled.
     pub fn from_bytes(data: &[u8]) -> Self {
         let mut buf = [0u8; CLUSTER_META_SIZE];
-        buf.copy_from_slice(&data[..CLUSTER_META_SIZE]);
+        let copy_len = data.len().min(CLUSTER_META_SIZE);
+        buf[..copy_len].copy_from_slice(&data[..copy_len]);
         Self { data: buf }
     }
 }

--- a/src/ivfpq/adc.rs
+++ b/src/ivfpq/adc.rs
@@ -57,7 +57,10 @@ impl AdcTable {
         let len = pq_codes.len().min(self.num_subvectors);
         let mut dist = 0.0f32;
         for (m, &code) in pq_codes[..len].iter().enumerate() {
-            dist += self.distances[m * 256 + code as usize];
+            let idx = m * 256 + code as usize;
+            if let Some(&d) = self.distances.get(idx) {
+                dist += d;
+            }
         }
         dist
     }

--- a/src/ivfpq/pq.rs
+++ b/src/ivfpq/pq.rs
@@ -30,10 +30,21 @@ pub struct Codebooks {
 
 impl Codebooks {
     /// Returns the centroid for sub-quantizer `m`, codeword `k`.
+    ///
+    /// Returns an empty slice if indices are out of bounds (corrupted data).
     #[inline]
     pub fn centroid(&self, m: usize, k: usize) -> &[f32] {
-        let start = (m * 256 + k) * self.sub_dim;
-        &self.data[start..start + self.sub_dim]
+        let Some(start) = (m.checked_mul(256))
+            .and_then(|v| v.checked_add(k))
+            .and_then(|v| v.checked_mul(self.sub_dim))
+        else {
+            return &[];
+        };
+        let end = match start.checked_add(self.sub_dim) {
+            Some(e) if e <= self.data.len() => e,
+            _ => return &[],
+        };
+        &self.data[start..end]
     }
 
     /// Encode a full vector into PQ codes.
@@ -95,15 +106,20 @@ impl Codebooks {
     }
 
     /// Deserialize a single codebook from bytes.
+    ///
+    /// If the byte length does not match the expected `256 * sub_dim * 4`,
+    /// returns as many floats as possible (truncated or padded with zeros).
     pub fn deserialize_codebook(bytes: &[u8], sub_dim: usize) -> Vec<f32> {
+        let expected = 256 * sub_dim;
         let num_floats = bytes.len() / 4;
-        debug_assert_eq!(num_floats, 256 * sub_dim);
-        let mut floats = Vec::with_capacity(num_floats);
+        let mut floats = Vec::with_capacity(num_floats.max(expected));
         for chunk in bytes.chunks_exact(4) {
             if let Ok(b) = chunk.try_into() {
                 floats.push(f32::from_le_bytes(b));
             }
         }
+        // Pad to expected size if data was truncated
+        floats.resize(expected, 0.0);
         floats
     }
 }

--- a/src/types.rs
+++ b/src/types.rs
@@ -79,6 +79,12 @@ impl TypeName {
     }
 
     pub(crate) fn from_bytes(bytes: &[u8]) -> Self {
+        if bytes.is_empty() {
+            return Self {
+                classification: TypeClassification::UserDefined,
+                name: alloc::string::String::from("<empty>"),
+            };
+        }
         let classification =
             TypeClassification::from_byte(bytes[0]).unwrap_or(TypeClassification::UserDefined);
         let name = core::str::from_utf8(&bytes[1..])
@@ -578,7 +584,9 @@ impl Value for char {
     where
         Self: 'a,
     {
-        // Use replacement character on corrupted data instead of panicking
+        if data.len() < 3 {
+            return '\u{FFFD}';
+        }
         char::from_u32(u32::from_le_bytes([data[0], data[1], data[2], 0])).unwrap_or('\u{FFFD}')
     }
 


### PR DESCRIPTION
## Summary
- **IVF-PQ codebooks** (`pq.rs`): Checked arithmetic in `centroid()` prevents out-of-bounds on corrupted indices; `deserialize_codebook()` pads to expected size instead of debug_assert
- **ADC distance** (`adc.rs`): Bounds-checked distance table access via `.get()` instead of direct indexing
- **Fractal cluster** (`cluster.rs`): Division-by-zero guard in `merge_cluster()`, checked PQ reconstruction bounds, saturating population increments
- **Cluster ID allocation** (`config.rs`): `alloc_cluster_id()` returns `Result` to handle ID space exhaustion at u32::MAX
- **Type deserialization** (`types.rs`, `fractal/types.rs`): Safe `from_bytes` for `ClusterMeta` (short data zero-fill), `TypeName` (empty guard), and `char` (length validation)

## Issues addressed
Closes #109, closes #110, closes #111, closes #112, closes #114, closes #115, closes #116, closes #117, closes #128, closes #139

## Notes on #118 and #119
- **#118** (BlobRef deserialization): All `from_le_bytes` methods take fixed-size arrays (`[u8; SERIALIZED_SIZE]`), so sub-slice unwraps are type-safe by design
- **#119** (variable-width array): B-tree internal `Value::from_bytes` trait returns `Self::SelfType` (not `Result`), so error propagation isn't possible without a trait-breaking change. The data integrity is guaranteed by the B-tree storage layer.

## Test plan
- [x] `cargo clippy --all-targets` -- zero warnings
- [x] `cargo test` -- all tests pass
- [x] `cargo fmt -- --check` -- clean