### PR TITLE
fix: multimap signed key ordering, typed scan, property tests

### DIFF
--- a/src/bf_tree_store/database.rs
+++ b/src/bf_tree_store/database.rs
@@ -1071,11 +1071,15 @@ impl BfTreeDatabaseReadTxn {
         self.adapter.contains_key(&encoded_key)
     }
 
-    /// Scan all entries in the given table.
+    /// Scan all entries in the given table (low-level, untyped).
     ///
-    /// Returns an iterator yielding `(key_bytes, value_bytes)` pairs.
-    /// The caller must use `K::from_bytes()` and `V::from_bytes()` to
-    /// deserialize the returned byte slices.
+    /// Returns an iterator yielding raw `(key_bytes, value_bytes)` pairs.
+    ///
+    /// **Important:** Key bytes are returned in byte-ordered storage form.
+    /// For signed integer key types (i8, i16, i32, i64, i128), callers must
+    /// call `K::from_byte_ordered_in_place(&mut key)` before `K::from_bytes()`
+    /// to recover the original value. For a typed API that handles this
+    /// automatically, use [`scan_table_typed`](Self::scan_table_typed).
     pub fn scan_table<K: Key + 'static, V: Value + 'static>(
         &self,
         definition: &TableDefinition<K, V>,
@@ -1085,6 +1089,25 @@ impl BfTreeDatabaseReadTxn {
         let prefix_len = prefix.len();
         let iter = self.adapter.scan_range(&prefix, &prefix_end)?;
         Ok(BfTreeTableScan { iter, prefix_len })
+    }
+
+    /// Typed scan over all entries in a table.
+    ///
+    /// Unlike [`scan_table`](Self::scan_table), this automatically reverses
+    /// byte-order transformation on keys, so returned key bytes are ready
+    /// for `K::from_bytes()`.
+    pub fn scan_table_typed<K: Key + 'static, V: Value + 'static>(
+        &self,
+        definition: &TableDefinition<K, V>,
+    ) -> Result<BfTreeTypedScan<'_, K, V>, BfTreeError> {
+        let scan = self.scan_table(definition)?;
+        let max_record_size = self.adapter.inner().config().get_cb_max_record_size();
+        Ok(BfTreeTypedScan {
+            scan,
+            buf: alloc::vec![0u8; max_record_size * 2],
+            _key: core::marker::PhantomData,
+            _val: core::marker::PhantomData,
+        })
     }
 
     /// Read CDC changes committed after the given transaction ID.
@@ -1227,6 +1250,30 @@ impl BfTreeTableScan<'_> {
             // Malformed entry (key_len <= prefix_len) -- skip and try the next
             // entry instead of terminating the entire scan.
         }
+    }
+}
+
+/// Typed iterator over table entries, auto-reversing byte-order transformation.
+///
+/// Wraps [`BfTreeTableScan`] and applies `K::from_byte_ordered_in_place` to
+/// keys before returning them, so callers can pass the bytes directly to
+/// `K::from_bytes()`.
+pub struct BfTreeTypedScan<'a, K: Key + 'static, V: Value + 'static> {
+    scan: BfTreeTableScan<'a>,
+    buf: Vec<u8>,
+    _key: core::marker::PhantomData<K>,
+    _val: core::marker::PhantomData<V>,
+}
+
+impl<K: Key + 'static, V: Value + 'static> BfTreeTypedScan<'_, K, V> {
+    /// Get the next `(key_bytes, value_bytes)` entry with key bytes in
+    /// user-space form (byte-order transformation reversed).
+    pub fn next(&mut self) -> Option<(Vec<u8>, Vec<u8>)> {
+        let (key_bytes, val_bytes) = self.scan.next(&mut self.buf)?;
+        let mut key_owned = key_bytes.to_vec();
+        K::from_byte_ordered_in_place(&mut key_owned);
+        let val_owned = val_bytes.to_vec();
+        Some((key_owned, val_owned))
     }
 }
 
