### PR TITLE
refactor: reclassify Corrupted catch-all to typed error variants

### DIFF
--- a/src/cdc/types.rs
+++ b/src/cdc/types.rs
@@ -48,7 +48,7 @@ impl ChangeOp {
             0 => Ok(Self::Insert),
             1 => Ok(Self::Update),
             2 => Ok(Self::Delete),
-            other => Err(StorageError::Corrupted(format!(
+            other => Err(StorageError::format_error(format!(
                 "invalid ChangeOp discriminant byte: {other}"
             ))),
         }
@@ -237,13 +237,13 @@ impl fmt::Debug for CdcRecord {
 impl CdcRecord {
     pub fn from_event(event: &CdcEvent) -> Result<Self, StorageError> {
         if u16::try_from(event.table_name.len()).is_err() {
-            return Err(StorageError::Corrupted(format!(
+            return Err(StorageError::format_error(format!(
                 "CDC table_name exceeds u16::MAX bytes ({})",
                 event.table_name.len()
             )));
         }
         if event.key.len() >= NONE_SENTINEL as usize {
-            return Err(StorageError::Corrupted(format!(
+            return Err(StorageError::format_error(format!(
                 "CDC key exceeds maximum serializable length ({})",
                 event.key.len()
             )));
@@ -253,7 +253,7 @@ impl CdcRecord {
             .as_ref()
             .is_some_and(|v| v.len() >= NONE_SENTINEL as usize)
         {
-            return Err(StorageError::Corrupted(format!(
+            return Err(StorageError::format_error(format!(
                 "CDC new_value exceeds maximum serializable length ({})",
                 event.new_value.as_ref().unwrap().len()
             )));
@@ -263,7 +263,7 @@ impl CdcRecord {
             .as_ref()
             .is_some_and(|v| v.len() >= NONE_SENTINEL as usize)
         {
-            return Err(StorageError::Corrupted(format!(
+            return Err(StorageError::format_error(format!(
                 "CDC old_value exceeds maximum serializable length ({})",
                 event.old_value.as_ref().unwrap().len()
             )));
@@ -330,7 +330,7 @@ impl CdcRecord {
         let mut pos = 0;
 
         if data.is_empty() {
-            return Err(StorageError::Corrupted("CDC record is empty".into()));
+            return Err(StorageError::format_error("CDC record is empty"));
         }
 
         // Detect format: if first byte is the magic, this is a versioned
@@ -339,37 +339,37 @@ impl CdcRecord {
         if data[pos] == CDC_FORMAT_MAGIC {
             pos += 1; // skip magic
             if pos >= data.len() {
-                return Err(StorageError::Corrupted(
-                    "CDC record truncated at version byte".into(),
+                return Err(StorageError::format_error(
+                    "CDC record truncated at version byte",
                 ));
             }
             let version = data[pos];
             pos += 1;
             if version != CDC_FORMAT_VERSION {
-                return Err(StorageError::Corrupted(format!(
+                return Err(StorageError::format_error(format!(
                     "unsupported CDC record version {version} (expected {CDC_FORMAT_VERSION})"
                 )));
             }
         }
 
         if pos >= data.len() {
-            return Err(StorageError::Corrupted(
-                "CDC record truncated at op byte".into(),
+            return Err(StorageError::format_error(
+                "CDC record truncated at op byte",
             ));
         }
         let op = ChangeOp::from_u8(data[pos])?;
         pos += 1;
 
         if pos + 2 > data.len() {
-            return Err(StorageError::Corrupted(
-                "CDC record truncated at table name length".into(),
+            return Err(StorageError::format_error(
+                "CDC record truncated at table name length",
             ));
         }
         let name_len = u16::from_le_bytes(data[pos..pos + 2].try_into().unwrap());
         pos += 2;
         if pos + usize::from(name_len) > data.len() {
-            return Err(StorageError::Corrupted(
-                "CDC record truncated at table name".into(),
+            return Err(StorageError::format_error(
+                "CDC record truncated at table name",
             ));
         }
         let table_name =
@@ -377,23 +377,23 @@ impl CdcRecord {
         pos += usize::from(name_len);
 
         if pos + 4 > data.len() {
-            return Err(StorageError::Corrupted(
-                "CDC record truncated at key length".into(),
+            return Err(StorageError::format_error(
+                "CDC record truncated at key length",
             ));
         }
         let key_len = u32::from_le_bytes(data[pos..pos + 4].try_into().unwrap());
         pos += 4;
         if pos + key_len as usize > data.len() {
-            return Err(StorageError::Corrupted(
-                "CDC record truncated at key data".into(),
+            return Err(StorageError::format_error(
+                "CDC record truncated at key data",
             ));
         }
         let key = data[pos..pos + key_len as usize].to_vec();
         pos += key_len as usize;
 
         if pos + 4 > data.len() {
-            return Err(StorageError::Corrupted(
-                "CDC record truncated at new value length".into(),
+            return Err(StorageError::format_error(
+                "CDC record truncated at new value length",
             ));
         }
         let new_val_len = u32::from_le_bytes(data[pos..pos + 4].try_into().unwrap());
@@ -402,8 +402,8 @@ impl CdcRecord {
             None
         } else {
             if pos + new_val_len as usize > data.len() {
-                return Err(StorageError::Corrupted(
-                    "CDC record truncated at new value data".into(),
+                return Err(StorageError::format_error(
+                    "CDC record truncated at new value data",
                 ));
             }
             let v = data[pos..pos + new_val_len as usize].to_vec();
@@ -412,8 +412,8 @@ impl CdcRecord {
         };
 
         if pos + 4 > data.len() {
-            return Err(StorageError::Corrupted(
-                "CDC record truncated at old value length".into(),
+            return Err(StorageError::format_error(
+                "CDC record truncated at old value length",
             ));
         }
         let old_val_len = u32::from_le_bytes(data[pos..pos + 4].try_into().unwrap());
@@ -422,8 +422,8 @@ impl CdcRecord {
             None
         } else {
             if pos + old_val_len as usize > data.len() {
-                return Err(StorageError::Corrupted(
-                    "CDC record truncated at old value data".into(),
+                return Err(StorageError::format_error(
+                    "CDC record truncated at old value data",
                 ));
             }
             let v = data[pos..pos + old_val_len as usize].to_vec();
@@ -631,10 +631,10 @@ mod tests {
     fn cdc_change_op_invalid_discriminant() {
         let err = ChangeOp::from_u8(255).unwrap_err();
         match err {
-            crate::error::StorageError::Corrupted(msg) => {
-                assert!(msg.contains("invalid ChangeOp discriminant"));
+            crate::error::StorageError::FormatError { detail } => {
+                assert!(detail.contains("invalid ChangeOp discriminant"));
             }
-            other => panic!("expected StorageError::Corrupted, got: {other:?}"),
+            other => panic!("expected StorageError::FormatError, got: {other:?}"),
         }
     }
 
@@ -642,10 +642,10 @@ mod tests {
     fn cdc_record_deserialize_empty_data() {
         let err = CdcRecord::deserialize(&[]).unwrap_err();
         match err {
-            crate::error::StorageError::Corrupted(msg) => {
-                assert!(msg.contains("empty"));
+            crate::error::StorageError::FormatError { detail } => {
+                assert!(detail.contains("empty"));
             }
-            other => panic!("expected StorageError::Corrupted, got: {other:?}"),
+            other => panic!("expected StorageError::FormatError, got: {other:?}"),
         }
     }
 
@@ -663,10 +663,10 @@ mod tests {
         bytes[0] = 99;
         let err = CdcRecord::deserialize(&bytes).unwrap_err();
         match err {
-            crate::error::StorageError::Corrupted(msg) => {
-                assert!(msg.contains("invalid ChangeOp discriminant"));
+            crate::error::StorageError::FormatError { detail } => {
+                assert!(detail.contains("invalid ChangeOp discriminant"));
             }
-            other => panic!("expected StorageError::Corrupted, got: {other:?}"),
+            other => panic!("expected StorageError::FormatError, got: {other:?}"),
         }
     }
 }

--- a/src/db.rs
+++ b/src/db.rs
@@ -3041,7 +3041,7 @@ mod test {
         let err = Database::builder().open(tmpfile.path()).unwrap_err();
 
         match err {
-            DatabaseError::Storage(StorageError::Corrupted(_)) => {}
+            DatabaseError::Storage(StorageError::FormatError { .. }) => {}
             err => panic!("Unexpected error for empty file: {err}"),
         }
     }

--- a/src/error.rs
+++ b/src/error.rs
@@ -532,6 +532,42 @@ impl StorageError {
             detail,
         }
     }
+
+    pub(crate) fn invalid_config(message: impl Into<String>) -> Self {
+        StorageError::InvalidConfiguration {
+            message: message.into(),
+        }
+    }
+
+    pub(crate) fn index_not_trained(index_name: impl Into<String>) -> Self {
+        StorageError::IndexNotTrained {
+            index_name: index_name.into(),
+        }
+    }
+
+    pub(crate) fn dimension_mismatch(
+        index_name: impl Into<String>,
+        expected: usize,
+        actual: usize,
+    ) -> Self {
+        StorageError::DimensionMismatch {
+            index_name: index_name.into(),
+            expected,
+            actual,
+        }
+    }
+
+    pub(crate) fn invalid_index_config(detail: impl Into<String>) -> Self {
+        StorageError::InvalidIndexConfig {
+            detail: detail.into(),
+        }
+    }
+
+    pub(crate) fn format_error(detail: impl Into<String>) -> Self {
+        StorageError::FormatError {
+            detail: detail.into(),
+        }
+    }
 }
 
 /// Errors related to opening tables

--- a/src/ivfpq/cluster_blob.rs
+++ b/src/ivfpq/cluster_blob.rs
@@ -180,7 +180,7 @@ impl<'a> ClusterBlobRef<'a> {
     /// `dim` is the vector dimensionality (needed to validate raw vector sizes).
     pub fn new(data: &'a [u8], expected_pq_len: u16, dim: usize) -> crate::Result<Self> {
         if data.len() < HEADER_SIZE {
-            return Err(StorageError::Corrupted(alloc::format!(
+            return Err(StorageError::format_error(alloc::format!(
                 "cluster blob too small: {} < {HEADER_SIZE}",
                 data.len()
             )));
@@ -188,14 +188,14 @@ impl<'a> ClusterBlobRef<'a> {
 
         let magic = u32::from_le_bytes([data[0], data[1], data[2], data[3]]);
         if magic != MAGIC {
-            return Err(StorageError::Corrupted(alloc::format!(
+            return Err(StorageError::format_error(alloc::format!(
                 "cluster blob bad magic: {magic:#010x}"
             )));
         }
 
         let version = u32::from_le_bytes([data[4], data[5], data[6], data[7]]);
         if version != VERSION {
-            return Err(StorageError::Corrupted(alloc::format!(
+            return Err(StorageError::format_error(alloc::format!(
                 "cluster blob version {version} != {VERSION}"
             )));
         }
@@ -206,7 +206,7 @@ impl<'a> ClusterBlobRef<'a> {
         let has_raw = flags & FLAG_HAS_RAW_VECTORS != 0;
 
         if pq_len != expected_pq_len {
-            return Err(StorageError::Corrupted(alloc::format!(
+            return Err(StorageError::format_error(alloc::format!(
                 "cluster blob pq_len {pq_len} != expected {expected_pq_len}"
             )));
         }

--- a/src/ivfpq/index.rs
+++ b/src/ivfpq/index.rs
@@ -1,5 +1,5 @@
 use alloc::collections::BinaryHeap;
-use alloc::string::{String, ToString};
+use alloc::string::String;
 use alloc::vec;
 use alloc::vec::Vec;
 use core::cmp::Ordering as CmpOrdering;
@@ -76,25 +76,25 @@ fn vector_meta_name(name: &str) -> String {
 /// Validate that an index configuration is internally consistent.
 fn validate_config(config: &IndexConfig) -> crate::Result<()> {
     if config.num_subvectors == 0 {
-        return Err(StorageError::Corrupted(
-            "IVF-PQ: num_subvectors must be > 0".to_string(),
+        return Err(StorageError::invalid_index_config(
+            "IVF-PQ: num_subvectors must be > 0",
         ));
     }
     if config.dim == 0 {
-        return Err(StorageError::Corrupted(
-            "IVF-PQ: dim must be > 0".to_string(),
+        return Err(StorageError::invalid_index_config(
+            "IVF-PQ: dim must be > 0",
         ));
     }
     if config.dim as usize % config.num_subvectors as usize != 0 {
-        return Err(StorageError::Corrupted(alloc::format!(
+        return Err(StorageError::invalid_index_config(alloc::format!(
             "IVF-PQ: dim ({}) must be divisible by num_subvectors ({})",
             config.dim,
             config.num_subvectors,
         )));
     }
     if config.num_clusters == 0 {
-        return Err(StorageError::Corrupted(
-            "IVF-PQ: num_clusters must be > 0".to_string(),
+        return Err(StorageError::invalid_index_config(
+            "IVF-PQ: num_clusters must be > 0",
         ));
     }
     Ok(())
@@ -149,7 +149,7 @@ impl<'txn, T: StorageWrite> IvfPqIndex<'txn, T> {
 
         // Reject legacy format -- re-training is required.
         if config.format_version == FORMAT_V0_LEGACY && config.state != 0 {
-            return Err(StorageError::Corrupted(alloc::format!(
+            return Err(StorageError::format_error(alloc::format!(
                 "IVF-PQ '{name}': legacy format v0 -- re-train required for blob format v1",
             )));
         }
@@ -224,12 +224,7 @@ impl<'txn, T: StorageWrite> IvfPqIndex<'txn, T> {
         let mut flat: Vec<f32> = Vec::new();
         for (_id, mut vec) in training_vectors {
             if vec.len() != dim {
-                return Err(StorageError::Corrupted(alloc::format!(
-                    "IVF-PQ '{}': training vector dim {} != {}",
-                    self.name,
-                    vec.len(),
-                    dim,
-                )));
+                return Err(StorageError::dimension_mismatch(&self.name, dim, vec.len()));
             }
             if self.config.metric == DistanceMetric::Cosine {
                 l2_normalize(&mut vec);
@@ -239,7 +234,7 @@ impl<'txn, T: StorageWrite> IvfPqIndex<'txn, T> {
 
         let n = flat.len() / dim;
         if n == 0 {
-            return Err(StorageError::Corrupted(alloc::format!(
+            return Err(StorageError::invalid_index_config(alloc::format!(
                 "IVF-PQ '{}': no training vectors provided",
                 self.name,
             )));
@@ -351,12 +346,7 @@ impl<'txn, T: StorageWrite> IvfPqIndex<'txn, T> {
         let mut count = 0usize;
         for (_id, mut vec) in training_vectors {
             if vec.len() != dim {
-                return Err(StorageError::Corrupted(alloc::format!(
-                    "IVF-PQ '{}': training vector dim {} != {}",
-                    self.name,
-                    vec.len(),
-                    dim,
-                )));
+                return Err(StorageError::dimension_mismatch(&self.name, dim, vec.len()));
             }
             if self.config.metric == DistanceMetric::Cosine {
                 l2_normalize(&mut vec);
@@ -368,7 +358,7 @@ impl<'txn, T: StorageWrite> IvfPqIndex<'txn, T> {
 
         let n = flat.len() / dim;
         if n == 0 {
-            return Err(StorageError::Corrupted(alloc::format!(
+            return Err(StorageError::invalid_index_config(alloc::format!(
                 "IVF-PQ '{}': no training vectors provided",
                 self.name,
             )));
@@ -463,12 +453,11 @@ impl<'txn, T: StorageWrite> IvfPqIndex<'txn, T> {
         self.ensure_trained()?;
         let dim = self.config.dim as usize;
         if vector.len() != dim {
-            return Err(StorageError::Corrupted(alloc::format!(
-                "IVF-PQ '{}': vector dim {} != {}",
-                self.name,
-                vector.len(),
+            return Err(StorageError::dimension_mismatch(
+                &self.name,
                 dim,
-            )));
+                vector.len(),
+            ));
         }
         Self::validate_finite(vector, &self.name)?;
 
@@ -597,12 +586,7 @@ impl<'txn, T: StorageWrite> IvfPqIndex<'txn, T> {
 
         for (vector_id, mut vec) in vectors {
             if vec.len() != dim {
-                return Err(StorageError::Corrupted(alloc::format!(
-                    "IVF-PQ '{}': vector dim {} != {}",
-                    self.name,
-                    vec.len(),
-                    dim,
-                )));
+                return Err(StorageError::dimension_mismatch(&self.name, dim, vec.len()));
             }
             Self::validate_finite(&vec, &self.name)?;
             if metric == DistanceMetric::Cosine {
@@ -758,12 +742,11 @@ impl<'txn, T: StorageWrite> IvfPqIndex<'txn, T> {
         self.flush()?;
         let dim = self.config.dim as usize;
         if query.len() != dim {
-            return Err(StorageError::Corrupted(alloc::format!(
-                "IVF-PQ '{}': query dim {} != {}",
-                self.name,
-                query.len(),
+            return Err(StorageError::dimension_mismatch(
+                &self.name,
                 dim,
-            )));
+                query.len(),
+            ));
         }
 
         let centroids = self.load_centroids()?;
@@ -865,7 +848,7 @@ impl<'txn, T: StorageWrite> IvfPqIndex<'txn, T> {
     fn validate_finite(vector: &[f32], name: &str) -> crate::Result<()> {
         for (i, &v) in vector.iter().enumerate() {
             if !v.is_finite() {
-                return Err(StorageError::Corrupted(alloc::format!(
+                return Err(StorageError::invalid_index_config(alloc::format!(
                     "IVF-PQ '{name}': vector contains non-finite value ({v}) at index {i}",
                 )));
             }
@@ -918,10 +901,7 @@ impl<'txn, T: StorageWrite> IvfPqIndex<'txn, T> {
 
     fn ensure_trained(&self) -> crate::Result<()> {
         if self.config.state != STATE_TRAINED {
-            return Err(StorageError::Corrupted(alloc::format!(
-                "IVF-PQ '{}' not trained -- call train() first",
-                self.name,
-            )));
+            return Err(StorageError::index_not_trained(&self.name));
         }
         Ok(())
     }
@@ -1144,8 +1124,8 @@ impl ReadOnlyIvfPqIndex {
         let config = match mt.st_get(&"config")? {
             Some(guard) => decode_index_config(guard.value()),
             None => {
-                return Err(StorageError::Corrupted(alloc::format!(
-                    "IVF-PQ index '{mn}' not found (missing config)",
+                return Err(StorageError::index_not_trained(alloc::format!(
+                    "{name} (missing config)",
                 )));
             }
         };
@@ -1219,20 +1199,16 @@ impl ReadOnlyIvfPqIndex {
         params: &SearchParams,
     ) -> crate::Result<Vec<Neighbor<u64>>> {
         if self.config.state != STATE_TRAINED {
-            return Err(StorageError::Corrupted(alloc::format!(
-                "IVF-PQ '{}' not trained",
-                self.name,
-            )));
+            return Err(StorageError::index_not_trained(&self.name));
         }
 
         let dim = self.config.dim as usize;
         if query.len() != dim {
-            return Err(StorageError::Corrupted(alloc::format!(
-                "IVF-PQ '{}': query dim {} != {}",
-                self.name,
-                query.len(),
+            return Err(StorageError::dimension_mismatch(
+                &self.name,
                 dim,
-            )));
+                query.len(),
+            ));
         }
 
         let query_owned;

--- a/src/ivfpq/pq.rs
+++ b/src/ivfpq/pq.rs
@@ -157,9 +157,9 @@ pub fn train_codebooks(
     _metric: DistanceMetric,
 ) -> Result<Codebooks, crate::StorageError> {
     if dim == 0 || num_subvectors == 0 || dim % num_subvectors != 0 {
-        return Err(crate::StorageError::Corrupted(alloc::string::String::from(
+        return Err(crate::StorageError::invalid_index_config(
             "PQ training: dim must be non-zero and divisible by num_subvectors",
-        )));
+        ));
     }
     let n = flat_vectors.len() / dim;
     let sub_dim = dim / num_subvectors;

--- a/src/tree_store/page_store/page_manager.rs
+++ b/src/tree_store/page_store/page_manager.rs
@@ -23,7 +23,6 @@ use crate::{DatabaseError, Result, StorageError};
 use alloc::boxed::Box;
 #[cfg(feature = "std")]
 use alloc::format;
-use alloc::string::ToString;
 use alloc::sync::Arc;
 use alloc::vec;
 use alloc::vec::Vec;
@@ -179,9 +178,9 @@ impl TransactionalMemory {
         read_verification_callback: Option<Arc<ReadVerificationCallback>>,
     ) -> Result<Self, DatabaseError> {
         if !page_size.is_power_of_two() || page_size < DB_HEADER_SIZE {
-            return Err(StorageError::Corrupted(alloc::string::String::from(
+            return Err(StorageError::invalid_config(
                 "page_size must be a power of two and at least DB_HEADER_SIZE",
-            ))
+            )
             .into());
         }
 
@@ -191,10 +190,7 @@ impl TransactionalMemory {
             (u64::from(MAX_PAGE_INDEX) + 1) * page_size as u64,
         );
         if !region_size.is_power_of_two() {
-            return Err(StorageError::Corrupted(alloc::string::String::from(
-                "region_size must be a power of two",
-            ))
-            .into());
+            return Err(StorageError::invalid_config("region_size must be a power of two").into());
         }
 
         let storage = PagedCachedFile::new(
@@ -213,8 +209,8 @@ impl TransactionalMemory {
                     .read_direct(0, MAGICNUMBER.len())?
                     .try_into()
                     .map_err(|_| {
-                        StorageError::Corrupted(
-                            "Failed to read magic number: unexpected byte length".to_string(),
+                        StorageError::format_error(
+                            "Failed to read magic number: unexpected byte length",
                         )
                     })?
             } else {
@@ -224,18 +220,12 @@ impl TransactionalMemory {
         if initial_storage_len > 0 {
             // File already exists check that the magic number matches
             if magic_number != MAGICNUMBER {
-                return Err(StorageError::Corrupted(alloc::string::String::from(
-                    "Invalid database file",
-                ))
-                .into());
+                return Err(StorageError::format_error("Invalid database file").into());
             }
         } else {
             // File is empty, check that we're allowed to initialize a new database (i.e. the caller is Database::create() and not open())
             if !allow_initialize {
-                return Err(StorageError::Corrupted(alloc::string::String::from(
-                    "Invalid database file",
-                ))
-                .into());
+                return Err(StorageError::format_error("Invalid database file").into());
             }
         }
 
@@ -255,16 +245,16 @@ impl TransactionalMemory {
             let starting_size = size + tracker_space;
 
             let page_size_u64 = u64::try_from(page_size)
-                .map_err(|_| StorageError::Corrupted("page_size exceeds u64 range".to_string()))?;
-            let page_capacity = (region_size / page_size_u64).try_into().map_err(|_| {
-                StorageError::Corrupted("page_capacity exceeds u32 range".to_string())
-            })?;
+                .map_err(|_| StorageError::invalid_config("page_size exceeds u64 range"))?;
+            let page_capacity = (region_size / page_size_u64)
+                .try_into()
+                .map_err(|_| StorageError::invalid_config("page_capacity exceeds u32 range"))?;
             let layout = DatabaseLayout::calculate(
                 starting_size,
                 page_capacity,
                 NO_HEADER,
                 page_size.try_into().map_err(|_| {
-                    StorageError::Corrupted("page_size exceeds target integer range".to_string())
+                    StorageError::invalid_config("page_size exceeds target integer range")
                 })?,
             );
 
@@ -319,9 +309,9 @@ impl TransactionalMemory {
         let compression = header.compression;
 
         if header.page_size() as usize != page_size {
-            return Err(StorageError::Corrupted(alloc::string::String::from(
+            return Err(StorageError::invalid_config(
                 "Database page_size does not match requested page_size",
-            ))
+            )
             .into());
         }
         // The blob region (if any) is appended after the B-tree region.
@@ -330,9 +320,9 @@ impl TransactionalMemory {
         let blob_region_offset = header.primary_slot().blob_region_offset;
         let btree_file_len = Self::effective_btree_file_len(&storage, blob_region_offset)?;
         if btree_file_len < header.layout().len() {
-            return Err(StorageError::Corrupted(alloc::string::String::from(
+            return Err(StorageError::format_error(
                 "B-tree file length is less than the database layout length",
-            ))
+            )
             .into());
         }
         let needs_recovery = header.recovery_required || header.layout().len() != btree_file_len;
@@ -351,10 +341,9 @@ impl TransactionalMemory {
             ));
             header.pick_primary_for_repair(repair_info)?;
             if repair_info.invalid_magic_number {
-                return Err(StorageError::Corrupted(alloc::string::String::from(
-                    "Invalid magic number during recovery",
-                ))
-                .into());
+                return Err(
+                    StorageError::format_error("Invalid magic number during recovery").into(),
+                );
             }
             storage
                 .write(0, DB_HEADER_SIZE, true)?
@@ -365,9 +354,9 @@ impl TransactionalMemory {
 
         let layout = header.layout();
         if layout.len() != btree_file_len {
-            return Err(StorageError::Corrupted(alloc::string::String::from(
+            return Err(StorageError::format_error(
                 "Database layout length does not match B-tree file length",
-            ))
+            )
             .into());
         }
         let region_size = layout.full_region_layout().len();
@@ -435,10 +424,7 @@ impl TransactionalMemory {
 
         let initial_storage_len = storage.raw_file_len()?;
         if initial_storage_len < DB_HEADER_SIZE as u64 {
-            return Err(StorageError::Corrupted(alloc::string::String::from(
-                "Invalid database file",
-            ))
-            .into());
+            return Err(StorageError::format_error("Invalid database file").into());
         }
 
         let magic_number: [u8; MAGICNUMBER.len()] = storage
@@ -447,10 +433,7 @@ impl TransactionalMemory {
             .unwrap();
 
         if magic_number != MAGICNUMBER {
-            return Err(StorageError::Corrupted(alloc::string::String::from(
-                "Invalid database file",
-            ))
-            .into());
+            return Err(StorageError::format_error("Invalid database file").into());
         }
 
         let header_bytes = storage.read_direct(0, DB_HEADER_SIZE)?;
@@ -495,7 +478,7 @@ impl TransactionalMemory {
         let layout = header.layout();
         let file_len = storage.raw_file_len()?;
         if file_len < layout.len() {
-            return Err(StorageError::Corrupted(format!(
+            return Err(StorageError::format_error(format!(
                 "File too short: {file_len} bytes, expected at least {} bytes",
                 layout.len()
             ))
@@ -692,7 +675,7 @@ impl TransactionalMemory {
                 was_clean = false;
             }
             if repair_info.invalid_magic_number {
-                return Err(StorageError::Corrupted("Invalid magic number".to_string()).into());
+                return Err(StorageError::format_error("Invalid magic number").into());
             }
             self.storage
                 .write(0, DB_HEADER_SIZE, true)?
@@ -711,9 +694,7 @@ impl TransactionalMemory {
     pub(crate) fn begin_writable(&self) -> Result {
         let mut state = self.state.lock();
         if state.header.recovery_required {
-            return Err(StorageError::Corrupted(alloc::string::String::from(
-                "Cannot begin writable transaction: recovery is already required",
-            )));
+            return Err(StorageError::RecoveryRequired);
         }
         state.header.recovery_required = true;
         self.write_header(&state.header)?;
@@ -951,9 +932,7 @@ impl TransactionalMemory {
 
     pub(crate) fn load_allocator_state(&self, tree: &AllocatorStateTree) -> Result {
         if !self.is_valid_allocator_state(tree)? {
-            return Err(StorageError::Corrupted(alloc::string::String::from(
-                "Allocator state is stale or invalid for current transaction",
-            )));
+            return Err(StorageError::RecoveryRequired);
         }
 
         // Load the allocator state
@@ -1039,9 +1018,7 @@ impl TransactionalMemory {
         #[cfg(debug_assertions)]
         debug_assert!(self.open_dirty_pages.lock().is_empty());
         if self.needs_recovery.load(Ordering::Acquire) {
-            return Err(StorageError::Corrupted(alloc::string::String::from(
-                "Cannot proceed: database recovery is required",
-            )));
+            return Err(StorageError::RecoveryRequired);
         }
 
         let mut state = self.state.lock();
@@ -1160,9 +1137,7 @@ impl TransactionalMemory {
         #[cfg(debug_assertions)]
         debug_assert!(self.open_dirty_pages.lock().is_empty());
         if self.needs_recovery.load(Ordering::Acquire) {
-            return Err(StorageError::Corrupted(alloc::string::String::from(
-                "Cannot proceed: database recovery is required",
-            )));
+            return Err(StorageError::RecoveryRequired);
         }
 
         // Verify that recovery_required is set on disk. This is the invariant
@@ -1225,9 +1200,7 @@ impl TransactionalMemory {
             );
         }
         if self.needs_recovery.load(Ordering::Acquire) {
-            return Err(StorageError::Corrupted(alloc::string::String::from(
-                "Cannot proceed: database recovery is required",
-            )));
+            return Err(StorageError::RecoveryRequired);
         }
         let mut state = self.state.lock();
         let mut guard = self.allocated_since_commit.lock();

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -1658,8 +1658,8 @@ fn does_not_exist() {
     let tmpfile = create_tempfile();
 
     let result = Database::open(tmpfile.path());
-    if let Err(DatabaseError::Storage(StorageError::Corrupted(_))) = result {
-        // Empty file is detected as corrupted
+    if let Err(DatabaseError::Storage(StorageError::FormatError { .. })) = result {
+        // Empty file is detected as format error
     } else {
         panic!();
     }
@@ -1670,15 +1670,15 @@ fn invalid_database_file() {
     let mut tmpfile = create_tempfile();
     tmpfile.write_all(b"hi").unwrap();
     let result = Database::open(tmpfile.path());
-    if let Err(DatabaseError::Storage(StorageError::Corrupted(_))) = result {
-        // Invalid magic number is detected as corrupted
+    if let Err(DatabaseError::Storage(StorageError::FormatError { .. })) = result {
+        // Invalid magic number is detected as format error
     } else {
         panic!();
     }
 
     let result = Database::create(tmpfile.path());
-    if let Err(DatabaseError::Storage(StorageError::Corrupted(_))) = result {
-        // Invalid existing file is detected as corrupted
+    if let Err(DatabaseError::Storage(StorageError::FormatError { .. })) = result {
+        // Invalid existing file is detected as format error
     } else {
         panic!();
     }


### PR DESCRIPTION
## Summary
- Reclassify ~65 `StorageError::Corrupted` misuses across IVF-PQ, CDC, and page_manager to typed variants
- IVF-PQ: 20 sites → DimensionMismatch, IndexNotTrained, InvalidIndexConfig, FormatError
- CDC: 17 sites → FormatError
- Page manager: 21 sites → InvalidConfiguration, FormatError, RecoveryRequired
- 5 legitimate Corrupted uses kept per module (true invariant violations)
- Test assertions updated to match new error variants

Depends on: #280 (merged)