### PR TITLE
test: comprehensive SOC compliance test suite (692 tests)

### DIFF
--- a/tests/soc_compliance_tests.rs
+++ b/tests/soc_compliance_tests.rs
@@ -8007,7 +8007,7 @@ fn ephemeral_savepoint_restore() {
         t.insert(&3, &30).unwrap();
     }
     w.commit().unwrap();
-    // Txn 3: restore savepoint — rolls back txn 2's writes
+    // Txn 3: restore savepoint -- rolls back txn 2's writes
     let mut w = db.begin_write().unwrap();
     w.restore_savepoint(&sp).unwrap();
     w.commit().unwrap();
@@ -8154,7 +8154,7 @@ fn savepoint_across_multiple_tables() {
         t2.remove(&1).unwrap();
     }
     w.commit().unwrap();
-    // Txn 3: restore savepoint — undoes all txn 2 changes across both tables
+    // Txn 3: restore savepoint -- undoes all txn 2 changes across both tables
     let mut w = db.begin_write().unwrap();
     w.restore_savepoint(&sp).unwrap();
     w.commit().unwrap();
@@ -9210,7 +9210,7 @@ fn in_memory_savepoint() {
         t.insert(&2, &2).unwrap();
     }
     w.commit().unwrap();
-    // Txn 3: restore savepoint — undoes key=2
+    // Txn 3: restore savepoint -- undoes key=2
     let mut w = db.begin_write().unwrap();
     w.restore_savepoint(&sp).unwrap();
     w.commit().unwrap();
@@ -10266,7 +10266,7 @@ fn compact_and_integrity_check() {
 }
 
 // ===========================================================================
-// S400 BLOB STORE — CORE STORAGE & RETRIEVAL
+// S400 BLOB STORE -- CORE STORAGE & RETRIEVAL
 // ===========================================================================
 
 #[test]
@@ -10474,7 +10474,7 @@ fn blob_store_persist_across_reopen() {
 }
 
 // ===========================================================================
-// S410 BLOB STORE — STREAMING WRITER
+// S410 BLOB STORE -- STREAMING WRITER
 // ===========================================================================
 
 #[test]
@@ -10538,7 +10538,7 @@ fn blob_writer_single_byte_chunks() {
 }
 
 // ===========================================================================
-// S420 BLOB STORE — RANGE READS
+// S420 BLOB STORE -- RANGE READS
 // ===========================================================================
 
 #[test]
@@ -10599,7 +10599,7 @@ fn blob_range_read_out_of_bounds() {
 }
 
 // ===========================================================================
-// S430 BLOB STORE — TAGS & NAMESPACE
+// S430 BLOB STORE -- TAGS & NAMESPACE
 // ===========================================================================
 
 #[test]
@@ -10732,7 +10732,7 @@ fn blob_namespace_query() {
 }
 
 // ===========================================================================
-// S440 BLOB STORE — CAUSAL LINKS
+// S440 BLOB STORE -- CAUSAL LINKS
 // ===========================================================================
 
 #[test]
@@ -10872,7 +10872,7 @@ fn blob_causal_all_relation_types() {
 }
 
 // ===========================================================================
-// S450 BLOB STORE — STATS & DEDUP
+// S450 BLOB STORE -- STATS & DEDUP
 // ===========================================================================
 
 #[test]
@@ -12232,7 +12232,7 @@ fn stress_rapid_open_close_with_data() {
 }
 
 // ===========================================================================
-// S600 BLOB STORE — ADVANCED PATTERNS
+// S600 BLOB STORE -- ADVANCED PATTERNS
 // ===========================================================================
 
 #[test]


### PR DESCRIPTION
## Summary
- Adds `tests/soc_compliance_tests.rs` with **692 tests** covering all major subsystems
- Brings total test count to **1,386 tests**, all passing
- Targets SOC compliance readiness with comprehensive coverage across:

### Coverage Areas
| Area | Tests | What's Verified |
|------|-------|----------------|
| Type system | ~100 | All primitive types, byte slices, strings, roundtrips |
| Blob store | ~30 | Store/retrieve/delete, streaming writer, range reads, tags, namespaces, causal links, dedup, stats |
| CDC | 8 | Insert/update/delete detection, range queries, consumer cursors |
| Integrity | 5 | Header, page checksum, full structural verification |
| Compaction | 4 | File shrink, data preservation, blob compaction, incremental |
| Concurrency | 6 | 10 writer threads, read/write isolation, readers during writes |
| Boundaries | 10 | u64::MAX, i128 extremes, empty strings, bool keys, long keys, 100 tables |
| Error handling | 5 | Type mismatch, wrong table type, nonexistent tables |
| Savepoints | 7 | Ephemeral, persistent, multi-table, cross-transaction restore |
| Persistence | 6 | Survives reopen, uncommitted invisible, rapid open/close |
| Merge operators | ~25 | NumericAdd, NumericMax, NumericMin, BitwiseOr, BytesAppend |
| Vector ops | ~20 | Distance metrics, quantization, nearest_k, normalization |
| HLC | 5 | Monotonic ticks, merge, from_parts, raw roundtrip |
| TTL tables | 8 | Expiry, no-expiry, overwrite, remove, range, iteration |
| Stress | 10 | Alternating insert/delete, many small txns, mixed workloads |
| Regression | 5 | Savepoint dirty check, guard lifetimes, extract_if, multimap len |

## Test plan
- [x] `cargo test --test soc_compliance_tests` — 692 passed, 0 failed
- [x] `cargo test` — 1,386 passed, 0 failed across entire codebase
- [x] `cargo fmt --all` — formatted