@@ -1817,6 +1864,211 @@ mod tests {
         assert_eq!(
             recovered, 4,
             "recovery with CDC should return next available id"
+        );
+    }
+
+    // -----------------------------------------------------------------------
+    // Signed key integration tests
+    // -----------------------------------------------------------------------
+
+    const SIGNED_I32: TableDefinition<i32, u64> = TableDefinition::new("signed_i32");
+    const SIGNED_I64: TableDefinition<i64, u64> = TableDefinition::new("signed_i64");
+
+    #[test]
+    fn signed_i32_range_scan_ordering() {
+        let db = BfTreeDatabase::create(BfTreeConfig::new_memory(4)).unwrap();
+
+        let wtxn = db.begin_write();
+        {
+            let mut table = wtxn.open_table(SIGNED_I32).unwrap();
+            for &v in &[100i32, -1, 0, -100, 10, -10, 1] {
+                table.insert(&v, &((v as i64 + 1000) as u64)).unwrap();
+            }
+        }
+        wtxn.commit().unwrap();
+
+        let rtxn = db.begin_read();
+        let mut scan = rtxn.scan_table_typed(&SIGNED_I32).unwrap();
+        let mut recovered_keys: Vec<i32> = Vec::new();
+        while let Some((key_bytes, _val_bytes)) = scan.next() {
+            recovered_keys.push(i32::from_bytes(&key_bytes));
+        }
+        assert_eq!(
+            recovered_keys,
+            vec![-100, -10, -1, 0, 1, 10, 100],
+            "i32 keys must scan in numeric order"
+        );
+    }
+
+    #[test]
+    fn signed_i64_range_scan_ordering() {
+        let db = BfTreeDatabase::create(BfTreeConfig::new_memory(4)).unwrap();
+
+        let expected: Vec<i64> = vec![i64::MIN, -1_000_000, -1, 0, 1, 1_000_000, i64::MAX];
+
+        let wtxn = db.begin_write();
+        {
+            let mut table = wtxn.open_table(SIGNED_I64).unwrap();
+            for &v in &[0i64, i64::MAX, -1, i64::MIN, 1_000_000, -1_000_000, 1] {
+                table.insert(&v, &(v.wrapping_add(5000) as u64)).unwrap();
+            }
+        }
+        wtxn.commit().unwrap();
+
+        let rtxn = db.begin_read();
+        let mut scan = rtxn.scan_table_typed(&SIGNED_I64).unwrap();
+        let mut recovered_keys: Vec<i64> = Vec::new();
+        while let Some((key_bytes, _)) = scan.next() {
+            recovered_keys.push(i64::from_bytes(&key_bytes));
+        }
+        assert_eq!(
+            recovered_keys, expected,
+            "i64 keys must scan in numeric order"
+        );
+    }
+
+    #[test]
+    fn signed_i32_boundary_values() {
+        let db = BfTreeDatabase::create(BfTreeConfig::new_memory(4)).unwrap();
+
+        let boundaries = [i32::MIN, i32::MIN + 1, -1, 0, 1, i32::MAX - 1, i32::MAX];
+
+        let wtxn = db.begin_write();
+        {
+            let mut table = wtxn.open_table(SIGNED_I32).unwrap();
+            for &v in boundaries.iter().rev() {
+                table.insert(&v, &(v as u64)).unwrap();
+            }
+        }
+        wtxn.commit().unwrap();
+
+        let rtxn = db.begin_read();
+        let mut scan = rtxn.scan_table_typed(&SIGNED_I32).unwrap();
+        let mut recovered: Vec<i32> = Vec::new();
+        while let Some((key_bytes, _)) = scan.next() {
+            recovered.push(i32::from_bytes(&key_bytes));
+        }
+        assert_eq!(recovered, boundaries.to_vec());
+    }
+
+    #[test]
+    fn multimap_signed_i32_ordering() {
+        let db = BfTreeDatabase::create(BfTreeConfig::new_memory(4)).unwrap();
+
+        let wtxn = db.begin_write();
+        {
+            let mut mm = wtxn.open_multimap_table::<i32, u64>("mm_signed").unwrap();
+            for &k in &[-10i32, 5, -1, 0, 10] {
+                mm.insert(&k, &(k.unsigned_abs() as u64)).unwrap();
+                mm.insert(&k, &((k.unsigned_abs() as u64) + 100)).unwrap();
+            }
+        }
+        wtxn.commit().unwrap();
+
+        let rtxn = db.begin_read();
+        let mm = rtxn.open_multimap_table::<i32, u64>("mm_signed").unwrap();
+
+        let vals_neg10 = mm.get_values(&-10i32).unwrap();
+        assert_eq!(vals_neg10.len(), 2, "should find 2 values for key -10");
+
+        let vals_neg1 = mm.get_values(&-1i32).unwrap();
+        assert_eq!(vals_neg1.len(), 2, "should find 2 values for key -1");
+
+        let vals_zero = mm.get_values(&0i32).unwrap();
+        assert_eq!(vals_zero.len(), 2, "should find 2 values for key 0");
+
+        // Verify contains works with signed keys after commit.
+        assert!(mm.contains(&-10i32, &10u64).unwrap());
+        assert!(mm.contains(&5i32, &5u64).unwrap());
+        assert!(!mm.contains(&-10i32, &999u64).unwrap());
+    }
+
+    #[test]
+    fn empty_table_scan() {
+        let db = BfTreeDatabase::create(BfTreeConfig::new_memory(4)).unwrap();
+
+        let wtxn = db.begin_write();
+        {
+            let _table = wtxn.open_table(SIGNED_I32).unwrap();
+        }
+        wtxn.commit().unwrap();
+
+        let rtxn = db.begin_read();
+        let mut scan = rtxn.scan_table_typed(&SIGNED_I32).unwrap();
+        assert!(scan.next().is_none(), "empty table must yield no entries");
+    }
+
+    #[test]
+    fn single_element_signed_table() {
+        let db = BfTreeDatabase::create(BfTreeConfig::new_memory(4)).unwrap();
+
+        let wtxn = db.begin_write();
+        {
+            let mut table = wtxn.open_table(SIGNED_I32).unwrap();
+            table.insert(&-1i32, &42u64).unwrap();
+        }
+        wtxn.commit().unwrap();
+
+        let mut rtxn = db.begin_read();
+        let val = rtxn.get::<i32, u64>(&SIGNED_I32, &-1i32).unwrap();
+        assert!(val.is_some(), "single key must be readable");
+        let val_bytes = val.unwrap();
+        assert_eq!(
+            u64::from_le_bytes(val_bytes.as_slice().try_into().unwrap()),
+            42,
+        );
+
+        let mut scan = rtxn.scan_table_typed(&SIGNED_I32).unwrap();
+        assert!(scan.next().is_some(), "scan must yield the single entry");
+        assert!(scan.next().is_none(), "scan must stop after one entry");
+    }
+
+    #[test]
+    fn signed_key_overwrite() {
+        let db = BfTreeDatabase::create(BfTreeConfig::new_memory(4)).unwrap();
+
+        let wtxn = db.begin_write();
+        {
+            let mut table = wtxn.open_table(SIGNED_I32).unwrap();
+            table.insert(&-5i32, &10u64).unwrap();
+            table.insert(&-5i32, &20u64).unwrap();
+        }
+        wtxn.commit().unwrap();
+
+        let mut rtxn = db.begin_read();
+        let val = rtxn.get::<i32, u64>(&SIGNED_I32, &-5i32).unwrap().unwrap();
+        assert_eq!(
+            u64::from_le_bytes(val.as_slice().try_into().unwrap()),
+            20,
+            "overwritten key must return latest value"
+        );
+    }
+
+    #[test]
+    fn signed_key_delete() {
+        let db = BfTreeDatabase::create(BfTreeConfig::new_memory(4)).unwrap();
+
+        let wtxn = db.begin_write();
+        {
+            let mut table = wtxn.open_table(SIGNED_I32).unwrap();
+            table.insert(&i32::MIN, &1u64).unwrap();
+            table.insert(&0i32, &2u64).unwrap();
+            table.insert(&i32::MAX, &3u64).unwrap();
+            table.remove(&0i32).unwrap();
+        }
+        wtxn.commit().unwrap();
+
+        let mut rtxn = db.begin_read();
+        assert!(rtxn.get::<i32, u64>(&SIGNED_I32, &0i32).unwrap().is_none());
+        assert!(
+            rtxn.get::<i32, u64>(&SIGNED_I32, &i32::MIN)
+                .unwrap()
+                .is_some()
+        );
+        assert!(
+            rtxn.get::<i32, u64>(&SIGNED_I32, &i32::MAX)
+                .unwrap()
+                .is_some()
         );
     }
 }

