### PR TITLE
fix: silicon audit batch 2 — numeric stability, atomics, encoding

### DIFF
--- a/src/bf_tree_store/database.rs
+++ b/src/bf_tree_store/database.rs
@@ -410,12 +410,10 @@ pub(crate) fn table_prefix_end(table_name: &str, kind: TableKind) -> Vec<u8> {
         // This byte overflows; zero it and carry to the next position.
         prefix[i] = 0x00;
     }
-    // Every byte in the prefix was 0xFF.  The only way to produce a value
-    // strictly greater than 0xFF..FF of the same length is to use a longer
-    // byte string.  Restore the prefix and append 0xFF so the result is
-    // lexicographically larger than any key that starts with the original
-    // prefix.
-    prefix.fill(0xFF);
+    // Every byte in the prefix was 0xFF. This is unreachable in practice:
+    // the kind discriminator byte is at most 0x02, so the carry always stops
+    // there. Guard with debug_assert to catch any future encoding changes.
+    debug_assert!(false, "table_prefix_end: all-0xFF prefix is unreachable");
     prefix.push(0xFF);
     prefix
 }
@@ -673,7 +671,7 @@ impl BfTreeDatabaseWriteTxn {
         // time on crash recovery. The snapshot_lock serializes concurrent
         // snapshot attempts so only one thread performs the expensive I/O.
         if self.snapshot_interval > 0 && !self.adapter.inner().config().is_memory_backend() {
-            let count = self.commit_count.fetch_add(1, Ordering::Relaxed) + 1;
+            let count = self.commit_count.fetch_add(1, Ordering::AcqRel) + 1;
             if count % self.snapshot_interval == 0 {
                 let _snap_guard = self.snapshot_lock.lock();
                 self.adapter.snapshot()?;

--- a/src/composite/scoring.rs
+++ b/src/composite/scoring.rs
@@ -29,23 +29,30 @@ pub(crate) fn normalize_semantic(blob_distances: &[(BlobId, f32)]) -> HashMap<Bl
         return HashMap::new();
     }
 
+    // Filter non-finite distances (NaN, Inf) to prevent poison propagation
+    // through the min/max folds. Non-finite entries get score 0.0 below.
     let min_d = blob_distances
         .iter()
         .map(|(_, d)| *d)
+        .filter(|d| d.is_finite())
         .fold(f32::INFINITY, f32::min);
     let max_d = blob_distances
         .iter()
         .map(|(_, d)| *d)
+        .filter(|d| d.is_finite())
         .fold(f32::NEG_INFINITY, f32::max);
     let range = max_d - min_d;
 
-    if range <= f32::EPSILON {
+    if !range.is_finite() || range <= f32::EPSILON {
         return blob_distances.iter().map(|(id, _)| (*id, 1.0)).collect();
     }
 
     blob_distances
         .iter()
         .map(|(id, d)| {
+            if !d.is_finite() {
+                return (*id, 0.0);
+            }
             let score = f64::from(1.0 - (d - min_d) / range);
             (*id, score)
         })

--- a/src/vector_ops.rs
+++ b/src/vector_ops.rs
@@ -27,6 +27,13 @@ fn sqrt_f32(x: f32) -> f32 {
         if x == 0.0 || x.is_infinite() {
             return x;
         }
+        // Subnormals (x < MIN_POSITIVE) have a biased exponent of 0, which
+        // makes the bit-manipulation initial guess wildly inaccurate. Scale
+        // into the normal range, compute sqrt there, then scale back.
+        if x < f32::MIN_POSITIVE {
+            // 2^24 = 16777216.0; sqrt(2^24) = 4096.0
+            return sqrt_f32(x * 16_777_216.0) / 4096.0;
+        }
         // Initial estimate via bit manipulation (fast inverse sqrt trick variant)
         let bits = x.to_bits();
         let guess_bits = (bits >> 1) + 0x1FC0_0000;
@@ -89,6 +96,9 @@ impl DistanceMetric {
     /// [`f32::MAX`] when the computed distance is NaN (e.g. due to NaN
     /// elements in the input vectors) to avoid silent NaN propagation
     /// through search results.
+    ///
+    /// NaN distances are replaced with `f32::MAX` (treated as maximally
+    /// distant) so that `BinaryHeap` ordering is never corrupted.
     #[inline]
     pub fn compute(&self, a: &[f32], b: &[f32]) -> f32 {
         if a.len() != b.len() {


### PR DESCRIPTION
## Summary

Audit playbook phases 1-7, 16, 18 executed. Three parallel investigations covered concurrency/atomicity, key encoding/namespace isolation, and unsafe code/numeric stability.

### Findings triaged as NOT bugs (correctly designed)
- TOCTOU in insert/remove/merge: Correctly guarded by Mutex
- BfTreeDatabaseWriteTxn Send+Sync: By design (Mutex protects internal state)
- CDC event loss on commit failure: Correct (failed txn's events should be discarded)
- Key namespace isolation: TableKind discriminator + `"__"` prefix guard works
- All 12 unsafe blocks: Correct with verified SAFETY comments
- ratio_u64(0,0): Already guarded, k-means empty clusters: Already handled

### Fixes applied
- **P1: normalize_semantic NaN propagation** — filter non-finite distances before min/max; NaN entries score 0.0
- **P2: Snapshot interval Relaxed→AcqRel** — proper cross-thread counter visibility
- **P3: table_prefix_end dead code** — replace buggy all-0xFF branch with debug_assert (unreachable)
- **P3: sqrt_f32 subnormal precision** — scale subnormals into normal range before Newton-Raphson
- **P3: DistanceMetric NaN doc** — document NaN→f32::MAX sentinel behavior

## Test plan
- [x] `cargo check --features bf_tree` — clean
- [x] `cargo clippy --features bf_tree -- -D warnings` — clean
- [x] `cargo test --features bf_tree` — 1,629 tests pass, 0 failures