### PR TITLE
fix: audit hardening - panic paths, f32 serialization, merge tests

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,5 +1,5 @@
 # shodh-redb
-Embedded multi-modal database engine in Rust. B-tree page store with vector indexing (IVF-PQ, fractal), blob store, CDC, TTL, merge operators. no_std compatible core, std feature for file backends.
+Embedded multi-modal database engine in Rust. B-tree page store with vector indexing (IVF-PQ), blob store, CDC, TTL, merge operators. no_std compatible core, std feature for file backends.
 
 # Build & Test
 - IMPORTANT: Do NOT run `cargo build` or `trunk serve` -- user runs builds in background

--- a/src/ivfpq/index.rs
+++ b/src/ivfpq/index.rs
@@ -273,10 +273,7 @@ impl<'txn, T: StorageWrite> IvfPqIndex<'txn, T> {
             let def = TableDefinition::<u32, &[u8]>::new(&tn);
             let mut table = self.txn.open_storage_table(def)?;
             for c in 0..actual_k {
-                let bytes: Vec<u8> = centroid_data[c * dim..(c + 1) * dim]
-                    .iter()
-                    .flat_map(|f| f.to_le_bytes())
-                    .collect();
+                let bytes = f32_slice_to_le_bytes(&centroid_data[c * dim..(c + 1) * dim]);
                 #[allow(clippy::cast_possible_truncation)]
                 table.st_insert(&(c as u32), &bytes.as_slice())?;
             }
@@ -392,7 +389,7 @@ impl<'txn, T: StorageWrite> IvfPqIndex<'txn, T> {
 
         // Store raw vector separately for reranking.
         if self.config.store_raw_vectors {
-            let raw_bytes: Vec<u8> = vec_ref.iter().flat_map(|f| f.to_le_bytes()).collect();
+            let raw_bytes = f32_slice_to_le_bytes(vec_ref);
             let vn = vectors_name(&self.name);
             let vdef = TableDefinition::<u64, &[u8]>::new(&vn);
             let mut vt = self.txn.open_storage_table(vdef)?;
@@ -479,7 +476,7 @@ impl<'txn, T: StorageWrite> IvfPqIndex<'txn, T> {
             if store_raw {
                 raw_vectors.push((
                     vector_id,
-                    vec.iter().flat_map(|f| f.to_le_bytes()).collect(),
+                    f32_slice_to_le_bytes(&vec),
                 ));
             }
 
@@ -1259,6 +1256,37 @@ impl CandidateHeap {
 // ---------------------------------------------------------------------------
 // Utility
 // ---------------------------------------------------------------------------
+
+/// Encode a slice of f32s into LE bytes.
+///
+/// On little-endian targets this is a direct memcpy; on big-endian it
+/// converts each float individually.
+#[inline]
+fn f32_slice_to_le_bytes(floats: &[f32]) -> Vec<u8> {
+    let byte_len = floats.len() * 4;
+    let mut out = vec![0u8; byte_len];
+    #[cfg(target_endian = "little")]
+    {
+        // SAFETY: On LE targets f32 memory layout matches LE byte order.
+        // `floats` has `floats.len() * 4` bytes, `out` has the same size.
+        // Both pointers are valid and non-overlapping (Vec owns its buffer).
+        unsafe {
+            core::ptr::copy_nonoverlapping(
+                floats.as_ptr().cast::<u8>(),
+                out.as_mut_ptr(),
+                byte_len,
+            );
+        }
+    }
+    #[cfg(not(target_endian = "little"))]
+    {
+        for (i, &f) in floats.iter().enumerate() {
+            let b = f.to_le_bytes();
+            out[i * 4..i * 4 + 4].copy_from_slice(&b);
+        }
+    }
+    out
+}
 
 /// Decode LE f32s from `bytes` into the pre-allocated `buf`.
 /// Caller must ensure `bytes.len() == buf.len() * 4`.

--- a/src/ivfpq/index.rs
+++ b/src/ivfpq/index.rs
@@ -474,10 +474,7 @@ impl<'txn, T: StorageWrite> IvfPqIndex<'txn, T> {
 
             let pq_codes = codebooks.encode(&residual);
             if store_raw {
-                raw_vectors.push((
-                    vector_id,
-                    f32_slice_to_le_bytes(&vec),
-                ));
+                raw_vectors.push((vector_id, f32_slice_to_le_bytes(&vec)));
             }
 
             // Check for existing assignment.

--- a/src/merge.rs
+++ b/src/merge.rs
@@ -545,7 +545,7 @@ mod tests {
     #[test]
     fn float_add_no_existing() {
         let op = FloatAdd;
-        let operand = 3.14f32.to_le_bytes();
+        let operand = 7.5f32.to_le_bytes();
         let result = op.merge(KEY, None, &operand).unwrap();
         assert_eq!(result, operand);
     }

--- a/src/merge.rs
+++ b/src/merge.rs
@@ -535,10 +535,7 @@ mod tests {
         let a = u64::MAX.to_le_bytes();
         let b = 1u64.to_le_bytes();
         let result = op.merge(KEY, Some(&a), &b).unwrap();
-        assert_eq!(
-            u64::from_le_bytes(result.try_into().unwrap()),
-            u64::MAX
-        );
+        assert_eq!(u64::from_le_bytes(result.try_into().unwrap()), u64::MAX);
     }
 
     // -----------------------------------------------------------------------

--- a/src/merge.rs
+++ b/src/merge.rs
@@ -736,10 +736,7 @@ mod tests {
             }
         });
         assert!(op.merge(KEY, Some(b"val"), b"DELETE").is_none());
-        assert_eq!(
-            op.merge(KEY, Some(b"val"), b"keep").unwrap(),
-            b"keep"
-        );
+        assert_eq!(op.merge(KEY, Some(b"val"), b"keep").unwrap(), b"keep");
     }
 
     #[test]

--- a/src/merge.rs
+++ b/src/merge.rs
@@ -423,3 +423,340 @@ where
 {
     FnMergeOperator { f }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const KEY: &[u8] = b"test_key";
+
+    // -----------------------------------------------------------------------
+    // NumericAdd
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn numeric_add_no_existing() {
+        let op = NumericAdd;
+        let operand = 42u64.to_le_bytes();
+        let result = op.merge(KEY, None, &operand).unwrap();
+        assert_eq!(result, operand);
+    }
+
+    #[test]
+    fn numeric_add_u8() {
+        let op = NumericAdd;
+        let result = op.merge(KEY, Some(&[200]), &[100]).unwrap();
+        assert_eq!(result, vec![44]); // 200 + 100 = 300, wraps to 44
+    }
+
+    #[test]
+    fn numeric_add_u16() {
+        let op = NumericAdd;
+        let a = 1000u16.to_le_bytes();
+        let b = 2000u16.to_le_bytes();
+        let result = op.merge(KEY, Some(&a), &b).unwrap();
+        assert_eq!(u16::from_le_bytes(result.try_into().unwrap()), 3000);
+    }
+
+    #[test]
+    fn numeric_add_u32() {
+        let op = NumericAdd;
+        let a = 100_000u32.to_le_bytes();
+        let b = 200_000u32.to_le_bytes();
+        let result = op.merge(KEY, Some(&a), &b).unwrap();
+        assert_eq!(u32::from_le_bytes(result.try_into().unwrap()), 300_000);
+    }
+
+    #[test]
+    fn numeric_add_u64() {
+        let op = NumericAdd;
+        let a = 1_000_000u64.to_le_bytes();
+        let b = 2_000_000u64.to_le_bytes();
+        let result = op.merge(KEY, Some(&a), &b).unwrap();
+        assert_eq!(u64::from_le_bytes(result.try_into().unwrap()), 3_000_000);
+    }
+
+    #[test]
+    fn numeric_add_wrapping_u64() {
+        let op = NumericAdd;
+        let a = u64::MAX.to_le_bytes();
+        let b = 1u64.to_le_bytes();
+        let result = op.merge(KEY, Some(&a), &b).unwrap();
+        assert_eq!(u64::from_le_bytes(result.try_into().unwrap()), 0);
+    }
+
+    #[test]
+    fn numeric_add_mismatched_widths() {
+        let op = NumericAdd;
+        let a = 42u32.to_le_bytes();
+        let b = 1u64.to_le_bytes();
+        let result = op.merge(KEY, Some(&a), &b).unwrap();
+        assert_eq!(result, a, "mismatched widths should preserve existing");
+    }
+
+    #[test]
+    fn numeric_add_unsupported_width() {
+        let op = NumericAdd;
+        let a = [1u8; 3];
+        let b = [2u8; 3];
+        let result = op.merge(KEY, Some(&a), &b).unwrap();
+        assert_eq!(result, a, "3-byte width should preserve existing");
+    }
+
+    // -----------------------------------------------------------------------
+    // SaturatingAdd
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn saturating_add_no_existing() {
+        let op = SaturatingAdd;
+        let operand = 42u64.to_le_bytes();
+        let result = op.merge(KEY, None, &operand).unwrap();
+        assert_eq!(result, operand);
+    }
+
+    #[test]
+    fn saturating_add_u8_no_overflow() {
+        let op = SaturatingAdd;
+        let result = op.merge(KEY, Some(&[100]), &[50]).unwrap();
+        assert_eq!(result, vec![150]);
+    }
+
+    #[test]
+    fn saturating_add_u8_saturates() {
+        let op = SaturatingAdd;
+        let result = op.merge(KEY, Some(&[200]), &[100]).unwrap();
+        assert_eq!(result, vec![255]); // saturates at u8::MAX
+    }
+
+    #[test]
+    fn saturating_add_u64_saturates() {
+        let op = SaturatingAdd;
+        let a = u64::MAX.to_le_bytes();
+        let b = 1u64.to_le_bytes();
+        let result = op.merge(KEY, Some(&a), &b).unwrap();
+        assert_eq!(
+            u64::from_le_bytes(result.try_into().unwrap()),
+            u64::MAX
+        );
+    }
+
+    // -----------------------------------------------------------------------
+    // FloatAdd
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn float_add_no_existing() {
+        let op = FloatAdd;
+        let operand = 3.14f32.to_le_bytes();
+        let result = op.merge(KEY, None, &operand).unwrap();
+        assert_eq!(result, operand);
+    }
+
+    #[test]
+    fn float_add_f32() {
+        let op = FloatAdd;
+        let a = 1.5f32.to_le_bytes();
+        let b = 2.5f32.to_le_bytes();
+        let result = op.merge(KEY, Some(&a), &b).unwrap();
+        let sum = f32::from_le_bytes(result.try_into().unwrap());
+        assert!((sum - 4.0).abs() < f32::EPSILON);
+    }
+
+    #[test]
+    fn float_add_f64() {
+        let op = FloatAdd;
+        let a = 1.5f64.to_le_bytes();
+        let b = 2.5f64.to_le_bytes();
+        let result = op.merge(KEY, Some(&a), &b).unwrap();
+        let sum = f64::from_le_bytes(result.try_into().unwrap());
+        assert!((sum - 4.0).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn float_add_nan_propagates() {
+        let op = FloatAdd;
+        let a = f32::NAN.to_le_bytes();
+        let b = 1.0f32.to_le_bytes();
+        let result = op.merge(KEY, Some(&a), &b).unwrap();
+        let sum = f32::from_le_bytes(result.try_into().unwrap());
+        assert!(sum.is_nan());
+    }
+
+    #[test]
+    fn float_add_unsupported_width() {
+        let op = FloatAdd;
+        let a = [1u8; 3];
+        let b = [2u8; 3];
+        let result = op.merge(KEY, Some(&a), &b).unwrap();
+        assert_eq!(result, a);
+    }
+
+    // -----------------------------------------------------------------------
+    // NumericMax
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn numeric_max_no_existing() {
+        let op = NumericMax;
+        let operand = 42u64.to_le_bytes();
+        let result = op.merge(KEY, None, &operand).unwrap();
+        assert_eq!(result, operand);
+    }
+
+    #[test]
+    fn numeric_max_u64_picks_larger() {
+        let op = NumericMax;
+        let a = 100u64.to_le_bytes();
+        let b = 200u64.to_le_bytes();
+        let result = op.merge(KEY, Some(&a), &b).unwrap();
+        assert_eq!(u64::from_le_bytes(result.try_into().unwrap()), 200);
+    }
+
+    #[test]
+    fn numeric_max_u64_keeps_existing() {
+        let op = NumericMax;
+        let a = 200u64.to_le_bytes();
+        let b = 100u64.to_le_bytes();
+        let result = op.merge(KEY, Some(&a), &b).unwrap();
+        assert_eq!(u64::from_le_bytes(result.try_into().unwrap()), 200);
+    }
+
+    #[test]
+    fn numeric_max_u8() {
+        let op = NumericMax;
+        let result = op.merge(KEY, Some(&[10]), &[20]).unwrap();
+        assert_eq!(result, vec![20]);
+    }
+
+    // -----------------------------------------------------------------------
+    // NumericMin
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn numeric_min_no_existing() {
+        let op = NumericMin;
+        let operand = 42u64.to_le_bytes();
+        let result = op.merge(KEY, None, &operand).unwrap();
+        assert_eq!(result, operand);
+    }
+
+    #[test]
+    fn numeric_min_u64_picks_smaller() {
+        let op = NumericMin;
+        let a = 200u64.to_le_bytes();
+        let b = 100u64.to_le_bytes();
+        let result = op.merge(KEY, Some(&a), &b).unwrap();
+        assert_eq!(u64::from_le_bytes(result.try_into().unwrap()), 100);
+    }
+
+    #[test]
+    fn numeric_min_u64_keeps_existing() {
+        let op = NumericMin;
+        let a = 100u64.to_le_bytes();
+        let b = 200u64.to_le_bytes();
+        let result = op.merge(KEY, Some(&a), &b).unwrap();
+        assert_eq!(u64::from_le_bytes(result.try_into().unwrap()), 100);
+    }
+
+    // -----------------------------------------------------------------------
+    // BitwiseOr
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn bitwise_or_no_existing() {
+        let op = BitwiseOr;
+        let operand = vec![0b1010_1010, 0b0101_0101];
+        let result = op.merge(KEY, None, &operand).unwrap();
+        assert_eq!(result, operand);
+    }
+
+    #[test]
+    fn bitwise_or_combines() {
+        let op = BitwiseOr;
+        let a = [0b1010_0000, 0b0000_1111];
+        let b = [0b0101_0000, 0b1111_0000];
+        let result = op.merge(KEY, Some(&a), &b).unwrap();
+        assert_eq!(result, vec![0b1111_0000, 0b1111_1111]);
+    }
+
+    #[test]
+    fn bitwise_or_mismatched_lengths() {
+        let op = BitwiseOr;
+        let a = [0xFF, 0xFF];
+        let b = [0x00];
+        let result = op.merge(KEY, Some(&a), &b).unwrap();
+        assert_eq!(result, a, "mismatched lengths should preserve existing");
+    }
+
+    // -----------------------------------------------------------------------
+    // BytesAppend
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn bytes_append_no_existing() {
+        let op = BytesAppend;
+        let operand = b"hello";
+        let result = op.merge(KEY, None, operand).unwrap();
+        assert_eq!(result, b"hello");
+    }
+
+    #[test]
+    fn bytes_append_concatenates() {
+        let op = BytesAppend;
+        let result = op.merge(KEY, Some(b"hello "), b"world").unwrap();
+        assert_eq!(result, b"hello world");
+    }
+
+    #[test]
+    fn bytes_append_empty_operand() {
+        let op = BytesAppend;
+        let result = op.merge(KEY, Some(b"existing"), b"").unwrap();
+        assert_eq!(result, b"existing");
+    }
+
+    #[test]
+    fn bytes_append_empty_existing() {
+        let op = BytesAppend;
+        let result = op.merge(KEY, Some(b""), b"new").unwrap();
+        assert_eq!(result, b"new");
+    }
+
+    // -----------------------------------------------------------------------
+    // merge_fn
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn merge_fn_custom_delete() {
+        let op = merge_fn(|_key, _existing, operand| {
+            if operand == b"DELETE" {
+                None
+            } else {
+                Some(operand.to_vec())
+            }
+        });
+        assert!(op.merge(KEY, Some(b"val"), b"DELETE").is_none());
+        assert_eq!(
+            op.merge(KEY, Some(b"val"), b"keep").unwrap(),
+            b"keep"
+        );
+    }
+
+    #[test]
+    fn merge_fn_key_aware() {
+        let op = merge_fn(|key, existing, operand| {
+            if key == b"counter" {
+                NumericAdd.merge(key, existing, operand)
+            } else {
+                Some(operand.to_vec())
+            }
+        });
+        let a = 10u64.to_le_bytes();
+        let b = 20u64.to_le_bytes();
+        let result = op.merge(b"counter", Some(&a), &b).unwrap();
+        assert_eq!(u64::from_le_bytes(result.try_into().unwrap()), 30);
+
+        let result = op.merge(b"other", Some(b"old"), b"new").unwrap();
+        assert_eq!(result, b"new");
+    }
+}

--- a/src/tree_store/table_tree.rs
+++ b/src/tree_store/table_tree.rs
@@ -986,7 +986,10 @@ impl Drop for TableTreeMut<'_> {
         if is_panicking {
             return;
         }
-        assert!(self.allocated_pages.lock().is_empty());
+        debug_assert!(
+            self.allocated_pages.lock().is_empty(),
+            "TableTree dropped with unreleased allocated pages"
+        );
     }
 }
 

--- a/src/vector.rs
+++ b/src/vector.rs
@@ -53,32 +53,37 @@ impl<const N: usize> Value for FixedVec<N> {
         Self: 'a,
     {
         let expected = N * core::mem::size_of::<f32>();
-        assert!(
+        debug_assert!(
             data.len() >= expected,
             "FixedVec<{N}>::from_bytes: truncated data ({} < {expected}); \
              this indicates on-disk corruption or a dimension mismatch \
              between the table definition and stored data",
             data.len(),
         );
+        // Clamp to available bytes (zero-pad if truncated) to avoid panicking
+        // on corrupted data. The result will be a degraded vector but the
+        // database remains operational.
+        let usable = data.len().min(expected);
         let mut result = [0.0f32; N];
         #[cfg(target_endian = "little")]
         {
             // SAFETY: On little-endian targets, f32 byte representation matches
-            // memory layout. Source has >= N*4 bytes (asserted above), dest is
-            // [f32; N] with size N*4. Both pointers are valid and non-overlapping.
+            // memory layout. `usable` <= data.len() and usable <= N*4, so both
+            // source and dest have sufficient bytes. Pointers are non-overlapping.
             unsafe {
                 core::ptr::copy_nonoverlapping(
                     data.as_ptr(),
                     result.as_mut_ptr().cast::<u8>(),
-                    N * 4,
+                    usable,
                 );
             }
         }
         #[cfg(not(target_endian = "little"))]
         {
-            for (i, val) in result.iter_mut().enumerate() {
+            let full_floats = usable / 4;
+            for i in 0..full_floats {
                 let start = i * 4;
-                *val = f32::from_le_bytes([
+                result[i] = f32::from_le_bytes([
                     data[start],
                     data[start + 1],
                     data[start + 2],


### PR DESCRIPTION
## Summary
- Replace `assert!()` with `debug_assert!()` in `FixedVec::from_bytes` and `TableTree::drop` to prevent production panics on corrupted data
- Add `f32_slice_to_le_bytes()` with LE memcpy fast path, replacing 3 `flat_map(to_le_bytes).collect()` sites in IVF-PQ insert/train
- Add 31 unit tests for all 8 merge operators (NumericAdd, SaturatingAdd, FloatAdd, NumericMax, NumericMin, BitwiseOr, BytesAppend, merge_fn)
- Remove stale fractal index reference from CLAUDE.md

## Test plan
- [x] `cargo test --lib -p shodh-redb` -- 231 tests pass
- [x] `cargo clippy --lib -- -D warnings` -- clean
- [ ] CI: lint, wasm32, all-features, MSRV