### PR TITLE
fix: eliminate panic-on-corruption in allocator deserialization

### DIFF
--- a/src/tree_store/page_store/bitmap.rs
+++ b/src/tree_store/page_store/bitmap.rs
@@ -92,11 +92,18 @@ impl BtreeBitmap {
         result
     }
 
-    pub(crate) fn from_bytes(data: &[u8]) -> Self {
+    pub(crate) fn from_bytes(data: &[u8]) -> Result<Self, crate::StorageError> {
+        if data.len() < HEIGHT_OFFSET + size_of::<u32>() {
+            return Err(crate::StorageError::Corrupted(
+                "BtreeBitmap: buffer too small for header".into(),
+            ));
+        }
         let height = u32::from_le_bytes(
             data[HEIGHT_OFFSET..(HEIGHT_OFFSET + size_of::<u32>())]
                 .try_into()
-                .unwrap(),
+                .map_err(|_| {
+                    crate::StorageError::Corrupted("BtreeBitmap: failed to read height".into())
+                })?,
         );
 
         let mut metadata = END_OFFSETS;
@@ -104,17 +111,29 @@ impl BtreeBitmap {
 
         let mut heights = vec![];
         for _ in 0..height {
+            if metadata + size_of::<u32>() > data.len() {
+                return Err(crate::StorageError::Corrupted(
+                    "BtreeBitmap: truncated offset table".into(),
+                ));
+            }
             let data_end = u32::from_le_bytes(
                 data[metadata..(metadata + size_of::<u32>())]
                     .try_into()
-                    .unwrap(),
+                    .map_err(|_| {
+                        crate::StorageError::Corrupted("BtreeBitmap: failed to read offset".into())
+                    })?,
             ) as usize;
-            heights.push(U64GroupedBitmap::from_bytes(&data[data_start..data_end]));
+            if data_end > data.len() || data_start > data_end {
+                return Err(crate::StorageError::Corrupted(
+                    "BtreeBitmap: offset out of bounds".into(),
+                ));
+            }
+            heights.push(U64GroupedBitmap::from_bytes(&data[data_start..data_end])?);
             data_start = data_end;
             metadata += size_of::<u32>();
         }
 
-        Self { heights }
+        Ok(Self { heights })
     }
 
     // Initializes a new allocator, with no ids free
@@ -268,22 +287,37 @@ impl U64GroupedBitmap {
         result
     }
 
-    pub fn from_bytes(serialized: &[u8]) -> Self {
-        assert_eq!(0, (serialized.len() - size_of::<u32>()) % size_of::<u64>());
-        let mut data = vec![];
-        let len = u32::from_le_bytes(serialized[..size_of::<u32>()].try_into().unwrap());
+    pub fn from_bytes(serialized: &[u8]) -> Result<Self, crate::StorageError> {
+        if serialized.len() < size_of::<u32>() {
+            return Err(crate::StorageError::Corrupted(
+                "U64GroupedBitmap: buffer too small for header".into(),
+            ));
+        }
+        if (serialized.len() - size_of::<u32>()) % size_of::<u64>() != 0 {
+            return Err(crate::StorageError::Corrupted(
+                "U64GroupedBitmap: buffer size not aligned to u64".into(),
+            ));
+        }
+        let len = u32::from_le_bytes(serialized[..size_of::<u32>()].try_into().map_err(|_| {
+            crate::StorageError::Corrupted("U64GroupedBitmap: failed to read length".into())
+        })?);
         let words = (serialized.len() - size_of::<u32>()) / size_of::<u64>();
+        let mut data = Vec::with_capacity(words);
         for i in 0..words {
             let start = size_of::<u32>() + i * size_of::<u64>();
             let value = u64::from_le_bytes(
                 serialized[start..(start + size_of::<u64>())]
                     .try_into()
-                    .unwrap(),
+                    .map_err(|_| {
+                        crate::StorageError::Corrupted(
+                            "U64GroupedBitmap: failed to read word".into(),
+                        )
+                    })?,
             );
             data.push(value);
         }
 
-        Self { len, data }
+        Ok(Self { len, data })
     }
 
     fn data_index_of(bit: u32) -> (usize, usize) {

--- a/src/tree_store/page_store/buddy_allocator.rs
+++ b/src/tree_store/page_store/buddy_allocator.rs
@@ -108,12 +108,21 @@ impl BuddyAllocator {
         result
     }
 
-    pub(crate) fn from_bytes(data: &[u8]) -> Self {
+    pub(crate) fn from_bytes(data: &[u8]) -> Result<Self, crate::StorageError> {
+        if data.len() < FREE_END_OFFSETS {
+            return Err(crate::StorageError::Corrupted(
+                "BuddyAllocator: buffer too small for header".into(),
+            ));
+        }
         let max_order = data[MAX_ORDER_OFFSET];
         let num_pages = u32::from_le_bytes(
             data[NUM_PAGES_OFFSET..(NUM_PAGES_OFFSET + size_of::<u32>())]
                 .try_into()
-                .unwrap(),
+                .map_err(|_| {
+                    crate::StorageError::Corrupted(
+                        "BuddyAllocator: failed to read num_pages".into(),
+                    )
+                })?,
         );
 
         let mut metadata = FREE_END_OFFSETS;
@@ -121,21 +130,35 @@ impl BuddyAllocator {
 
         let mut free = vec![];
         for _ in 0..=max_order {
+            if metadata + size_of::<u32>() > data.len() {
+                return Err(crate::StorageError::Corrupted(
+                    "BuddyAllocator: truncated offset table".into(),
+                ));
+            }
             let data_end = u32::from_le_bytes(
                 data[metadata..(metadata + size_of::<u32>())]
                     .try_into()
-                    .unwrap(),
+                    .map_err(|_| {
+                        crate::StorageError::Corrupted(
+                            "BuddyAllocator: failed to read offset".into(),
+                        )
+                    })?,
             ) as usize;
-            free.push(BtreeBitmap::from_bytes(&data[data_start..data_end]));
+            if data_end > data.len() || data_start > data_end {
+                return Err(crate::StorageError::Corrupted(
+                    "BuddyAllocator: offset out of bounds".into(),
+                ));
+            }
+            free.push(BtreeBitmap::from_bytes(&data[data_start..data_end])?);
             data_start = data_end;
             metadata += size_of::<u32>();
         }
 
-        Self {
+        Ok(Self {
             free,
             len: num_pages,
             max_order,
-        }
+        })
     }
 
     #[inline]

--- a/src/tree_store/page_store/page_manager.rs
+++ b/src/tree_store/page_store/page_manager.rs
@@ -940,14 +940,16 @@ impl TransactionalMemory {
         for region in
             tree.range(&(AllocatorStateKey::Region(0)..=AllocatorStateKey::Region(u32::MAX)))?
         {
-            region_allocators.push(BuddyAllocator::from_bytes(region?.value()));
+            region_allocators.push(BuddyAllocator::from_bytes(region?.value())?);
         }
 
         let region_tracker = RegionTracker::from_bytes(
             tree.get(&AllocatorStateKey::RegionTracker)?
-                .unwrap()
+                .ok_or_else(|| {
+                    StorageError::Corrupted("Missing RegionTracker entry in allocator state".into())
+                })?
                 .value(),
-        );
+        )?;
 
         let mut state = self.state.lock();
         state.allocators = Allocators {

--- a/src/tree_store/page_store/region.rs
+++ b/src/tree_store/page_store/region.rs
@@ -47,28 +47,50 @@ impl RegionTracker {
         result
     }
 
-    pub(super) fn from_bytes(page: &[u8]) -> Self {
-        let orders = u32::from_le_bytes(page[..size_of::<u32>()].try_into().unwrap());
+    pub(super) fn from_bytes(page: &[u8]) -> Result<Self, crate::StorageError> {
+        if page.len() < size_of::<u32>() {
+            return Err(crate::StorageError::Corrupted(
+                "RegionTracker: buffer too small for header".into(),
+            ));
+        }
+        let orders = u32::from_le_bytes(page[..size_of::<u32>()].try_into().map_err(|_| {
+            crate::StorageError::Corrupted("RegionTracker: failed to read order count".into())
+        })?);
         let mut start = size_of::<u32>();
         let mut allocator_lens = vec![];
         for _ in 0..orders {
+            if start + size_of::<u32>() > page.len() {
+                return Err(crate::StorageError::Corrupted(
+                    "RegionTracker: truncated allocator length table".into(),
+                ));
+            }
             let allocator_len =
-                u32::from_le_bytes(page[start..start + size_of::<u32>()].try_into().unwrap())
-                    as usize;
+                u32::from_le_bytes(page[start..start + size_of::<u32>()].try_into().map_err(
+                    |_| {
+                        crate::StorageError::Corrupted(
+                            "RegionTracker: failed to read allocator length".into(),
+                        )
+                    },
+                )?) as usize;
             allocator_lens.push(allocator_len);
             start += size_of::<u32>();
         }
         let mut data = vec![];
         for allocator_len in allocator_lens {
+            if start + allocator_len > page.len() {
+                return Err(crate::StorageError::Corrupted(
+                    "RegionTracker: allocator data extends beyond buffer".into(),
+                ));
+            }
             data.push(BtreeBitmap::from_bytes(
                 &page[start..(start + allocator_len)],
-            ));
+            )?);
             start += allocator_len;
         }
 
-        Self {
+        Ok(Self {
             order_trackers: data,
-        }
+        })
     }
 
     pub(crate) fn find_free(&self, order: u8) -> Option<u32> {


### PR DESCRIPTION
## Summary
- Change `from_bytes()` in 4 allocator types from panicking to returning `Result<Self, StorageError>`
- `U64GroupedBitmap::from_bytes()` — validates buffer size and alignment
- `BtreeBitmap::from_bytes()` — validates height, offsets, bounds
- `BuddyAllocator::from_bytes()` — validates header and free list offsets
- `RegionTracker::from_bytes()` — validates order count and allocator lengths
- Fix `.unwrap()` on missing `RegionTracker` entry in `load_allocator_state()`

## Context
Depends on #281 (typed errors) -> #280 (error variants).

Previously, corrupted allocator state (e.g., from a power loss during commit) would crash the process with a panic. Now it returns a descriptive `StorageError::Corrupted` allowing graceful error handling.

## Test plan
- [x] `cargo clippy -- -D warnings` clean
- [x] `cargo fmt --all -- --check` clean
- [x] Full test suite: 1,432 tests pass (0 failures)
- All callers already returned `Result` — mechanical `?` propagation