--- a/src/bf_tree_store/multimap.rs
+++ b/src/bf_tree_store/multimap.rs
@@ -197,8 +197,12 @@ impl<'txn, K: Key + 'static, V: Key + 'static> BfTreeMultimapTable<'txn, K, V> {
         value: &V::SelfType<'_>,
     ) -> Result<bool, BfTreeError> {
         let user_key = K::as_bytes(key);
+        let mut user_key_ordered = user_key.as_ref().to_vec();
+        K::to_byte_ordered_in_place(&mut user_key_ordered);
         let val_key = V::as_bytes(value);
-        let encoded = encode_multimap_key(&self.name, user_key.as_ref(), val_key.as_ref())?;
+        let mut val_key_ordered = val_key.as_ref().to_vec();
+        V::to_byte_ordered_in_place(&mut val_key_ordered);
+        let encoded = encode_multimap_key(&self.name, &user_key_ordered, &val_key_ordered)?;
 
         let mut buffer = self.buffer.lock();
         let already_exists = match buffer.get(&encoded) {
@@ -243,8 +247,12 @@ impl<'txn, K: Key + 'static, V: Key + 'static> BfTreeMultimapTable<'txn, K, V> {
         value: &V::SelfType<'_>,
     ) -> Result<bool, BfTreeError> {
         let user_key = K::as_bytes(key);
+        let mut user_key_ordered = user_key.as_ref().to_vec();
+        K::to_byte_ordered_in_place(&mut user_key_ordered);
         let val_key = V::as_bytes(value);
-        let encoded = encode_multimap_key(&self.name, user_key.as_ref(), val_key.as_ref())?;
+        let mut val_key_ordered = val_key.as_ref().to_vec();
+        V::to_byte_ordered_in_place(&mut val_key_ordered);
+        let encoded = encode_multimap_key(&self.name, &user_key_ordered, &val_key_ordered)?;
 
         let mut buffer = self.buffer.lock();
         let existed = match buffer.get(&encoded) {
@@ -279,8 +287,10 @@ impl<'txn, K: Key + 'static, V: Key + 'static> BfTreeMultimapTable<'txn, K, V> {
     /// Remove all values for a given key. Returns the number of values removed.
     pub fn remove_all(&mut self, key: &K::SelfType<'_>) -> Result<u64, BfTreeError> {
         let user_key = K::as_bytes(key);
-        let prefix = multimap_key_prefix(&self.name, user_key.as_ref())?;
-        let scan_end = multimap_scan_end(&self.name, user_key.as_ref())?;
+        let mut user_key_ordered = user_key.as_ref().to_vec();
+        K::to_byte_ordered_in_place(&mut user_key_ordered);
+        let prefix = multimap_key_prefix(&self.name, &user_key_ordered)?;
+        let scan_end = multimap_scan_end(&self.name, &user_key_ordered)?;
 
         let max_record_size = self.adapter.inner().config().get_cb_max_record_size();
 
@@ -375,8 +385,10 @@ impl<'txn, K: Key + 'static, V: Key + 'static> BfTreeMultimapTable<'txn, K, V> {
     /// Values are returned in sorted byte order.
     pub fn get_values(&self, key: &K::SelfType<'_>) -> Result<Vec<Vec<u8>>, BfTreeError> {
         let user_key = K::as_bytes(key);
-        let prefix = multimap_key_prefix(&self.name, user_key.as_ref())?;
-        let scan_end = multimap_scan_end(&self.name, user_key.as_ref())?;
+        let mut user_key_ordered = user_key.as_ref().to_vec();
+        K::to_byte_ordered_in_place(&mut user_key_ordered);
+        let prefix = multimap_key_prefix(&self.name, &user_key_ordered)?;
+        let scan_end = multimap_scan_end(&self.name, &user_key_ordered)?;
         let prefix_len = prefix.len();
         let max_record_size = self.adapter.inner().config().get_cb_max_record_size();
 
@@ -415,7 +427,9 @@ impl<'txn, K: Key + 'static, V: Key + 'static> BfTreeMultimapTable<'txn, K, V> {
                 BufferLookup::Tombstone => { /* hidden by tombstone, skip */ }
                 BufferLookup::Found(_) | BufferLookup::NotInBuffer => {
                     let val_key = extract_value_key(encoded_key, prefix_len);
-                    values.push(val_key.to_vec());
+                    let mut val_decoded = val_key.to_vec();
+                    V::from_byte_ordered_in_place(&mut val_decoded);
+                    values.push(val_decoded);
                 }
             }
         }
@@ -427,7 +441,9 @@ impl<'txn, K: Key + 'static, V: Key + 'static> BfTreeMultimapTable<'txn, K, V> {
                 for (k, v) in buffer.range_excluded_end(&prefix, end) {
                     if v.is_some() && !bftree_entries.iter().any(|bk| bk == k) {
                         let val_key = extract_value_key(k, prefix_len);
-                        values.push(val_key.to_vec());
+                        let mut val_decoded = val_key.to_vec();
+                        V::from_byte_ordered_in_place(&mut val_decoded);
+                        values.push(val_decoded);
                     }
                 }
             }
@@ -435,7 +451,9 @@ impl<'txn, K: Key + 'static, V: Key + 'static> BfTreeMultimapTable<'txn, K, V> {
                 for (k, v) in buffer.prefix_range(&prefix) {
                     if v.is_some() && !bftree_entries.iter().any(|bk| bk == k) {
                         let val_key = extract_value_key(k, prefix_len);
-                        values.push(val_key.to_vec());
+                        let mut val_decoded = val_key.to_vec();
+                        V::from_byte_ordered_in_place(&mut val_decoded);
+                        values.push(val_decoded);
                     }
                 }
             }
@@ -455,8 +473,12 @@ impl<'txn, K: Key + 'static, V: Key + 'static> BfTreeMultimapTable<'txn, K, V> {
         value: &V::SelfType<'_>,
     ) -> Result<bool, BfTreeError> {
         let user_key = K::as_bytes(key);
+        let mut user_key_ordered = user_key.as_ref().to_vec();
+        K::to_byte_ordered_in_place(&mut user_key_ordered);
         let val_key = V::as_bytes(value);
-        let encoded = encode_multimap_key(&self.name, user_key.as_ref(), val_key.as_ref())?;
+        let mut val_key_ordered = val_key.as_ref().to_vec();
+        V::to_byte_ordered_in_place(&mut val_key_ordered);
+        let encoded = encode_multimap_key(&self.name, &user_key_ordered, &val_key_ordered)?;
 
         let buffer = self.buffer.lock();
         match buffer.get(&encoded) {
@@ -500,8 +522,10 @@ impl<'txn, K: Key + 'static, V: Key + 'static> BfTreeReadOnlyMultimapTable<'txn,
     /// Get all values for a given key, as a `Vec` of raw value bytes.
     pub fn get_values(&self, key: &K::SelfType<'_>) -> Result<Vec<Vec<u8>>, BfTreeError> {
         let user_key = K::as_bytes(key);
-        let prefix = multimap_key_prefix(&self.name, user_key.as_ref())?;
-        let scan_end = multimap_scan_end(&self.name, user_key.as_ref())?;
+        let mut user_key_ordered = user_key.as_ref().to_vec();
+        K::to_byte_ordered_in_place(&mut user_key_ordered);
+        let prefix = multimap_key_prefix(&self.name, &user_key_ordered)?;
+        let scan_end = multimap_scan_end(&self.name, &user_key_ordered)?;
         let prefix_len = prefix.len();
         let max_record_size = self.adapter.inner().config().get_cb_max_record_size();
 
@@ -511,7 +535,9 @@ impl<'txn, K: Key + 'static, V: Key + 'static> BfTreeReadOnlyMultimapTable<'txn,
             let mut iter = self.adapter.scan_range(&prefix, &end)?;
             while let Ok(Some((key_len, _val_len))) = iter.next(&mut buf) {
                 let val_key = extract_value_key(&buf[..key_len], prefix_len);
-                values.push(val_key.to_vec());
+                let mut val_decoded = val_key.to_vec();
+                V::from_byte_ordered_in_place(&mut val_decoded);
+                values.push(val_decoded);
             }
         } else {
             let max_end = {
@@ -524,7 +550,9 @@ impl<'txn, K: Key + 'static, V: Key + 'static> BfTreeReadOnlyMultimapTable<'txn,
                 let k = &buf[..key_len];
                 if key_matches_prefix(k, &prefix) {
                     let val_key = extract_value_key(k, prefix_len);
-                    values.push(val_key.to_vec());
+                    let mut val_decoded = val_key.to_vec();
+                    V::from_byte_ordered_in_place(&mut val_decoded);
+                    values.push(val_decoded);
                 }
             }
         }
@@ -538,8 +566,12 @@ impl<'txn, K: Key + 'static, V: Key + 'static> BfTreeReadOnlyMultimapTable<'txn,
         value: &V::SelfType<'_>,
     ) -> Result<bool, BfTreeError> {
         let user_key = K::as_bytes(key);
+        let mut user_key_ordered = user_key.as_ref().to_vec();
+        K::to_byte_ordered_in_place(&mut user_key_ordered);
         let val_key = V::as_bytes(value);
-        let encoded = encode_multimap_key(&self.name, user_key.as_ref(), val_key.as_ref())?;
+        let mut val_key_ordered = val_key.as_ref().to_vec();
+        V::to_byte_ordered_in_place(&mut val_key_ordered);
+        let encoded = encode_multimap_key(&self.name, &user_key_ordered, &val_key_ordered)?;
         Ok(self.adapter.contains_key(&encoded))
     }
 

--- a/src/bf_tree_store/stress.rs
+++ b/src/bf_tree_store/stress.rs
@@ -508,4 +508,56 @@ mod tests {
             );
         }
     }
+
+    /// Concurrent blob sequence allocation must produce unique sequence numbers.
+    ///
+    /// 8 threads each allocate 50 blobs via separate write transactions on the
+    /// same database. The shared `AtomicU64` counter must ensure no two blobs
+    /// receive the same sequence number.
+    #[test]
+    fn blob_sequence_no_collision() {
+        use crate::blob_store::types::ContentType;
+        use std::collections::HashSet;
+
+        let db = Arc::new(BfTreeDatabase::create(BfTreeConfig::new_memory(8)).unwrap());
+        let num_threads = 8usize;
+        let allocs_per_thread = 50usize;
+        let barrier = Arc::new(Barrier::new(num_threads));
+
+        let handles: Vec<_> = (0..num_threads)
+            .map(|_| {
+                let db = db.clone();
+                let barrier = barrier.clone();
+                thread::spawn(move || {
+                    barrier.wait();
+                    let mut seqs = Vec::with_capacity(allocs_per_thread);
+                    for i in 0..allocs_per_thread {
+                        let wtxn = db.begin_write();
+                        let blob_store = wtxn.open_blob_store();
+                        let content = alloc::format!("blob-{i}");
+                        let blob_id = blob_store
+                            .store(
+                                content.as_bytes(),
+                                ContentType::OctetStream,
+                                "",
+                                Default::default(),
+                            )
+                            .unwrap();
+                        seqs.push(blob_id.sequence);
+                        wtxn.commit().unwrap();
+                    }
+                    seqs
+                })
+            })
+            .collect();
+
+        let mut all_seqs = HashSet::new();
+        for h in handles {
+            for s in h.join().unwrap() {
+                assert!(all_seqs.insert(s), "duplicate blob sequence number {s}");
+            }
+        }
+
+        assert_eq!(all_seqs.len(), num_threads * allocs_per_thread);
+    }
 }

--- a/src/types.rs
+++ b/src/types.rs
@@ -770,3 +770,74 @@ le_signed_impl!(i64);
 le_signed_impl!(i128);
 le_value!(f32);
 le_value!(f64);
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use proptest::prelude::*;
+    use proptest::test_runner::{Config, TestRunner};
+
+    macro_rules! proptest_signed_ordering {
+        ($test_name:ident, $t:ty) => {
+            #[test]
+            fn $test_name() {
+                let config = Config {
+                    cases: 10_000,
+                    ..Config::default()
+                };
+                let mut runner = TestRunner::new(config);
+                runner
+                    .run(&(any::<$t>(), any::<$t>()), |(a, b)| {
+                        let mut a_bytes = <$t as Value>::as_bytes(&a).as_ref().to_vec();
+                        let mut b_bytes = <$t as Value>::as_bytes(&b).as_ref().to_vec();
+                        <$t as Key>::to_byte_ordered_in_place(&mut a_bytes);
+                        <$t as Key>::to_byte_ordered_in_place(&mut b_bytes);
+                        prop_assert_eq!(
+                            a_bytes.cmp(&b_bytes),
+                            a.cmp(&b),
+                            "byte ordering mismatch: a={}, b={}",
+                            a,
+                            b
+                        );
+                        Ok(())
+                    })
+                    .unwrap();
+            }
+        };
+    }
+
+    proptest_signed_ordering!(proptest_i8_byte_ordering, i8);
+    proptest_signed_ordering!(proptest_i16_byte_ordering, i16);
+    proptest_signed_ordering!(proptest_i32_byte_ordering, i32);
+    proptest_signed_ordering!(proptest_i64_byte_ordering, i64);
+    proptest_signed_ordering!(proptest_i128_byte_ordering, i128);
+
+    macro_rules! proptest_signed_roundtrip {
+        ($test_name:ident, $t:ty) => {
+            #[test]
+            fn $test_name() {
+                let config = Config {
+                    cases: 10_000,
+                    ..Config::default()
+                };
+                let mut runner = TestRunner::new(config);
+                runner
+                    .run(&any::<$t>(), |v| {
+                        let mut bytes = <$t as Value>::as_bytes(&v).as_ref().to_vec();
+                        <$t as Key>::to_byte_ordered_in_place(&mut bytes);
+                        <$t as Key>::from_byte_ordered_in_place(&mut bytes);
+                        let recovered = <$t as Value>::from_bytes(&bytes);
+                        prop_assert_eq!(recovered, v, "round-trip failed");
+                        Ok(())
+                    })
+                    .unwrap();
+            }
+        };
+    }
+
+    proptest_signed_roundtrip!(proptest_i8_roundtrip, i8);
+    proptest_signed_roundtrip!(proptest_i16_roundtrip, i16);
+    proptest_signed_roundtrip!(proptest_i32_roundtrip, i32);
+    proptest_signed_roundtrip!(proptest_i64_roundtrip, i64);
+    proptest_signed_roundtrip!(proptest_i128_roundtrip, i128);
+}


### PR DESCRIPTION
## Summary

- **Fix multimap signed key ordering**: Same bug as regular tables (PR #266). Signed integers in LE encoding don't sort correctly under lexicographic byte comparison. Applied `K::to_byte_ordered_in_place` at all 7 encode sites and `V::from_byte_ordered_in_place` at all 5 decode sites in `multimap.rs`.
- **Add `BfTreeTypedScan` wrapper**: Type-safe table scan that auto-reverses byte-order transformation on keys. Updated `scan_table` docs to warn about raw byte-ordered format.
- **10 proptest property tests**: Verify signed key ordering preservation and encode/decode round-trip for i8/i16/i32/i64/i128 (10K random cases each).
- **Concurrent blob sequence collision test**: 8 threads x 50 blob allocations, assert no duplicate sequence numbers.
- **8 integration tests**: Signed key scan ordering, multimap signed keys, boundary values (MIN/MAX), empty table scan, single element, overwrite, delete.

## Test plan

- [x] `cargo clippy --features bf_tree -- -D warnings` clean
- [x] `cargo test --features bf_tree --lib` -- 400 tests pass (19 new)
- [x] No non-ASCII characters
- [x] `cargo fmt` clean