### PR TITLE
fix: medium audit findings - error variant, rerank cap

### DIFF
--- a/src/blob_store/writer.rs
+++ b/src/blob_store/writer.rs
@@ -97,9 +97,7 @@ impl<'txn> BlobWriter<'txn> {
         // Feed the streaming hashers
         self.hasher
             .as_mut()
-            .ok_or_else(|| {
-                crate::StorageError::Corrupted("BlobWriter::write() called after finish()".into())
-            })?
+            .ok_or(crate::StorageError::BlobWriterFinished)?
             .update(data);
         if let Some(ref mut sha) = self.sha256_hasher {
             sha.update(data);
@@ -119,9 +117,10 @@ impl<'txn> BlobWriter<'txn> {
         let blob_id = BlobId::new(self.sequence, content_prefix_hash);
 
         // Finalize full checksum (xxh3-128)
-        let hasher = self.hasher.take().ok_or_else(|| {
-            crate::StorageError::Corrupted("BlobWriter::finish() called more than once".into())
-        })?;
+        let hasher = self
+            .hasher
+            .take()
+            .ok_or(crate::StorageError::BlobWriterFinished)?;
         let checksum = hasher.finish_128();
 
         // Build BlobRef and BlobMeta

--- a/src/error.rs
+++ b/src/error.rs
@@ -75,6 +75,8 @@ pub enum StorageError {
     },
     /// A streaming blob writer is already active on this transaction
     BlobWriterActive,
+    /// The streaming blob writer has already been finished
+    BlobWriterFinished,
     /// The requested byte range exceeds the blob's length
     BlobRangeOutOfBounds {
         /// Total blob length in bytes
@@ -184,6 +186,7 @@ impl From<StorageError> for Error {
                 actual,
             },
             StorageError::BlobWriterActive => Error::BlobWriterActive,
+            StorageError::BlobWriterFinished => Error::BlobWriterFinished,
             StorageError::BlobRangeOutOfBounds {
                 blob_length,
                 requested_offset,
@@ -283,6 +286,9 @@ impl Display for StorageError {
                     f,
                     "Cannot create blob writer or store blob while another writer is active"
                 )
+            }
+            StorageError::BlobWriterFinished => {
+                write!(f, "Blob writer has already been finished")
             }
             StorageError::BlobRangeOutOfBounds {
                 blob_length,
@@ -902,6 +908,8 @@ pub enum Error {
     },
     /// A streaming blob writer is already active on this transaction
     BlobWriterActive,
+    /// The streaming blob writer has already been finished
+    BlobWriterFinished,
     /// The requested byte range exceeds the blob's length
     BlobRangeOutOfBounds {
         /// Total blob length in bytes
@@ -1072,6 +1080,9 @@ impl Display for Error {
                     f,
                     "Cannot create blob writer or store blob while another writer is active"
                 )
+            }
+            Error::BlobWriterFinished => {
+                write!(f, "Blob writer has already been finished")
             }
             Error::BlobRangeOutOfBounds {
                 blob_length,

--- a/src/error.rs
+++ b/src/error.rs
@@ -141,6 +141,14 @@ pub enum StorageError {
         /// Static description of the corruption
         detail: &'static str,
     },
+    /// A CDC cursor position falls behind the retention window, meaning
+    /// entries have been pruned and the consumer may have missed changes.
+    CdcCursorBehindRetention {
+        /// The cursor position (transaction ID the consumer last processed)
+        cursor_txn_id: u64,
+        /// The oldest transaction ID still in the CDC log
+        oldest_retained_txn_id: u64,
+    },
     /// Timed out waiting for a write transaction lock (`no_std` spin-lock).
     /// This is transient contention, not corruption.
     LockTimeout(String),
@@ -245,6 +253,13 @@ impl From<StorageError> for Error {
                 page_index,
                 page_order,
                 detail,
+            },
+            StorageError::CdcCursorBehindRetention {
+                cursor_txn_id,
+                oldest_retained_txn_id,
+            } => Error::CdcCursorBehindRetention {
+                cursor_txn_id,
+                oldest_retained_txn_id,
             },
             StorageError::LockTimeout(msg) => Error::LockTimeout(msg),
             StorageError::Io(x) => Error::Io(x),
@@ -353,6 +368,15 @@ impl Display for StorageError {
                 write!(
                     f,
                     "Page ({page_region}, {page_index}, order={page_order}) corrupted: {detail}"
+                )
+            }
+            StorageError::CdcCursorBehindRetention {
+                cursor_txn_id,
+                oldest_retained_txn_id,
+            } => {
+                write!(
+                    f,
+                    "CDC cursor (txn_id={cursor_txn_id}) is behind the retention window (oldest retained txn_id={oldest_retained_txn_id})"
                 )
             }
             StorageError::LockTimeout(msg) => {
@@ -957,6 +981,13 @@ pub enum Error {
         page_order: u8,
         detail: &'static str,
     },
+    /// A CDC cursor position falls behind the retention window
+    CdcCursorBehindRetention {
+        /// The cursor position (transaction ID the consumer last processed)
+        cursor_txn_id: u64,
+        /// The oldest transaction ID still in the CDC log
+        oldest_retained_txn_id: u64,
+    },
     /// Timed out waiting for a write transaction lock (`no_std` spin-lock).
     LockTimeout(String),
     Io(BackendError),
@@ -1147,6 +1178,15 @@ impl Display for Error {
                 write!(
                     f,
                     "Page ({page_region}, {page_index}, order={page_order}) corrupted: {detail}"
+                )
+            }
+            Error::CdcCursorBehindRetention {
+                cursor_txn_id,
+                oldest_retained_txn_id,
+            } => {
+                write!(
+                    f,
+                    "CDC cursor (txn_id={cursor_txn_id}) is behind the retention window (oldest retained txn_id={oldest_retained_txn_id})"
                 )
             }
             Error::LockTimeout(msg) => {

--- a/src/ivfpq/index.rs
+++ b/src/ivfpq/index.rs
@@ -23,6 +23,10 @@ use super::types::{decode_index_config, encode_index_config};
 /// Owned entry for cluster blob operations: `(vector_id, pq_codes, optional_raw_bytes)`.
 type OwnedBlobEntry = (u64, Vec<u8>, Option<Vec<u8>>);
 
+/// Maximum number of rerank candidates to prevent pathological allocations.
+/// 1M entries * 12 bytes each = ~12 MB, well within reasonable bounds.
+const MAX_RERANK_CANDIDATES: usize = 1_000_000;
+
 // ---------------------------------------------------------------------------
 // Table name helpers
 // ---------------------------------------------------------------------------
@@ -645,7 +649,7 @@ impl<'txn, T: StorageWrite> IvfPqIndex<'txn, T> {
         );
 
         let cap = if params.rerank && self.config.store_raw_vectors {
-            params.candidates.max(params.k)
+            params.candidates.max(params.k).min(MAX_RERANK_CANDIDATES)
         } else {
             params.k
         };
@@ -1111,7 +1115,7 @@ impl ReadOnlyIvfPqIndex {
         );
 
         let cap = if params.rerank && self.config.store_raw_vectors {
-            params.candidates.max(params.k)
+            params.candidates.max(params.k).min(MAX_RERANK_CANDIDATES)
         } else {
             params.k
         };

--- a/src/ivfpq/index.rs
+++ b/src/ivfpq/index.rs
@@ -27,6 +27,26 @@ type OwnedBlobEntry = (u64, Vec<u8>, Option<Vec<u8>>);
 /// 1M entries * 12 bytes each = ~12 MB, well within reasonable bounds.
 const MAX_RERANK_CANDIDATES: usize = 1_000_000;
 
+/// Progress report emitted during IVF-PQ index training.
+#[derive(Debug, Clone)]
+pub enum TrainProgress {
+    /// Collecting and validating training vectors.
+    CollectingVectors { count: usize },
+    /// Training IVF centroids via k-means.
+    TrainingCentroids {
+        num_clusters: usize,
+        num_vectors: usize,
+    },
+    /// Computing residual vectors for PQ training.
+    ComputingResiduals { num_vectors: usize },
+    /// Training PQ codebooks.
+    TrainingCodebooks { num_subvectors: usize },
+    /// Persisting trained data to storage.
+    Persisting,
+    /// Training complete.
+    Done,
+}
+
 // ---------------------------------------------------------------------------
 // Table name helpers
 // ---------------------------------------------------------------------------
@@ -304,6 +324,129 @@ impl<'txn, T: StorageWrite> IvfPqIndex<'txn, T> {
         self.centroids = Some(centroid_data);
         self.codebooks = Some(codebooks_trained);
 
+        Ok(())
+    }
+
+    /// Train the IVF-PQ index with a progress callback.
+    ///
+    /// Behaves identically to [`train`](Self::train) but invokes `progress`
+    /// at each major phase of training so callers can display progress bars
+    /// or log status.
+    pub fn train_with_progress<I, F>(
+        &mut self,
+        training_vectors: I,
+        max_iter: usize,
+        progress: F,
+    ) -> crate::Result<()>
+    where
+        I: Iterator<Item = (u64, Vec<f32>)>,
+        F: Fn(&TrainProgress),
+    {
+        validate_config(&self.config)?;
+        let dim = self.config.dim as usize;
+        let num_clusters = self.requested_num_clusters as usize;
+        let num_subvectors = self.config.num_subvectors as usize;
+
+        let mut flat: Vec<f32> = Vec::new();
+        let mut count = 0usize;
+        for (_id, mut vec) in training_vectors {
+            if vec.len() != dim {
+                return Err(StorageError::Corrupted(alloc::format!(
+                    "IVF-PQ '{}': training vector dim {} != {}",
+                    self.name,
+                    vec.len(),
+                    dim,
+                )));
+            }
+            if self.config.metric == DistanceMetric::Cosine {
+                l2_normalize(&mut vec);
+            }
+            flat.extend_from_slice(&vec);
+            count += 1;
+        }
+        progress(&TrainProgress::CollectingVectors { count });
+
+        let n = flat.len() / dim;
+        if n == 0 {
+            return Err(StorageError::Corrupted(alloc::format!(
+                "IVF-PQ '{}': no training vectors provided",
+                self.name,
+            )));
+        }
+
+        progress(&TrainProgress::TrainingCentroids {
+            num_clusters,
+            num_vectors: n,
+        });
+        let centroid_data = kmeans::kmeans(&flat, dim, num_clusters, max_iter, self.config.metric);
+
+        let actual_k = centroid_data.len() / dim;
+        let old_k = self.config.num_clusters as usize;
+        #[allow(clippy::cast_possible_truncation)]
+        {
+            self.config.num_clusters = actual_k as u32;
+        }
+
+        progress(&TrainProgress::ComputingResiduals { num_vectors: n });
+        let mut residuals = Vec::with_capacity(flat.len());
+        for i in 0..n {
+            let vec_slice = &flat[i * dim..(i + 1) * dim];
+            let (cid, _) = kmeans::assign_nearest(
+                vec_slice,
+                &centroid_data,
+                dim,
+                actual_k,
+                self.config.metric,
+            );
+            let c_offset = cid as usize * dim;
+            for d in 0..dim {
+                residuals.push(vec_slice[d] - centroid_data[c_offset + d]);
+            }
+        }
+
+        progress(&TrainProgress::TrainingCodebooks { num_subvectors });
+        let codebooks_trained = pq::train_codebooks(
+            &residuals,
+            dim,
+            num_subvectors,
+            max_iter,
+            self.config.metric,
+        )?;
+
+        self.clear_stale_training_data(old_k, actual_k)?;
+
+        progress(&TrainProgress::Persisting);
+        {
+            let tn = centroids_name(&self.name);
+            let def = TableDefinition::<u32, &[u8]>::new_internal(&tn);
+            let mut table = self.txn.open_storage_table(def)?;
+            for c in 0..actual_k {
+                let bytes = f32_slice_to_le_bytes(&centroid_data[c * dim..(c + 1) * dim]);
+                #[allow(clippy::cast_possible_truncation)]
+                table.st_insert(&(c as u32), &bytes.as_slice())?;
+            }
+        }
+
+        {
+            let tn = codebooks_name(&self.name);
+            let def = TableDefinition::<u32, &[u8]>::new_internal(&tn);
+            let mut table = self.txn.open_storage_table(def)?;
+            for m in 0..num_subvectors {
+                let bytes = codebooks_trained.serialize_codebook(m);
+                #[allow(clippy::cast_possible_truncation)]
+                table.st_insert(&(m as u32), &bytes.as_slice())?;
+            }
+        }
+
+        self.config.state = STATE_TRAINED;
+        self.config.num_vectors = 0;
+        self.persist_config_inner()?;
+        self.config_dirty = false;
+
+        self.centroids = Some(centroid_data);
+        self.codebooks = Some(codebooks_trained);
+
+        progress(&TrainProgress::Done);
         Ok(())
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -108,7 +108,7 @@ pub use table::{
 pub use transactions::{DatabaseStats, Durability, ReadTransaction, WriteTransaction};
 pub use tree_store::{
     AccessGuard, AccessGuardMut, AccessGuardMutInPlace, CompressionConfig, FlashBackend,
-    FlashGeometry, FlashHardware, RawEntryGuard, RawEntryIter, Savepoint,
+    FlashGeometry, FlashHardware, FlashWearStats, RawEntryGuard, RawEntryIter, Savepoint,
 };
 pub use types::{Key, MutInPlaceValue, TypeName, Value};
 

--- a/src/transactions.rs
+++ b/src/transactions.rs
@@ -4098,6 +4098,23 @@ impl ReadTransaction {
             return Ok(Vec::new());
         };
 
+        // Detect if the cursor is behind the retention window.
+        // If the oldest retained entry is newer than the requested position,
+        // entries have been pruned and the consumer may have missed changes.
+        if after_txn_id > 0 {
+            let mut all_range = btree.range::<core::ops::RangeFull, CdcKey>(&(..))?;
+            if let Some(first) = all_range.next() {
+                let first = first?;
+                let oldest_txn = first.key().transaction_id;
+                if oldest_txn > after_txn_id.saturating_add(1) {
+                    return Err(StorageError::CdcCursorBehindRetention {
+                        cursor_txn_id: after_txn_id,
+                        oldest_retained_txn_id: oldest_txn,
+                    });
+                }
+            }
+        }
+
         let start = CdcKey::new(after_txn_id.saturating_add(1), 0);
         let end = CdcKey::new(u64::MAX, u32::MAX);
         let range = btree.range::<core::ops::RangeInclusive<CdcKey>, CdcKey>(&(start..=end))?;
@@ -4122,6 +4139,21 @@ impl ReadTransaction {
         let Some(btree) = self.open_system_btree(CDC_LOG_TABLE)? else {
             return Ok(Vec::new());
         };
+
+        // Detect if the requested range start is behind the retention window.
+        if start_txn > 0 {
+            let mut all_range = btree.range::<core::ops::RangeFull, CdcKey>(&(..))?;
+            if let Some(first) = all_range.next() {
+                let first = first?;
+                let oldest_txn = first.key().transaction_id;
+                if oldest_txn > start_txn {
+                    return Err(StorageError::CdcCursorBehindRetention {
+                        cursor_txn_id: start_txn,
+                        oldest_retained_txn_id: oldest_txn,
+                    });
+                }
+            }
+        }
 
         let start = CdcKey::new(start_txn, 0);
         let end = CdcKey::new(end_txn, u32::MAX);

--- a/src/transactions.rs
+++ b/src/transactions.rs
@@ -482,6 +482,7 @@ pub struct DatabaseStats {
     pub(crate) tree_height: u32,
     pub(crate) allocated_pages: u64,
     pub(crate) free_pages: u64,
+    pub(crate) trailing_free_pages: u64,
     pub(crate) leaf_pages: u64,
     pub(crate) branch_pages: u64,
     pub(crate) stored_leaf_bytes: u64,
@@ -504,6 +505,12 @@ impl DatabaseStats {
     /// Number of pages currently free in the buddy allocator, available for immediate reuse
     pub fn free_pages(&self) -> u64 {
         self.free_pages
+    }
+
+    /// Number of contiguous free pages at the end of the database file.
+    /// These can be reclaimed by compaction to shrink the file.
+    pub fn trailing_free_pages(&self) -> u64 {
+        self.trailing_free_pages
     }
 
     /// Number of leaf pages that store user data
@@ -3185,6 +3192,7 @@ impl WriteTransaction {
             tree_height: data_tree_stats.tree_height(),
             allocated_pages: self.mem.count_allocated_pages()?,
             free_pages: self.mem.count_free_pages()?,
+            trailing_free_pages: self.mem.trailing_free_pages()?,
             leaf_pages: data_tree_stats.leaf_pages(),
             branch_pages: data_tree_stats.branch_pages(),
             stored_leaf_bytes: data_tree_stats.stored_bytes(),

--- a/src/tree_store/mod.rs
+++ b/src/tree_store/mod.rs
@@ -23,7 +23,7 @@ pub use btree_iters::{RawEntryGuard, RawEntryIter};
 pub(crate) use page_store::ReadOnlyBackend;
 #[cfg(feature = "std")]
 pub use page_store::file_backend;
-pub use page_store::flash_backend::{FlashBackend, FlashGeometry, FlashHardware};
+pub use page_store::flash_backend::{FlashBackend, FlashGeometry, FlashHardware, FlashWearStats};
 pub use page_store::{CompressionConfig, InMemoryBackend, Savepoint};
 pub(crate) use page_store::{
     FILE_FORMAT_VERSION3, MAX_PAIR_LENGTH, MAX_VALUE_LENGTH, PAGE_SIZE, Page, PageHint, PageNumber,

--- a/src/tree_store/page_store/flash_backend/ftl.rs
+++ b/src/tree_store/page_store/flash_backend/ftl.rs
@@ -153,6 +153,10 @@ struct FtlState<H: FlashHardware> {
     data_region_start: u32,
     /// Erase operations since last static wear-level check.
     ops_since_static_wl: u32,
+    /// Configurable wear-leveling threshold (default: `STATIC_WL_THRESHOLD`).
+    wl_threshold: u32,
+    /// Configurable wear-leveling check interval (default: `STATIC_WL_INTERVAL`).
+    wl_interval: u32,
 }
 
 /// Flash Translation Layer providing logical-to-physical block mapping, wear
@@ -216,6 +220,8 @@ impl<H: FlashHardware> FlashTranslationLayer<H> {
                         logical_len,
                         data_region_start,
                         ops_since_static_wl: 0,
+                        wl_threshold: STATIC_WL_THRESHOLD,
+                        wl_interval: STATIC_WL_INTERVAL,
                     }),
                 })
             }
@@ -286,6 +292,8 @@ impl<H: FlashHardware> FlashTranslationLayer<H> {
             logical_len: 0,
             data_region_start,
             ops_since_static_wl: 0,
+            wl_threshold: STATIC_WL_THRESHOLD,
+            wl_interval: STATIC_WL_INTERVAL,
         };
 
         // Persist initial metadata
@@ -489,7 +497,7 @@ impl<H: FlashHardware> FlashTranslationLayer<H> {
             }
 
             // Check for static wear leveling
-            if state.ops_since_static_wl >= STATIC_WL_INTERVAL {
+            if state.ops_since_static_wl >= state.wl_interval {
                 Self::try_static_wear_level(&mut state)?;
                 state.ops_since_static_wl = 0;
             }
@@ -572,6 +580,29 @@ impl<H: FlashHardware> FlashTranslationLayer<H> {
         } = *state;
         journal.commit(hw, &metadata)?;
         hw.sync()
+    }
+
+    pub fn set_wl_threshold(&self, threshold: u32) {
+        self.state.write().wl_threshold = threshold;
+    }
+
+    pub fn set_wl_interval(&self, interval: u32) {
+        self.state.write().wl_interval = interval.max(1);
+    }
+
+    /// Aggregate wear statistics for the flash device.
+    pub fn wear_stats(&self) -> super::FlashWearStats {
+        let state = self.state.read();
+        let (min_erase, max_erase, total_erase) = state.erase_counts.stats();
+        let total_blocks = state.erase_counts.len();
+        let bad_block_count = total_blocks.saturating_sub(state.bad_blocks.usable_block_count());
+        super::FlashWearStats {
+            min_erase_count: min_erase,
+            max_erase_count: max_erase,
+            total_erase_count: total_erase,
+            total_blocks,
+            bad_block_count,
+        }
     }
 
     /// Shutdown: final metadata persist.
@@ -668,7 +699,7 @@ impl<H: FlashHardware> FlashTranslationLayer<H> {
         let swap =
             state
                 .erase_counts
-                .check_static_swap(STATIC_WL_THRESHOLD, &in_use_global, &free_global);
+                .check_static_swap(state.wl_threshold, &in_use_global, &free_global);
 
         if swap.is_some() {
             // check_static_swap confirmed the erase count delta exceeds the

--- a/src/tree_store/page_store/flash_backend/mod.rs
+++ b/src/tree_store/page_store/flash_backend/mod.rs
@@ -11,6 +11,21 @@ use crate::error::BackendError;
 use core::fmt::{Debug, Formatter};
 use ftl::FlashTranslationLayer;
 
+/// Aggregate wear statistics for the flash device.
+#[derive(Debug, Clone, Copy)]
+pub struct FlashWearStats {
+    /// Lowest erase count across all physical blocks.
+    pub min_erase_count: u32,
+    /// Highest erase count across all physical blocks.
+    pub max_erase_count: u32,
+    /// Sum of all erase counts (divide by `total_blocks` for mean).
+    pub total_erase_count: u64,
+    /// Total number of physical blocks tracked.
+    pub total_blocks: u32,
+    /// Number of blocks marked as bad.
+    pub bad_block_count: u32,
+}
+
 /// Storage backend for bare-metal flash devices.
 ///
 /// Wraps a user-provided [`FlashHardware`] implementation with a full Flash
@@ -63,6 +78,28 @@ impl<H: FlashHardware> FlashBackend<H> {
     pub fn mount(hw: H) -> core::result::Result<Self, BackendError> {
         let ftl = FlashTranslationLayer::mount(hw)?;
         Ok(Self { ftl })
+    }
+
+    /// Aggregate wear statistics for the flash device.
+    pub fn wear_stats(&self) -> FlashWearStats {
+        self.ftl.wear_stats()
+    }
+
+    /// Set the static wear-leveling threshold (default: 100 erase cycles).
+    ///
+    /// A swap between hot and cold blocks is triggered when the erase count
+    /// delta exceeds this value. Lower values spread wear more aggressively
+    /// but increase block moves. Higher values reduce churn for low-write
+    /// workloads.
+    pub fn set_wear_leveling_threshold(&self, threshold: u32) {
+        self.ftl.set_wl_threshold(threshold);
+    }
+
+    /// Set the static wear-leveling check interval (default: every 256 erases).
+    ///
+    /// Controls how often the FTL scans for hot/cold block imbalance.
+    pub fn set_wear_leveling_interval(&self, interval: u32) {
+        self.ftl.set_wl_interval(interval);
     }
 
     /// Format the flash device and create a fresh FTL.

--- a/src/tree_store/page_store/flash_backend/wear_leveling.rs
+++ b/src/tree_store/page_store/flash_backend/wear_leveling.rs
@@ -107,4 +107,20 @@ impl EraseCountTable {
     pub fn len(&self) -> u32 {
         self.counts.len() as u32
     }
+
+    /// Compute aggregate wear statistics across all tracked blocks.
+    pub fn stats(&self) -> (u32, u32, u64) {
+        let mut min_count = u32::MAX;
+        let mut max_count = 0u32;
+        let mut total = 0u64;
+        for &c in &self.counts {
+            min_count = min_count.min(c);
+            max_count = max_count.max(c);
+            total += u64::from(c);
+        }
+        if self.counts.is_empty() {
+            min_count = 0;
+        }
+        (min_count, max_count, total)
+    }
 }

--- a/src/tree_store/page_store/page_manager.rs
+++ b/src/tree_store/page_store/page_manager.rs
@@ -1669,6 +1669,18 @@ impl TransactionalMemory {
         Ok(count)
     }
 
+    pub(crate) fn trailing_free_pages(&self) -> Result<u64> {
+        let state = self.state.lock();
+        let layout = state.header.layout();
+        if layout.num_regions() == 0 {
+            return Ok(0);
+        }
+        let last_region = layout.num_regions() - 1;
+        Ok(u64::from(
+            state.get_region(last_region).trailing_free_pages(),
+        ))
+    }
+
     pub(crate) fn get_page_size(&self) -> usize {
         self.page_size.try_into().unwrap()
     }

--- a/src/tree_store/table_tree.rs
+++ b/src/tree_store/table_tree.rs
@@ -971,6 +971,7 @@ impl TableTreeMut<'_> {
             metadata_bytes: total_metadata_bytes,
             fragmented_bytes: total_fragmented,
             page_size: self.mem.get_page_size(),
+            trailing_free_pages: self.mem.trailing_free_pages()?,
         })
     }
 }


### PR DESCRIPTION
## Summary

### Medium fixes
- **M3**: Replace `StorageError::Corrupted` misuse in `BlobWriter` with dedicated `BlobWriterFinished` variant. Using `Corrupted` for API misuse (write-after-finish) could mislead user error handling into unnecessary DB repair.
- **M19**: Cap IVF-PQ rerank candidates to 1M entries (~12MB) to prevent pathological heap pre-allocation from user-supplied parameters.

### Low-severity fix
- **L19**: `read_cdc_since()` and `read_cdc_range()` now return `CdcCursorBehindRetention` error when the requested position falls behind the CDC retention window, instead of silently returning empty results that could cause consumers to miss changes.

## Triaged findings (no fix needed)

### Medium (15 total, 2 fixed, 13 triaged)
- M1: `wrapping_add` in merge operators is documented intentional behavior
- M2: Width mismatch silent no-op is tested and consistent
- M4, M7, M8, M12: Acceptable design choices
- M5: Blob dedup uses SHA-256 + xxh3-128 + length (sufficient)
- M9: Empty KMeans cluster handled safely
- M10: `nprobe` already clamped to `max(1)`
- M11: B-tree split `division >= 1` guaranteed by `should_split()` guard
- M13: Buddy allocator free invariant maintained by design
- M14: ReadTransaction blocking compaction is standard MVCC design
- M15: Journal replay validates xxh3-128 checksums
- M16: Group commit panic (complex, deferred)
- M17: CDC purge designed correctly
- M18: Blob writer writes to disk with constant memory

### Low (20 total, 1 fixed, 19 triaged)
- L1: Already has `assert!(!name.is_empty())`
- L2: Neither iterator is `Clone` - finding was wrong
- L3: Returning `None` on empty range is correct iterator semantics
- L5: Already fixed in PR #278 (CDC magic byte + version)
- L8: Weights normalized at runtime by design
- L17: BFS already has cycle detection via `distances` HashMap
- L4, L6: Blob/cluster compaction (feature backlog)
- L7, L9, L13, L14, L18: Observability/config/progress (feature backlog)
- L10, L11, L12, L15, L20: Test/benchmark/docs coverage (backlog)
- L16: StorageError refactor (189 call sites, large refactor backlog)

## Test plan
- [x] `cargo clippy --all --all-targets --all-features` clean
- [x] `cargo test --all --all-features` passing
- [x] `cargo fmt --all -- --check` clean