### PR TITLE
chore: release v0.3.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "shodh-redb"
 description = "Multi-modal embedded database - vectors, blobs, TTL, merge operators, and causal tracking built on ACID B-trees"
 readme = "README.md"
-version = "0.3.0"
+version = "0.3.1"
 exclude = ["fuzz/", "crates/bf-tree/"]
 edition.workspace = true
 rust-version.workspace = true


### PR DESCRIPTION
## Summary
Patch release with correctness and hardening fixes from silicon audit batches 1-2.

### Changes since v0.3.0
- **fix**: NaN propagation in `normalize_semantic` composite scoring (P1 correctness)
- **fix**: Snapshot interval counter upgraded from Relaxed to AcqRel atomic ordering
- **fix**: Subnormal precision in no_std `sqrt_f32` Newton-Raphson
- **fix**: Unreachable overflow branch in `table_prefix_end`
- **fix**: SAFETY comments on all guarded `try_into().unwrap()` calls
- **fix**: `panic!()` → `unreachable!()`, `assert!` → `debug_assert!` in non-test paths
- **fix**: `checked_mul()` overflow guard in probe_select