### PR TITLE
fix: harden blob dedup, causal cleanup, CDC retention, IVF-PQ validation

### DIFF
--- a/src/ivfpq/index.rs
+++ b/src/ivfpq/index.rs
@@ -817,9 +817,10 @@ impl<'txn, T: StorageWrite> IvfPqIndex<'txn, T> {
                 ))
             })?;
             let raw = guard.value();
-            if raw.len() % 4 != 0 {
+            let expected_bytes = dim * 4;
+            if raw.len() != expected_bytes {
                 return Err(StorageError::Corrupted(alloc::format!(
-                    "IVF-PQ '{}': centroid {c} has misaligned byte length {} (not a multiple of 4)",
+                    "IVF-PQ '{}': centroid {c} byte length {} != expected {expected_bytes} (dim={dim})",
                     self.name,
                     raw.len(),
                 )));

--- a/src/transactions.rs
+++ b/src/transactions.rs
@@ -1643,12 +1643,18 @@ impl WriteTransaction {
             None
         };
 
-        let blob_ref = if let Some(existing) = dedup_hit {
-            // Reuse existing physical data -- skip writing to blob region
+        let blob_ref = if let Some(existing) = dedup_hit
+            && existing.checksum == checksum
+            && existing.length == data.len() as u64
+        {
+            // Reuse existing physical data -- SHA-256 matched AND xxh3-128
+            // checksum + length confirmed. Without the secondary check a
+            // SHA-256 collision (or corrupted dedup index entry) would
+            // silently bind the new blob_id to wrong physical data.
             BlobRef {
                 offset: existing.offset,
                 length: existing.length,
-                checksum: existing.checksum,
+                checksum,
                 ref_count: 1,
                 content_type: content_type.as_byte(),
                 compression: 0,
@@ -2118,7 +2124,7 @@ impl WriteTransaction {
         temporal_table.remove(&temporal_key)?;
         drop(temporal_table);
 
-        // Remove from causal edges index using composite key (parent, child).
+        // Remove incoming causal edge (parent → this blob).
         if let Some(parent) = meta.causal_parent {
             let mut edges_table = system_tables.open_system_table(self, BLOB_CAUSAL_EDGES)?;
             edges_table.remove(&CausalEdgeKey::new(parent, *blob_id))?;
@@ -2133,6 +2139,31 @@ impl WriteTransaction {
                 legacy_table.remove(&parent)?;
             }
             drop(legacy_table);
+        }
+
+        // Remove outgoing causal edges (this blob → children). Without this,
+        // deleting a parent blob leaves dangling edge entries that waste space
+        // and could confuse causal graph traversals.
+        {
+            let edges_table = system_tables.open_system_table(self, BLOB_CAUSAL_EDGES)?;
+            let start = CausalEdgeKey::new(*blob_id, BlobId::MIN);
+            let end = CausalEdgeKey::new(*blob_id, BlobId::MAX);
+            let mut outgoing = Vec::new();
+            if let Ok(range) = edges_table.range(start..=end) {
+                for entry in range {
+                    let (key_guard, _) = entry?;
+                    outgoing.push(key_guard.value());
+                }
+            }
+            drop(edges_table);
+
+            if !outgoing.is_empty() {
+                let mut edges_table = system_tables.open_system_table(self, BLOB_CAUSAL_EDGES)?;
+                for key in &outgoing {
+                    edges_table.remove(key)?;
+                }
+                drop(edges_table);
+            }
         }
 
         // Remove tag index entries -- scan for all TagKeys that reference this blob
@@ -2588,12 +2619,43 @@ impl WriteTransaction {
             cdc_table.insert(&key, &record)?;
         }
 
-        // Retention pruning
+        // Retention pruning — respect active consumer cursors to prevent
+        // silent data loss. The effective cutoff is the LARGER of (txn_id -
+        // retention_max_txns) and the oldest cursor position, so we never
+        // prune events that a registered consumer hasn't consumed yet.
         if self.cdc_config.retention_max_txns > 0 && txn_id > self.cdc_config.retention_max_txns {
-            let cutoff_txn = txn_id - self.cdc_config.retention_max_txns;
-            let end_key = CdcKey::new(cutoff_txn, u32::MAX);
-            for entry in cdc_table.extract_from_if(..=end_key, |_, _| true)? {
-                entry?;
+            let retention_cutoff = txn_id - self.cdc_config.retention_max_txns;
+
+            // Drop cdc_table to release the borrow on system_tables before
+            // opening the cursor table.
+            drop(cdc_table);
+
+            // Find the oldest active cursor position (if any cursors exist)
+            let oldest_cursor = {
+                let cursor_table = system_tables.open_system_table(self, CDC_CURSOR_TABLE)?;
+                let mut oldest: Option<u64> = None;
+                for entry in cursor_table.range::<&str>(..)? {
+                    let (_, val_guard) = entry?;
+                    let pos = val_guard.value();
+                    oldest = Some(oldest.map_or(pos, |o: u64| o.min(pos)));
+                }
+                drop(cursor_table);
+                oldest
+            };
+
+            // Don't prune past the oldest cursor — a slow consumer would
+            // silently miss mutations if we deleted entries it hasn't read.
+            let effective_cutoff = match oldest_cursor {
+                Some(cursor_pos) => retention_cutoff.max(cursor_pos),
+                None => retention_cutoff,
+            };
+
+            if effective_cutoff > 0 {
+                let mut cdc_table = system_tables.open_system_table(self, CDC_LOG_TABLE)?;
+                let end_key = CdcKey::new(effective_cutoff, u32::MAX);
+                for entry in cdc_table.extract_from_if(..=end_key, |_, _| true)? {
+                    entry?;
+                }
             }
         }
 

--- a/src/transactions.rs
+++ b/src/transactions.rs
@@ -2124,7 +2124,7 @@ impl WriteTransaction {
         temporal_table.remove(&temporal_key)?;
         drop(temporal_table);
 
-        // Remove incoming causal edge (parent → this blob).
+        // Remove incoming causal edge (parent -> this blob).
         if let Some(parent) = meta.causal_parent {
             let mut edges_table = system_tables.open_system_table(self, BLOB_CAUSAL_EDGES)?;
             edges_table.remove(&CausalEdgeKey::new(parent, *blob_id))?;
@@ -2141,7 +2141,7 @@ impl WriteTransaction {
             drop(legacy_table);
         }
 
-        // Remove outgoing causal edges (this blob → children). Without this,
+        // Remove outgoing causal edges (this blob -> children). Without this,
         // deleting a parent blob leaves dangling edge entries that waste space
         // and could confuse causal graph traversals.
         {
@@ -2619,7 +2619,7 @@ impl WriteTransaction {
             cdc_table.insert(&key, &record)?;
         }
 
-        // Retention pruning — respect active consumer cursors to prevent
+        // Retention pruning -- respect active consumer cursors to prevent
         // silent data loss. The effective cutoff is the LARGER of (txn_id -
         // retention_max_txns) and the oldest cursor position, so we never
         // prune events that a registered consumer hasn't consumed yet.
@@ -2643,7 +2643,7 @@ impl WriteTransaction {
                 oldest
             };
 
-            // Don't prune past the oldest cursor — a slow consumer would
+            // Don't prune past the oldest cursor -- a slow consumer would
             // silently miss mutations if we deleted entries it hasn't read.
             let effective_cutoff = match oldest_cursor {
                 Some(cursor_pos) => retention_cutoff.max(cursor_pos),

--- a/src/vector_ops.rs
+++ b/src/vector_ops.rs
@@ -727,7 +727,10 @@ pub fn read_f32_le(src: &[u8]) -> Vec<f32> {
         let mut result = Vec::with_capacity(count);
         for i in 0..count {
             let start = i * 4;
-            let bytes: [u8; 4] = src[start..start + 4].try_into().unwrap();
+            // Infallible: start + 4 <= usable <= src.len() by loop bounds.
+            let bytes: [u8; 4] = src[start..start + 4]
+                .try_into()
+                .unwrap_or([0u8; 4]);
             result.push(f32::from_le_bytes(bytes));
         }
         result

--- a/src/vector_ops.rs
+++ b/src/vector_ops.rs
@@ -728,9 +728,7 @@ pub fn read_f32_le(src: &[u8]) -> Vec<f32> {
         for i in 0..count {
             let start = i * 4;
             // Infallible: start + 4 <= usable <= src.len() by loop bounds.
-            let bytes: [u8; 4] = src[start..start + 4]
-                .try_into()
-                .unwrap_or([0u8; 4]);
+            let bytes: [u8; 4] = src[start..start + 4].try_into().unwrap_or([0u8; 4]);
             result.push(f32::from_le_bytes(bytes));
         }
         result


### PR DESCRIPTION
## Summary

Silicon audit playbook fixes (Phases 5, 7, 8):

- **IVF-PQ centroid validation**: `read_centroids()` now validates centroid byte length matches `dim * 4` exactly, instead of just checking divisibility by 4. Catches corrupted index data that would silently produce wrong-dimension centroids.

- **Blob dedup verification**: On SHA-256 dedup hit, now verifies xxh3-128 checksum AND length match before reusing physical data. Prevents silent data binding to wrong content on corrupted dedup index or (astronomically unlikely) SHA-256 collision.

- **Causal edge cleanup**: `delete_blob()` now removes outgoing causal edges (this_blob -> children) in addition to the incoming edge. Previously only the single incoming edge from `meta.causal_parent` was removed, leaving dangling entries.

- **CDC retention guard**: Retention pruning now respects active consumer cursor positions. The effective cutoff is `max(retention_cutoff, oldest_cursor)`, preventing silent data loss for slow consumers.

- **Big-endian read_f32_le**: Replaced bare `.unwrap()` with `.unwrap_or([0u8; 4])` fallback in the big-endian code path.

## Audit findings verified as FALSE POSITIVES (no action needed)

- **FTL journal ordering (P0)**: CoW design is correct — old blocks are never erased during write(), journal commit is atomic.
- **FTL reverse map bounds**: All `BlockMap` methods use bounds-checked `get()/get_mut()`.
- **FTL double-free**: Deferred-free pattern prevents reallocation of freed blocks.
- **Signed integer byte ordering**: B-tree uses `Key::compare()` (full deserialization), not raw byte comparison.
- **NaN in cosine similarity**: Both scalar and SIMD paths have `denom == 0.0` guards.

## Test plan

- [x] `cargo clippy -p shodh-redb -- -D warnings` — clean
- [x] `cargo test --lib -p shodh-redb` — 198 tests pass
- [ ] CI passes (lint, compile, test)