### PR TITLE
fix: audit-driven correctness fixes (16 findings)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2061,7 +2061,7 @@ checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
 name = "shodh-redb"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "bincode 2.0.1",
  "chrono",

--- a/src/composite/query.rs
+++ b/src/composite/query.rs
@@ -476,6 +476,18 @@ impl<'a, P: BlobQueryProvider, R: StorageRead> CompositeQuery<'a, P, R> {
                 "CompositeQuery: causal signal requires a root blob_id".to_string(),
             ));
         }
+        // When temporal is the only active signal, time_range is required to
+        // populate candidates. Without it, no other signal can seed the
+        // candidate set and the query silently returns empty.
+        if self.weights.temporal > 0.0
+            && self.weights.semantic <= 0.0
+            && self.weights.causal <= 0.0
+            && self.time_range.is_none()
+        {
+            return Err(StorageError::Corrupted(
+                "CompositeQuery: temporal-only signal requires a time_range".to_string(),
+            ));
+        }
         if self.top_k == 0 {
             return Err(StorageError::Corrupted(
                 "CompositeQuery: top_k must be >= 1".to_string(),

--- a/src/db.rs
+++ b/src/db.rs
@@ -125,6 +125,21 @@ impl MultimapTableHandle for UntypedMultimapTableHandle {
 
 impl Sealed for UntypedMultimapTableHandle {}
 
+/// Const-compatible byte-level prefix check for use in `const fn` table name validation.
+const fn const_starts_with(haystack: &[u8], needle: &[u8]) -> bool {
+    if needle.len() > haystack.len() {
+        return false;
+    }
+    let mut i = 0;
+    while i < needle.len() {
+        if haystack[i] != needle[i] {
+            return false;
+        }
+        i += 1;
+    }
+    true
+}
+
 /// Defines the name and types of a table
 ///
 /// A [`TableDefinition`] should be opened for use by calling [`ReadTransaction::open_table`] or [`WriteTransaction::open_table`]
@@ -142,9 +157,13 @@ impl<'a, K: Key + 'static, V: Value + 'static> TableDefinition<'a, K, V> {
     ///
     /// ## Invariant
     ///
-    /// `name` must not be empty.
+    /// `name` must not be empty and must not use the reserved `__ivfpq:` prefix.
     pub const fn new(name: &'a str) -> Self {
         assert!(!name.is_empty());
+        assert!(
+            !const_starts_with(name.as_bytes(), b"__ivfpq:"),
+            "table names starting with \"__ivfpq:\" are reserved for internal use"
+        );
         Self {
             name,
             _key_type: PhantomData,
@@ -198,6 +217,10 @@ pub struct MultimapTableDefinition<'a, K: Key + 'static, V: Key + 'static> {
 impl<'a, K: Key + 'static, V: Key + 'static> MultimapTableDefinition<'a, K, V> {
     pub const fn new(name: &'a str) -> Self {
         assert!(!name.is_empty());
+        assert!(
+            !const_starts_with(name.as_bytes(), b"__ivfpq:"),
+            "table names starting with \"__ivfpq:\" are reserved for internal use"
+        );
         Self {
             name,
             _key_type: PhantomData,
@@ -1311,7 +1334,11 @@ impl Database {
         }
 
         // -- Truncate the file ------------------------------------------------
-        let blob_state = self.mem.get_blob_state();
+        // IMPORTANT: Use committed state only. get_blob_state() may return
+        // non-durable pending state (if a prior Durability::None blob write
+        // set pending_blob_state.next_sequence != 0), which would cause
+        // truncation to a wrong length and permanent database corruption.
+        let blob_state = self.mem.get_committed_blob_state();
         let target_len = blob_state.region_offset + blob_state.region_length;
         if target_len > 0 {
             self.mem
@@ -1986,10 +2013,10 @@ impl Database {
             let txn = match self.begin_write() {
                 Ok(txn) => txn,
                 Err(e) => {
-                    let storage_err = e.into_storage_error();
+                    let msg = e.into_storage_error().to_string();
                     for b in batches {
                         let _ = b.result_tx.send(Err(GroupCommitError::TransactionFailed(
-                            StorageError::Corrupted(storage_err.to_string()),
+                            StorageError::Corrupted(msg.clone()),
                         )));
                     }
                     let _ = self.group_committer.finish_leader();
@@ -2040,7 +2067,7 @@ impl Database {
                     }
                 }
                 Err(e) => {
-                    let msg = e.to_string();
+                    let msg = e.into_storage_error().to_string();
                     for tx in senders {
                         let _ = tx.send(Err(GroupCommitError::CommitFailed(
                             StorageError::Corrupted(msg.clone()),

--- a/src/db.rs
+++ b/src/db.rs
@@ -170,6 +170,17 @@ impl<'a, K: Key + 'static, V: Value + 'static> TableDefinition<'a, K, V> {
             _value_type: PhantomData,
         }
     }
+
+    /// Internal constructor that permits reserved prefixes.
+    /// Only for use by IVF-PQ and other internal subsystems.
+    pub(crate) const fn new_internal(name: &'a str) -> Self {
+        assert!(!name.is_empty());
+        Self {
+            name,
+            _key_type: PhantomData,
+            _value_type: PhantomData,
+        }
+    }
 }
 
 impl<K: Key + 'static, V: Value + 'static> TableHandle for TableDefinition<'_, K, V> {

--- a/src/error.rs
+++ b/src/error.rs
@@ -139,6 +139,9 @@ pub enum StorageError {
         /// Static description of the corruption
         detail: &'static str,
     },
+    /// Timed out waiting for a write transaction lock (`no_std` spin-lock).
+    /// This is transient contention, not corruption.
+    LockTimeout(String),
     Io(BackendError),
     PreviousIo,
     DatabaseClosed,
@@ -240,6 +243,7 @@ impl From<StorageError> for Error {
                 page_order,
                 detail,
             },
+            StorageError::LockTimeout(msg) => Error::LockTimeout(msg),
             StorageError::Io(x) => Error::Io(x),
             StorageError::PreviousIo => Error::PreviousIo,
             StorageError::DatabaseClosed => Error::DatabaseClosed,
@@ -344,6 +348,9 @@ impl Display for StorageError {
                     f,
                     "Page ({page_region}, {page_index}, order={page_order}) corrupted: {detail}"
                 )
+            }
+            StorageError::LockTimeout(msg) => {
+                write!(f, "Lock timeout: {msg}")
             }
             StorageError::Io(err) => {
                 write!(f, "I/O error: {err}")
@@ -942,6 +949,8 @@ pub enum Error {
         page_order: u8,
         detail: &'static str,
     },
+    /// Timed out waiting for a write transaction lock (`no_std` spin-lock).
+    LockTimeout(String),
     Io(BackendError),
     DatabaseClosed,
     /// A previous IO error occurred. The database must be closed and re-opened
@@ -1128,6 +1137,9 @@ impl Display for Error {
                     f,
                     "Page ({page_region}, {page_index}, order={page_order}) corrupted: {detail}"
                 )
+            }
+            Error::LockTimeout(msg) => {
+                write!(f, "Lock timeout: {msg}")
             }
             Error::Io(err) => {
                 write!(f, "I/O error: {err}")

--- a/src/ivfpq/adc.rs
+++ b/src/ivfpq/adc.rs
@@ -167,7 +167,7 @@ impl IntAdcTable {
     /// No floating-point operations. Uses unchecked indexing for maximum
     /// throughput on the hot scan path (~40K calls per search).
     #[inline]
-    pub fn approximate_distance(&self, pq_codes: &[u8]) -> u32 {
+    pub(crate) fn approximate_distance(&self, pq_codes: &[u8]) -> u32 {
         debug_assert!(pq_codes.len() >= self.num_subvectors);
         debug_assert!(self.distances.len() >= self.num_subvectors * 256);
         let mut dist = 0u32;
@@ -190,7 +190,7 @@ impl IntAdcTable {
     /// `f32_total = u32_sum * scale + num_subvectors * offset`.
     #[inline]
     #[allow(clippy::cast_precision_loss)]
-    pub fn to_f32(&self, dist_u32: u32) -> f32 {
+    pub(crate) fn to_f32(&self, dist_u32: u32) -> f32 {
         dist_u32 as f32 * self.scale + self.num_subvectors as f32 * self.offset
     }
 }

--- a/src/ivfpq/cluster_blob.rs
+++ b/src/ivfpq/cluster_blob.rs
@@ -261,7 +261,7 @@ impl<'a> ClusterBlobRef<'a> {
     /// `i < self.count` is the caller's responsibility. Validated at blob
     /// construction time via size checks.
     #[inline]
-    pub fn vector_id(&self, i: u32) -> u64 {
+    pub(crate) fn vector_id(&self, i: u32) -> u64 {
         let offset = self.ids_offset + i as usize * 8;
         // SAFETY: blob size validated in new() to contain count * 8 bytes of IDs.
         debug_assert!(offset + 8 <= self.data.len());
@@ -281,7 +281,7 @@ impl<'a> ClusterBlobRef<'a> {
 
     /// Get the PQ codes for vector at position `i`.
     #[inline]
-    pub fn pq_codes(&self, i: u32) -> &[u8] {
+    pub(crate) fn pq_codes(&self, i: u32) -> &[u8] {
         let start = self.pq_offset + i as usize * self.pq_len as usize;
         let end = start + self.pq_len as usize;
         // SAFETY: blob size validated in new().
@@ -293,7 +293,7 @@ impl<'a> ClusterBlobRef<'a> {
     ///
     /// This is the hot-path accessor for ADC scanning -- one contiguous slice.
     #[inline]
-    pub fn pq_codes_block(&self) -> &[u8] {
+    pub(crate) fn pq_codes_block(&self) -> &[u8] {
         let end = self.pq_offset + self.count as usize * self.pq_len as usize;
         debug_assert!(end <= self.data.len());
         unsafe { self.data.get_unchecked(self.pq_offset..end) }
@@ -303,7 +303,7 @@ impl<'a> ClusterBlobRef<'a> {
     ///
     /// Returns `None` if the blob has no raw vectors.
     #[inline]
-    pub fn raw_vector_bytes(&self, i: u32) -> Option<&[u8]> {
+    pub(crate) fn raw_vector_bytes(&self, i: u32) -> Option<&[u8]> {
         if !self.has_raw {
             return None;
         }

--- a/src/ivfpq/index.rs
+++ b/src/ivfpq/index.rs
@@ -106,7 +106,7 @@ impl<'txn, T: StorageWrite> IvfPqIndex<'txn, T> {
         let name = String::from(definition.name());
 
         let mn = meta_name(&name);
-        let meta_def = TableDefinition::<&str, &[u8]>::new(&mn);
+        let meta_def = TableDefinition::<&str, &[u8]>::new_internal(&mn);
         let mut meta_table = txn.open_storage_table(meta_def)?;
 
         // Check if config exists; if not, persist the initial config.
@@ -133,15 +133,15 @@ impl<'txn, T: StorageWrite> IvfPqIndex<'txn, T> {
         // Eagerly create the other tables.
         {
             let cn = centroids_name(&name);
-            let _ = txn.open_storage_table(TableDefinition::<u32, &[u8]>::new(&cn))?;
+            let _ = txn.open_storage_table(TableDefinition::<u32, &[u8]>::new_internal(&cn))?;
             let cb = codebooks_name(&name);
-            let _ = txn.open_storage_table(TableDefinition::<u32, &[u8]>::new(&cb))?;
+            let _ = txn.open_storage_table(TableDefinition::<u32, &[u8]>::new_internal(&cb))?;
             let cl = clusters_name(&name);
-            let _ = txn.open_storage_table(TableDefinition::<u32, &[u8]>::new(&cl))?;
+            let _ = txn.open_storage_table(TableDefinition::<u32, &[u8]>::new_internal(&cl))?;
             let vn = vectors_name(&name);
-            let _ = txn.open_storage_table(TableDefinition::<u64, &[u8]>::new(&vn))?;
+            let _ = txn.open_storage_table(TableDefinition::<u64, &[u8]>::new_internal(&vn))?;
             let an = assignments_name(&name);
-            let _ = txn.open_storage_table(TableDefinition::<u64, u32>::new(&an))?;
+            let _ = txn.open_storage_table(TableDefinition::<u64, u32>::new_internal(&an))?;
         }
 
         let requested_num_clusters = definition.num_clusters();
@@ -270,7 +270,7 @@ impl<'txn, T: StorageWrite> IvfPqIndex<'txn, T> {
         // 5. Persist new centroids.
         {
             let tn = centroids_name(&self.name);
-            let def = TableDefinition::<u32, &[u8]>::new(&tn);
+            let def = TableDefinition::<u32, &[u8]>::new_internal(&tn);
             let mut table = self.txn.open_storage_table(def)?;
             for c in 0..actual_k {
                 let bytes = f32_slice_to_le_bytes(&centroid_data[c * dim..(c + 1) * dim]);
@@ -282,7 +282,7 @@ impl<'txn, T: StorageWrite> IvfPqIndex<'txn, T> {
         // 6. Persist PQ codebooks.
         {
             let tn = codebooks_name(&self.name);
-            let def = TableDefinition::<u32, &[u8]>::new(&tn);
+            let def = TableDefinition::<u32, &[u8]>::new_internal(&tn);
             let mut table = self.txn.open_storage_table(def)?;
             for m in 0..num_subvectors {
                 let bytes = codebooks_trained.serialize_codebook(m);
@@ -355,7 +355,7 @@ impl<'txn, T: StorageWrite> IvfPqIndex<'txn, T> {
         // Check if this vector_id already exists.
         let old_cluster = {
             let tn = assignments_name(&self.name);
-            let def = TableDefinition::<u64, u32>::new(&tn);
+            let def = TableDefinition::<u64, u32>::new_internal(&tn);
             let table = self.txn.open_storage_table(def)?;
             table.st_get(&vector_id)?.map(|g| g.value())
         };
@@ -372,7 +372,7 @@ impl<'txn, T: StorageWrite> IvfPqIndex<'txn, T> {
         // Merge into target cluster blob (PQ-only, no raw vectors).
         {
             let tn = clusters_name(&self.name);
-            let def = TableDefinition::<u32, &[u8]>::new(&tn);
+            let def = TableDefinition::<u32, &[u8]>::new_internal(&tn);
             let mut table = self.txn.open_storage_table(def)?;
 
             let existing_blob = table.st_get(&cluster_id)?;
@@ -391,7 +391,7 @@ impl<'txn, T: StorageWrite> IvfPqIndex<'txn, T> {
         if self.config.store_raw_vectors {
             let raw_bytes = f32_slice_to_le_bytes(vec_ref);
             let vn = vectors_name(&self.name);
-            let vdef = TableDefinition::<u64, &[u8]>::new(&vn);
+            let vdef = TableDefinition::<u64, &[u8]>::new_internal(&vn);
             let mut vt = self.txn.open_storage_table(vdef)?;
             vt.st_insert(&vector_id, &raw_bytes.as_slice())?;
         }
@@ -399,7 +399,7 @@ impl<'txn, T: StorageWrite> IvfPqIndex<'txn, T> {
         // Update assignment.
         {
             let tn = assignments_name(&self.name);
-            let def = TableDefinition::<u64, u32>::new(&tn);
+            let def = TableDefinition::<u64, u32>::new_internal(&tn);
             let mut table = self.txn.open_storage_table(def)?;
             table.st_insert(&vector_id, &cluster_id)?;
         }
@@ -441,7 +441,7 @@ impl<'txn, T: StorageWrite> IvfPqIndex<'txn, T> {
         let mut raw_vectors: Vec<(u64, Vec<u8>)> = Vec::new();
 
         let an = assignments_name(&self.name);
-        let ad = TableDefinition::<u64, u32>::new(&an);
+        let ad = TableDefinition::<u64, u32>::new_internal(&an);
         let mut at = self.txn.open_storage_table(ad)?;
 
         // Track old cluster assignments for upsert cleanup.
@@ -502,7 +502,7 @@ impl<'txn, T: StorageWrite> IvfPqIndex<'txn, T> {
         // Phase 3: For each cluster touched, read-modify-write the PQ blob.
         {
             let tn = clusters_name(&self.name);
-            let def = TableDefinition::<u32, &[u8]>::new(&tn);
+            let def = TableDefinition::<u32, &[u8]>::new_internal(&tn);
             let mut table = self.txn.open_storage_table(def)?;
 
             for (cid, mut entries) in grouped.into_iter().enumerate() {
@@ -526,7 +526,7 @@ impl<'txn, T: StorageWrite> IvfPqIndex<'txn, T> {
         // Phase 4: Write raw vectors to separate table.
         if !raw_vectors.is_empty() {
             let vn = vectors_name(&self.name);
-            let vdef = TableDefinition::<u64, &[u8]>::new(&vn);
+            let vdef = TableDefinition::<u64, &[u8]>::new_internal(&vn);
             let mut vt = self.txn.open_storage_table(vdef)?;
             for (vid, raw) in &raw_vectors {
                 vt.st_insert(vid, &raw.as_slice())?;
@@ -545,7 +545,7 @@ impl<'txn, T: StorageWrite> IvfPqIndex<'txn, T> {
     pub fn remove(&mut self, vector_id: u64) -> crate::Result<bool> {
         let cluster_id = {
             let tn = assignments_name(&self.name);
-            let def = TableDefinition::<u64, u32>::new(&tn);
+            let def = TableDefinition::<u64, u32>::new_internal(&tn);
             let mut table = self.txn.open_storage_table(def)?;
             match table.st_remove(&vector_id)? {
                 Some(guard) => guard.value(),
@@ -559,7 +559,7 @@ impl<'txn, T: StorageWrite> IvfPqIndex<'txn, T> {
         // Remove raw vector if stored.
         if self.config.store_raw_vectors {
             let vn = vectors_name(&self.name);
-            let vdef = TableDefinition::<u64, &[u8]>::new(&vn);
+            let vdef = TableDefinition::<u64, &[u8]>::new_internal(&vn);
             let mut vt = self.txn.open_storage_table(vdef)?;
             vt.st_remove(&vector_id)?;
         }
@@ -570,7 +570,7 @@ impl<'txn, T: StorageWrite> IvfPqIndex<'txn, T> {
         // Also remove associated metadata if present.
         {
             let mn = vector_meta_name(&self.name);
-            let mdef = TableDefinition::<u64, &[u8]>::new(&mn);
+            let mdef = TableDefinition::<u64, &[u8]>::new_internal(&mn);
             let mut mt = self.txn.open_storage_table(mdef)?;
             mt.st_remove(&vector_id)?;
         }
@@ -585,7 +585,7 @@ impl<'txn, T: StorageWrite> IvfPqIndex<'txn, T> {
     pub fn insert_metadata(&mut self, vector_id: u64, metadata: &MetadataMap) -> crate::Result<()> {
         let encoded = metadata.encode();
         let mn = vector_meta_name(&self.name);
-        let mdef = TableDefinition::<u64, &[u8]>::new(&mn);
+        let mdef = TableDefinition::<u64, &[u8]>::new_internal(&mn);
         let mut mt = self.txn.open_storage_table(mdef)?;
         mt.st_insert(&vector_id, &encoded.as_slice())?;
         Ok(())
@@ -594,7 +594,7 @@ impl<'txn, T: StorageWrite> IvfPqIndex<'txn, T> {
     /// Remove metadata for a vector.
     pub fn remove_metadata(&mut self, vector_id: u64) -> crate::Result<()> {
         let mn = vector_meta_name(&self.name);
-        let mdef = TableDefinition::<u64, &[u8]>::new(&mn);
+        let mdef = TableDefinition::<u64, &[u8]>::new_internal(&mn);
         let mut mt = self.txn.open_storage_table(mdef)?;
         mt.st_remove(&vector_id)?;
         Ok(())
@@ -657,12 +657,12 @@ impl<'txn, T: StorageWrite> IvfPqIndex<'txn, T> {
 
         {
             let tn = clusters_name(&self.name);
-            let def = TableDefinition::<u32, &[u8]>::new(&tn);
+            let def = TableDefinition::<u32, &[u8]>::new_internal(&tn);
             let table = self.txn.open_storage_table(def)?;
 
             let meta_table = if params.filter.is_some() {
                 let mn = vector_meta_name(&self.name);
-                let mdef = TableDefinition::<u64, &[u8]>::new(&mn);
+                let mdef = TableDefinition::<u64, &[u8]>::new_internal(&mn);
                 Some(self.txn.open_storage_table(mdef)?)
             } else {
                 None
@@ -734,7 +734,7 @@ impl<'txn, T: StorageWrite> IvfPqIndex<'txn, T> {
     fn clear_stale_training_data(&self, old_k: usize, new_k: usize) -> crate::Result<()> {
         if old_k > new_k {
             let tn = centroids_name(&self.name);
-            let def = TableDefinition::<u32, &[u8]>::new(&tn);
+            let def = TableDefinition::<u32, &[u8]>::new_internal(&tn);
             let mut table = self.txn.open_storage_table(def)?;
             for c in new_k..old_k {
                 #[allow(clippy::cast_possible_truncation)]
@@ -745,7 +745,7 @@ impl<'txn, T: StorageWrite> IvfPqIndex<'txn, T> {
         // Clear all cluster blobs.
         {
             let tn = clusters_name(&self.name);
-            let def = TableDefinition::<u32, &[u8]>::new(&tn);
+            let def = TableDefinition::<u32, &[u8]>::new_internal(&tn);
             let mut table = self.txn.open_storage_table(def)?;
             table.st_drain_all()?;
         }
@@ -753,7 +753,7 @@ impl<'txn, T: StorageWrite> IvfPqIndex<'txn, T> {
         // Clear all raw vectors.
         {
             let vn = vectors_name(&self.name);
-            let vdef = TableDefinition::<u64, &[u8]>::new(&vn);
+            let vdef = TableDefinition::<u64, &[u8]>::new_internal(&vn);
             let mut vt = self.txn.open_storage_table(vdef)?;
             vt.st_drain_all()?;
         }
@@ -761,7 +761,7 @@ impl<'txn, T: StorageWrite> IvfPqIndex<'txn, T> {
         // Clear all assignments.
         {
             let tn = assignments_name(&self.name);
-            let def = TableDefinition::<u64, u32>::new(&tn);
+            let def = TableDefinition::<u64, u32>::new_internal(&tn);
             let mut table = self.txn.open_storage_table(def)?;
             table.st_drain_all()?;
         }
@@ -781,7 +781,7 @@ impl<'txn, T: StorageWrite> IvfPqIndex<'txn, T> {
 
     fn persist_config_inner(&self) -> crate::Result<()> {
         let tn = meta_name(&self.name);
-        let def = TableDefinition::<&str, &[u8]>::new(&tn);
+        let def = TableDefinition::<&str, &[u8]>::new_internal(&tn);
         let mut table = self.txn.open_storage_table(def)?;
         let bytes = encode_index_config(&self.config);
         table.st_insert(&"config", &bytes.as_slice())?;
@@ -801,7 +801,7 @@ impl<'txn, T: StorageWrite> IvfPqIndex<'txn, T> {
         let dim = self.config.dim as usize;
         let k = self.config.num_clusters as usize;
         let tn = centroids_name(&self.name);
-        let def = TableDefinition::<u32, &[u8]>::new(&tn);
+        let def = TableDefinition::<u32, &[u8]>::new_internal(&tn);
         let table = self.txn.open_storage_table(def)?;
 
         let mut flat = Vec::with_capacity(k * dim);
@@ -844,7 +844,7 @@ impl<'txn, T: StorageWrite> IvfPqIndex<'txn, T> {
         let m = self.config.num_subvectors as usize;
         let sd = self.config.sub_dim();
         let tn = codebooks_name(&self.name);
-        let def = TableDefinition::<u32, &[u8]>::new(&tn);
+        let def = TableDefinition::<u32, &[u8]>::new_internal(&tn);
         let table = self.txn.open_storage_table(def)?;
 
         let mut data = Vec::with_capacity(m * 256 * sd);
@@ -876,7 +876,7 @@ impl<'txn, T: StorageWrite> IvfPqIndex<'txn, T> {
     ) -> crate::Result<()> {
         let dim = self.config.dim as usize;
         let tn = clusters_name(&self.name);
-        let def = TableDefinition::<u32, &[u8]>::new(&tn);
+        let def = TableDefinition::<u32, &[u8]>::new_internal(&tn);
         let mut table = self.txn.open_storage_table(def)?;
 
         let new_blob_or_empty = {
@@ -935,7 +935,7 @@ macro_rules! impl_rerank_from_vectors {
             k: usize,
         ) -> crate::Result<Vec<Neighbor<u64>>> {
             let vn = vectors_name(index_name);
-            let vdef = TableDefinition::<u64, &[u8]>::new(&vn);
+            let vdef = TableDefinition::<u64, &[u8]>::new_internal(&vn);
             let vt = txn.open_storage_table(vdef)?;
 
             // Sort by vector_id for sequential B-tree access.
@@ -991,7 +991,7 @@ impl ReadOnlyIvfPqIndex {
         let name = String::from(definition.name());
 
         let mn = meta_name(&name);
-        let md = TableDefinition::<&str, &[u8]>::new(&mn);
+        let md = TableDefinition::<&str, &[u8]>::new_internal(&mn);
         let mt = txn.open_storage_table(md)?;
 
         let config = match mt.st_get(&"config")? {
@@ -1007,7 +1007,7 @@ impl ReadOnlyIvfPqIndex {
         let num_clusters = config.num_clusters as usize;
         let centroids = {
             let tn = centroids_name(&name);
-            let def = TableDefinition::<u32, &[u8]>::new(&tn);
+            let def = TableDefinition::<u32, &[u8]>::new_internal(&tn);
             let table = txn.open_storage_table(def)?;
             let mut flat = Vec::with_capacity(num_clusters * dim);
             for c in 0..num_clusters {
@@ -1031,7 +1031,7 @@ impl ReadOnlyIvfPqIndex {
             let num_subvectors = config.num_subvectors as usize;
             let sub_dim = config.sub_dim();
             let tn = codebooks_name(&name);
-            let def = TableDefinition::<u32, &[u8]>::new(&tn);
+            let def = TableDefinition::<u32, &[u8]>::new_internal(&tn);
             let table = txn.open_storage_table(def)?;
             let mut data = Vec::with_capacity(num_subvectors * 256 * sub_dim);
             for m in 0..num_subvectors {
@@ -1123,12 +1123,12 @@ impl ReadOnlyIvfPqIndex {
 
         {
             let tn = clusters_name(&self.name);
-            let def = TableDefinition::<u32, &[u8]>::new(&tn);
+            let def = TableDefinition::<u32, &[u8]>::new_internal(&tn);
             let table = txn.open_storage_table(def)?;
 
             let meta_table = if params.filter.is_some() {
                 let mn = vector_meta_name(&self.name);
-                let mdef = TableDefinition::<u64, &[u8]>::new(&mn);
+                let mdef = TableDefinition::<u64, &[u8]>::new_internal(&mn);
                 Some(txn.open_storage_table(mdef)?)
             } else {
                 None

--- a/src/ivfpq/index.rs
+++ b/src/ivfpq/index.rs
@@ -688,17 +688,14 @@ impl<'txn, T: StorageWrite> IvfPqIndex<'txn, T> {
                     let dist = adc.to_f32(adc.approximate_distance(codes));
                     let vid = blob.vector_id(i);
 
+                    // Vectors without metadata pass the filter — absence
+                    // of metadata is not a filter match failure.
                     if let Some(ref filter) = params.filter
                         && let Some(ref mt) = meta_table
+                        && let Some(guard) = mt.st_get(&vid)?
+                        && !passes_filter(guard.value(), filter)
                     {
-                        match mt.st_get(&vid)? {
-                            Some(guard) => {
-                                if !passes_filter(guard.value(), filter) {
-                                    continue;
-                                }
-                            }
-                            None => continue,
-                        }
+                        continue;
                     }
                     heap.push(vid, dist);
                 }
@@ -1157,17 +1154,14 @@ impl ReadOnlyIvfPqIndex {
                     let dist = adc.to_f32(adc.approximate_distance(codes));
                     let vid = blob.vector_id(i);
 
+                    // Vectors without metadata pass the filter — absence
+                    // of metadata is not a filter match failure.
                     if let Some(ref filter) = params.filter
                         && let Some(ref mt) = meta_table
+                        && let Some(guard) = mt.st_get(&vid)?
+                        && !passes_filter(guard.value(), filter)
                     {
-                        match mt.st_get(&vid)? {
-                            Some(guard) => {
-                                if !passes_filter(guard.value(), filter) {
-                                    continue;
-                                }
-                            }
-                            None => continue,
-                        }
+                        continue;
                     }
                     heap.push(vid, dist);
                 }

--- a/src/ivfpq/index.rs
+++ b/src/ivfpq/index.rs
@@ -688,7 +688,7 @@ impl<'txn, T: StorageWrite> IvfPqIndex<'txn, T> {
                     let dist = adc.to_f32(adc.approximate_distance(codes));
                     let vid = blob.vector_id(i);
 
-                    // Vectors without metadata pass the filter — absence
+                    // Vectors without metadata pass the filter -- absence
                     // of metadata is not a filter match failure.
                     if let Some(ref filter) = params.filter
                         && let Some(ref mt) = meta_table
@@ -1154,7 +1154,7 @@ impl ReadOnlyIvfPqIndex {
                     let dist = adc.to_f32(adc.approximate_distance(codes));
                     let vid = blob.vector_id(i);
 
-                    // Vectors without metadata pass the filter — absence
+                    // Vectors without metadata pass the filter -- absence
                     // of metadata is not a filter match failure.
                     if let Some(ref filter) = params.filter
                         && let Some(ref mt) = meta_table

--- a/src/multimap_table.rs
+++ b/src/multimap_table.rs
@@ -998,6 +998,7 @@ impl<V: Key + 'static> DoubleEndedIterator for MultimapValue<'_, V> {
             },
             ValueIterState::InlineLeaf(iter) => iter.next_key_back()?.to_vec(),
         };
+        self.remaining -= 1;
         Some(Ok(AccessGuard::with_owned_value(bytes)))
     }
 }

--- a/src/table.rs
+++ b/src/table.rs
@@ -1017,43 +1017,37 @@ fn legacy_build_range<'a, K: Key + 'static, V: Value + 'static, T: ReadableTable
     start_inclusive: bool,
     end_inclusive: bool,
 ) -> crate::Result<Range<'a, K, V>> {
-    match (start, end) {
-        (None, None) => table.range::<K::SelfType<'_>>(..),
-        (Some(s), None) => {
-            let s_bytes = K::as_bytes(s).as_ref().to_vec();
-            let s_val = K::from_bytes(&s_bytes);
+    use core::ops::Bound;
+
+    // Hoist byte vecs so they outlive the Bound references.
+    let s_bytes = start.map(|s| K::as_bytes(s).as_ref().to_vec());
+    let e_bytes = end.map(|e| K::as_bytes(e).as_ref().to_vec());
+
+    let start_bound = match s_bytes.as_deref() {
+        Some(b) => {
+            let s_val = K::from_bytes(b);
             if start_inclusive {
-                table.range::<K::SelfType<'_>>(s_val..)
+                Bound::Included(s_val)
             } else {
-                // Exclusive start bound: start from inclusive, caller filters
-                table.range::<K::SelfType<'_>>(s_val..)
+                Bound::Excluded(s_val)
             }
         }
-        (None, Some(e)) => {
-            let e_bytes = K::as_bytes(e).as_ref().to_vec();
-            let e_val = K::from_bytes(&e_bytes);
+        None => Bound::Unbounded,
+    };
+
+    let end_bound = match e_bytes.as_deref() {
+        Some(b) => {
+            let e_val = K::from_bytes(b);
             if end_inclusive {
-                table.range::<K::SelfType<'_>>(..=e_val)
+                Bound::Included(e_val)
             } else {
-                table.range::<K::SelfType<'_>>(..e_val)
+                Bound::Excluded(e_val)
             }
         }
-        (Some(s), Some(e)) => {
-            let s_bytes = K::as_bytes(s).as_ref().to_vec();
-            let e_bytes = K::as_bytes(e).as_ref().to_vec();
-            let s_val = K::from_bytes(&s_bytes);
-            let e_val = K::from_bytes(&e_bytes);
-            if start_inclusive && end_inclusive {
-                table.range::<K::SelfType<'_>>(s_val..=e_val)
-            } else if start_inclusive {
-                table.range::<K::SelfType<'_>>(s_val..e_val)
-            } else if end_inclusive {
-                table.range::<K::SelfType<'_>>(s_val..=e_val)
-            } else {
-                table.range::<K::SelfType<'_>>(s_val..e_val)
-            }
-        }
-    }
+        None => Bound::Unbounded,
+    };
+
+    table.range::<K::SelfType<'_>>((start_bound, end_bound))
 }
 
 /// Build a `Range` from optional start/end keys for `ReadOnlyTable`.
@@ -1067,38 +1061,34 @@ fn legacy_build_range_ro<'a, K: Key + 'static, V: Value + 'static>(
     start_inclusive: bool,
     end_inclusive: bool,
 ) -> crate::Result<Range<'a, K, V>> {
-    match (start, end) {
-        (None, None) => table.range::<K::SelfType<'_>>(..),
-        (Some(s), None) => {
-            let s_bytes = K::as_bytes(s).as_ref().to_vec();
-            let s_val = K::from_bytes(&s_bytes);
-            // Note: RangeFrom is always inclusive in Rust's std. Exclusive-start
-            // semantics are handled by the caller via iterator-level filtering.
-            table.range::<K::SelfType<'_>>(s_val..)
+    use core::ops::Bound;
+
+    let s_bytes = start.map(|s| K::as_bytes(s).as_ref().to_vec());
+    let e_bytes = end.map(|e| K::as_bytes(e).as_ref().to_vec());
+
+    let start_bound = match s_bytes.as_deref() {
+        Some(b) => {
+            let s_val = K::from_bytes(b);
+            if start_inclusive {
+                Bound::Included(s_val)
+            } else {
+                Bound::Excluded(s_val)
+            }
         }
-        (None, Some(e)) => {
-            let e_bytes = K::as_bytes(e).as_ref().to_vec();
-            let e_val = K::from_bytes(&e_bytes);
+        None => Bound::Unbounded,
+    };
+
+    let end_bound = match e_bytes.as_deref() {
+        Some(b) => {
+            let e_val = K::from_bytes(b);
             if end_inclusive {
-                table.range::<K::SelfType<'_>>(..=e_val)
+                Bound::Included(e_val)
             } else {
-                table.range::<K::SelfType<'_>>(..e_val)
+                Bound::Excluded(e_val)
             }
         }
-        (Some(s), Some(e)) => {
-            let s_bytes = K::as_bytes(s).as_ref().to_vec();
-            let e_bytes = K::as_bytes(e).as_ref().to_vec();
-            let s_val = K::from_bytes(&s_bytes);
-            let e_val = K::from_bytes(&e_bytes);
-            if start_inclusive && end_inclusive {
-                table.range::<K::SelfType<'_>>(s_val..=e_val)
-            } else if start_inclusive {
-                table.range::<K::SelfType<'_>>(s_val..e_val)
-            } else if end_inclusive {
-                table.range::<K::SelfType<'_>>(s_val..=e_val)
-            } else {
-                table.range::<K::SelfType<'_>>(s_val..e_val)
-            }
-        }
-    }
+        None => Bound::Unbounded,
+    };
+
+    table.range::<K::SelfType<'_>>((start_bound, end_bound))
 }

--- a/src/transaction_tracker.rs
+++ b/src/transaction_tracker.rs
@@ -176,7 +176,7 @@ impl TransactionTracker {
 
             retries += 1;
             if retries >= MAX_SPIN_RETRIES {
-                return Err(StorageError::Corrupted(
+                return Err(StorageError::LockTimeout(
                     "Timed out waiting for write transaction lock after 1000 spin iterations"
                         .into(),
                 ));

--- a/src/transactions.rs
+++ b/src/transactions.rs
@@ -787,9 +787,19 @@ impl TableNamespace<'_> {
         }
     }
 
-    fn set_root(&mut self, root: Option<BtreeHeader>) {
-        debug_assert!(self.open_tables.is_empty());
+    fn set_root(&mut self, root: Option<BtreeHeader>) -> Result<(), StorageError> {
+        if !self.open_tables.is_empty() {
+            return Err(StorageError::Corrupted(
+                "set_root called with open tables".into(),
+            ));
+        }
+        // Clear pending table root updates accumulated by close_table() calls
+        // that occurred after the savepoint was taken. Without this, commit()
+        // would re-stage post-savepoint roots into the restored tree, producing
+        // a mix of pre- and post-savepoint state.
+        self.table_tree.clear_pending_updates();
         self.table_tree.set_root(root);
+        Ok(())
     }
 
     #[track_caller]
@@ -1331,7 +1341,7 @@ impl WriteTransaction {
 
         // 1) restore the table tree
         {
-            self.tables.lock().set_root(savepoint.get_user_root());
+            self.tables.lock().set_root(savepoint.get_user_root())?;
         }
 
         // 1a) purge all transactions that happened after the savepoint from the data freed tree
@@ -2645,8 +2655,10 @@ impl WriteTransaction {
 
             // Don't prune past the oldest cursor -- a slow consumer would
             // silently miss mutations if we deleted entries it hasn't read.
+            // Use min() so the cutoff never advances beyond what the slowest
+            // consumer has already read.
             let effective_cutoff = match oldest_cursor {
-                Some(cursor_pos) => retention_cutoff.max(cursor_pos),
+                Some(cursor_pos) => retention_cutoff.min(cursor_pos),
                 None => retention_cutoff,
             };
 

--- a/src/tree_store/page_store/buddy_allocator.rs
+++ b/src/tree_store/page_store/buddy_allocator.rs
@@ -15,6 +15,9 @@ const NUM_PAGES_OFFSET: usize = MAX_ORDER_OFFSET + size_of::<u8>() + PADDING;
 const FREE_END_OFFSETS: usize = NUM_PAGES_OFFSET + size_of::<u32>();
 
 fn calculate_usable_order(pages: u32) -> u8 {
+    if pages == 0 {
+        return 0;
+    }
     let max_order = (32 - pages.leading_zeros() - 1).try_into().unwrap();
     min(MAX_MAX_PAGE_ORDER, max_order)
 }

--- a/src/tree_store/page_store/flash_backend/ftl.rs
+++ b/src/tree_store/page_store/flash_backend/ftl.rs
@@ -741,9 +741,7 @@ impl<H: FlashHardware> FlashTranslationLayer<H> {
                 // Remove dst_rel from the free list BEFORE assign, otherwise
                 // it remains free-listed while mapped to a live logical block,
                 // causing double-allocation on the next allocate_block() call.
-                if let Some(pos) =
-                    state.block_map.free_list.iter().position(|&b| b == dst_rel)
-                {
+                if let Some(pos) = state.block_map.free_list.iter().position(|&b| b == dst_rel) {
                     state.block_map.free_list.swap_remove(pos);
                 }
                 let logical = state

--- a/src/tree_store/page_store/flash_backend/ftl.rs
+++ b/src/tree_store/page_store/flash_backend/ftl.rs
@@ -737,14 +737,22 @@ impl<H: FlashHardware> FlashTranslationLayer<H> {
                     return Ok(());
                 }
 
-                // Update the block map: remap logical block from src to dst
-                if let Some(logical) = state
+                // Update the block map: remap logical block from src to dst.
+                // Remove dst_rel from the free list BEFORE assign, otherwise
+                // it remains free-listed while mapped to a live logical block,
+                // causing double-allocation on the next allocate_block() call.
+                if let Some(pos) =
+                    state.block_map.free_list.iter().position(|&b| b == dst_rel)
+                {
+                    state.block_map.free_list.swap_remove(pos);
+                }
+                let logical = state
                     .block_map
                     .reverse
                     .get(src_rel as usize)
                     .copied()
-                    .filter(|&l| l != UNMAPPED)
-                {
+                    .filter(|&l| l != UNMAPPED);
+                if let Some(logical) = logical {
                     state.block_map.assign(logical, dst_rel);
                     state.block_map.free_list.push(src_rel);
                 }
@@ -753,13 +761,30 @@ impl<H: FlashHardware> FlashTranslationLayer<H> {
                 // crash. Without this, recovery would replay the old mapping
                 // while the physical data has already moved, causing silent
                 // data corruption.
+                //
+                // If the journal commit fails, rollback the in-memory block map
+                // to match the on-disk state. Without rollback, the in-memory
+                // map would be ahead of the persistent journal, and a subsequent
+                // power loss would cause silent data corruption.
                 let metadata = Self::serialize_metadata_inner(state);
                 let FtlState {
                     ref hw,
                     ref mut journal,
                     ..
                 } = *state;
-                journal.commit(hw, &metadata)?;
+                if let Err(e) = journal.commit(hw, &metadata) {
+                    // Rollback: undo the block map changes
+                    if let Some(logical) = logical {
+                        state.block_map.assign(logical, src_rel);
+                        if let Some(pos) =
+                            state.block_map.free_list.iter().position(|&b| b == src_rel)
+                        {
+                            state.block_map.free_list.swap_remove(pos);
+                        }
+                    }
+                    state.block_map.free_list.push(dst_rel);
+                    return Err(e);
+                }
             }
         }
 

--- a/src/tree_store/table_tree.rs
+++ b/src/tree_store/table_tree.rs
@@ -460,6 +460,10 @@ impl TableTreeMut<'_> {
             .insert(name.to_string(), (table_root, length));
     }
 
+    pub(crate) fn clear_pending_updates(&mut self) {
+        self.pending_table_updates.clear();
+    }
+
     pub(crate) fn clear_root_updates_and_close(&mut self) {
         self.pending_table_updates.clear();
         self.allocated_pages.lock().close();

--- a/src/vector_ops.rs
+++ b/src/vector_ops.rs
@@ -433,17 +433,20 @@ pub fn quantize_scalar<const N: usize>(v: &[f32; N]) -> SQVec<N> {
             codes,
         };
     }
-    if range > 0.0 {
+    if range >= f32::MIN_POSITIVE {
         let inv_range = 255.0 / range;
-        for (i, &x) in v.iter().enumerate() {
-            // Quantize to [0, 255]: value is guaranteed non-negative and <= 255.5
-            // because x is clamped within [min_val, max_val].
-            #[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
-            let q = ((x - min_val) * inv_range + 0.5) as u8;
-            codes[i] = q;
+        if inv_range.is_finite() {
+            for (i, &x) in v.iter().enumerate() {
+                // Quantize to [0, 255]: value is guaranteed non-negative and <= 255.5
+                // because x is clamped within [min_val, max_val].
+                #[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
+                let q = ((x - min_val) * inv_range + 0.5) as u8;
+                codes[i] = q;
+            }
         }
+        // else: inv_range is Inf/NaN from a subnormal range; treat as zero-range
     }
-    // If range == 0 all codes stay 0, and dequantize returns min_val for all
+    // If range < MIN_POSITIVE all codes stay 0, and dequantize returns min_val for all
 
     SQVec {
         min_val,


### PR DESCRIPTION
## Summary

Systematic codebase audit using `AUDIT_PLAYBOOK.md` identified 76 findings across 22 phases. This PR fixes the 16 most critical/high/medium findings:

**Critical (5):**
- **C1**: `compact_blobs` used non-durable `pending_blob_state` for truncation — could permanently corrupt database
- **C2**: CDC retention cutoff used `.max()` instead of `.min()` — slow consumers silently lost events
- **C3**: FTL wear-leveling didn't remove destination block from free list — double allocation
- **C4**: FTL journal commit failure left block map in inconsistent state — no rollback
- **C5**: Unsafe-guarded IVF-PQ methods were `pub` with only `debug_assert` bounds checks

**High (9):**
- **H1**: `restore_savepoint` didn't clear `pending_table_updates` — mixed pre/post-savepoint state
- **H2**: `set_root` open-tables guard was `debug_assert` only — silent corruption in release
- **H6**: `legacy_build_range` / `legacy_build_range_ro` treated exclusive start as inclusive
- **H7**: IVF-PQ filter excluded vectors without metadata instead of passing them
- **H11**: `quantize_scalar` produced `Inf` inverse range on subnormal float range
- **H14**: `MultimapValue::next_back()` didn't decrement `remaining` — wrong `len()` after reverse traversal
- **H15**: Temporal-only `CompositeQuery` without `time_range` silently returned empty
- **H22**: `calculate_usable_order(0)` caused u32 underflow panic
- **H25**: No guard on `__ivfpq:` reserved table name prefix — user tables could collide with internal index tables

**Medium (2):**
- **M6**: `no_std` spin-lock timeout returned `StorageError::Corrupted` — new `LockTimeout` variant
- **M20**: Group commit stringified `CommitError` then wrapped in `Corrupted`

## Test plan

- [x] `cargo test --lib` — 231 passed, 0 failed
- [x] `cargo clippy -- -D warnings` — clean
- [ ] CI green