### PR TITLE
chore: release shodh-redb v0.3.3

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "shodh-redb"
 description = "Multi-modal embedded database - vectors, blobs, TTL, merge operators, and causal tracking built on ACID B-trees"
 readme = "README.md"
-version = "0.3.2"
+version = "0.3.3"
 exclude = ["fuzz/", "data/"]
 edition.workspace = true
 rust-version.workspace = true


### PR DESCRIPTION
## Summary

Patch release with silicon audit hardening fixes.

### Changes since v0.3.2

**Correctness fixes:**
- IVF-PQ: validate centroid byte length matches dim*4 exactly (catches corrupted index data)
- Blob dedup: verify xxh3-128 checksum + length before reusing on SHA-256 hit
- Causal graph: clean up outgoing edges on blob delete (prevents dangling entries)
- CDC retention: respect active consumer cursor positions during pruning (prevents silent data loss for slow consumers)

**Robustness:**
- FixedVec::from_bytes: assert -> debug_assert + graceful zero-pad on truncated data
- TableTree Drop: assert -> debug_assert to prevent panic-in-drop
- Big-endian read_f32_le: bare unwrap replaced with fallback
- IVF-PQ f32 serialization: LE memcpy fast path via f32_slice_to_le_bytes()

**Tests:**
- 31 unit tests for all 8 merge operators (NumericAdd, SaturatingAdd, FloatAdd, NumericMax, NumericMin, BitwiseOr, BytesAppend, merge_fn)

## Test plan
- [x] All lib tests pass (198)
- [x] Clippy clean
- [x] Vector ops benchmarks show no regression
- [ ] CI green