### PR TITLE
fix: validate page bounds in LeafAccessor/BranchAccessor constructors

### DIFF
--- a/src/multimap_table.rs
+++ b/src/multimap_table.rs
@@ -61,7 +61,7 @@ fn multimap_stats_helper(
                 page.memory(),
                 fixed_key_size,
                 DynamicCollection::<()>::fixed_width_with(fixed_value_size),
-            );
+            )?;
             let mut leaf_bytes = 0u64;
             let mut is_branch = false;
             for i in 0..accessor.num_pairs() {
@@ -76,7 +76,7 @@ fn multimap_stats_helper(
                             collection.as_inline(),
                             fixed_value_size,
                             <() as Value>::fixed_width(),
-                        );
+                        )?;
                         leaf_bytes +=
                             inline_accessor.length_of_pairs(0, inline_accessor.num_pairs()) as u64;
                     }
@@ -128,7 +128,7 @@ fn multimap_stats_helper(
             })
         }
         BRANCH => {
-            let accessor = BranchAccessor::new(&page, fixed_key_size);
+            let accessor = BranchAccessor::new(&page, fixed_key_size)?;
             let mut max_child_height = 0;
             let mut leaf_pages = 0;
             let mut branch_pages = 1;
@@ -317,7 +317,7 @@ pub(crate) fn relocate_subtrees(
                 old_page.memory(),
                 key_size,
                 UntypedDynamicCollection::fixed_width_with(value_size),
-            );
+            )?;
             // TODO: maybe there's a better abstraction, so that we don't need to call into this low-level method?
             let mut mutator = LeafMutator::new(
                 new_page.memory_mut()?,
@@ -352,7 +352,7 @@ pub(crate) fn relocate_subtrees(
             }
         }
         BRANCH => {
-            let accessor = BranchAccessor::new(&old_page, key_size);
+            let accessor = BranchAccessor::new(&old_page, key_size)?;
             let mut mutator = BranchMutator::new(new_page.memory_mut()?);
             for i in 0..accessor.count_children() {
                 if let Some(child) = accessor.child_page(i) {
@@ -410,7 +410,7 @@ pub(crate) fn finalize_tree_and_subtree_checksums(
             leaf_page.memory(),
             key_size,
             DynamicCollection::<()>::fixed_width_with(value_size),
-        );
+        )?;
         for i in 0..accessor.num_pairs() {
             let entry = accessor
                 .entry(i)
@@ -464,7 +464,7 @@ fn parse_subtree_roots<T: Page>(
                 page.memory(),
                 fixed_key_size,
                 DynamicCollection::<()>::fixed_width_with(fixed_value_size),
-            );
+            )?;
             for i in 0..accessor.num_pairs() {
                 let entry = accessor
                     .entry(i)
@@ -562,52 +562,58 @@ impl<'a, V: Key> LeafKeyIter<'a, V> {
         data: AccessGuard<'a, &'static DynamicCollection<V>>,
         fixed_key_size: Option<usize>,
         fixed_value_size: Option<usize>,
-    ) -> Self {
+    ) -> Result<Self> {
         let accessor =
-            LeafAccessor::new(data.value().as_inline(), fixed_key_size, fixed_value_size);
+            LeafAccessor::new(data.value().as_inline(), fixed_key_size, fixed_value_size)?;
         let num_pairs = accessor.num_pairs();
         let end_entry = if num_pairs == 0 {
             -1
         } else {
             isize::try_from(num_pairs).unwrap_or(isize::MAX) - 1
         };
-        Self {
+        Ok(Self {
             inline_collection: data,
             fixed_key_size,
             fixed_value_size,
             start_entry: 0,
             end_entry,
-        }
+        })
     }
 
-    fn next_key(&mut self) -> Option<&[u8]> {
+    fn next_key(&mut self) -> Option<Result<&[u8]>> {
         if self.end_entry < self.start_entry {
             return None;
         }
-        let accessor = LeafAccessor::new(
+        let accessor = match LeafAccessor::new(
             self.inline_collection.value().as_inline(),
             self.fixed_key_size,
             self.fixed_value_size,
-        );
+        ) {
+            Ok(a) => a,
+            Err(e) => return Some(Err(e)),
+        };
         self.start_entry += 1;
         accessor
             .entry((self.start_entry - 1).try_into().unwrap())
-            .map(|e| e.key())
+            .map(|e| Ok(e.key()))
     }
 
-    fn next_key_back(&mut self) -> Option<&[u8]> {
+    fn next_key_back(&mut self) -> Option<Result<&[u8]>> {
         if self.end_entry < self.start_entry {
             return None;
         }
-        let accessor = LeafAccessor::new(
+        let accessor = match LeafAccessor::new(
             self.inline_collection.value().as_inline(),
             self.fixed_key_size,
             self.fixed_value_size,
-        );
+        ) {
+            Ok(a) => a,
+            Err(e) => return Some(Err(e)),
+        };
         self.end_entry -= 1;
         accessor
             .entry((self.end_entry + 1).try_into().unwrap())
-            .map(|e| e.key())
+            .map(|e| Ok(e.key()))
     }
 }
 
@@ -734,7 +740,7 @@ impl<V: Key> DynamicCollection<V> {
             Inline => {
                 let leaf_data = self.as_inline();
                 let accessor =
-                    LeafAccessor::new(leaf_data, V::fixed_width(), <() as Value>::fixed_width());
+                    LeafAccessor::new(leaf_data, V::fixed_width(), <() as Value>::fixed_width())?;
                 accessor.num_pairs() as u64
             }
             SubtreeV2 => {
@@ -775,7 +781,7 @@ impl<V: Key> DynamicCollection<V> {
         Ok(match collection.value().collection_type()? {
             Inline => {
                 let leaf_iter =
-                    LeafKeyIter::new(collection, V::fixed_width(), <() as Value>::fixed_width());
+                    LeafKeyIter::new(collection, V::fixed_width(), <() as Value>::fixed_width())?;
                 MultimapValue::new_inline(leaf_iter, guard)?
             }
             SubtreeV2 => {
@@ -812,7 +818,7 @@ impl<V: Key> DynamicCollection<V> {
         Ok(match collection.value().collection_type()? {
             Inline => {
                 let leaf_iter =
-                    LeafKeyIter::new(collection, V::fixed_width(), <() as Value>::fixed_width());
+                    LeafKeyIter::new(collection, V::fixed_width(), <() as Value>::fixed_width())?;
                 MultimapValue::new_inline(leaf_iter, guard)?
             }
             SubtreeV2 => {
@@ -980,7 +986,10 @@ impl<'a, V: Key + 'static> Iterator for MultimapValue<'a, V> {
                     return Some(Err(err));
                 }
             },
-            ValueIterState::InlineLeaf(iter) => iter.next_key()?.to_vec(),
+            ValueIterState::InlineLeaf(iter) => match iter.next_key()? {
+                Ok(bytes) => bytes.to_vec(),
+                Err(err) => return Some(Err(err)),
+            },
         };
         self.remaining -= 1;
         Some(Ok(AccessGuard::with_owned_value(bytes)))
@@ -996,7 +1005,10 @@ impl<V: Key + 'static> DoubleEndedIterator for MultimapValue<'_, V> {
                     return Some(Err(err));
                 }
             },
-            ValueIterState::InlineLeaf(iter) => iter.next_key_back()?.to_vec(),
+            ValueIterState::InlineLeaf(iter) => match iter.next_key_back()? {
+                Ok(bytes) => bytes.to_vec(),
+                Err(err) => return Some(Err(err)),
+            },
         };
         self.remaining -= 1;
         Some(Ok(AccessGuard::with_owned_value(bytes)))
@@ -1186,7 +1198,7 @@ impl<'txn, K: Key + 'static, V: Key + 'static> MultimapTable<'txn, K, V> {
                         leaf_data,
                         V::fixed_width(),
                         <() as Value>::fixed_width(),
-                    );
+                    )?;
                     let (position, found) = accessor.position::<V>(value_bytes_ref);
                     if found {
                         return Ok(true);
@@ -1366,7 +1378,7 @@ impl<'txn, K: Key + 'static, V: Key + 'static> MultimapTable<'txn, K, V> {
             Inline => {
                 let leaf_data = v.as_inline();
                 let accessor =
-                    LeafAccessor::new(leaf_data, V::fixed_width(), <() as Value>::fixed_width());
+                    LeafAccessor::new(leaf_data, V::fixed_width(), <() as Value>::fixed_width())?;
                 if let Some(position) = accessor.find_key::<V>(V::as_bytes(value.borrow()).as_ref())
                 {
                     let old_num_pairs = accessor.num_pairs();
@@ -1447,7 +1459,7 @@ impl<'txn, K: Key + 'static, V: Key + 'static> MultimapTable<'txn, K, V> {
                                 page.memory(),
                                 V::fixed_width(),
                                 <() as Value>::fixed_width(),
-                            );
+                            )?;
                             let len = accessor.total_length();
                             if len < self.mem.get_page_size() / 2 {
                                 let inline_data =

--- a/src/tree_store/btree.rs
+++ b/src/tree_store/btree.rs
@@ -118,7 +118,7 @@ impl UntypedBtree {
                 // No-op
             }
             BRANCH => {
-                let accessor = BranchAccessor::new(&page, self.key_width);
+                let accessor = BranchAccessor::new(&page, self.key_width)?;
                 for i in 0..accessor.count_children() {
                     let child_page = accessor.child_page(i).ok_or_else(|| {
                         StorageError::invalid_child_pointer(page.get_page_number(), i)
@@ -198,7 +198,8 @@ fn salvage_node(
         LEAF => {
             // Use catch_unwind to handle panics from corrupt leaf data
             let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
-                let accessor = LeafAccessor::new(node_mem, fixed_key_size, fixed_value_size);
+                let accessor = LeafAccessor::new(node_mem, fixed_key_size, fixed_value_size)
+                    .expect("internal: valid page");
                 let mut leaf_pairs = Vec::new();
                 for i in 0..accessor.num_pairs() {
                     if let Some(entry) = accessor.entry(i) {
@@ -225,7 +226,8 @@ fn salvage_node(
             // Use catch_unwind for the branch accessor too
             let children: Vec<PageNumber> =
                 std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
-                    let accessor = BranchAccessor::new(&page, fixed_key_size);
+                    let accessor =
+                        BranchAccessor::new(&page, fixed_key_size).expect("internal: valid page");
                     let mut kids = Vec::new();
                     for i in 0..accessor.count_children() {
                         if let Some(child) = accessor.child_page(i) {
@@ -328,7 +330,7 @@ impl UntypedBtreeMut {
         match page.memory()[0] {
             LEAF => leaf_checksum(&page, self.key_width, self.value_width),
             BRANCH => {
-                let accessor = BranchAccessor::new(&page, self.key_width);
+                let accessor = BranchAccessor::new(&page, self.key_width)?;
                 let mut new_children = vec![];
                 for i in 0..accessor.count_children() {
                     let child_page = accessor
@@ -401,7 +403,7 @@ impl UntypedBtreeMut {
                 visitor(page)?;
             }
             BRANCH => {
-                let accessor = BranchAccessor::new(&page, self.key_width);
+                let accessor = BranchAccessor::new(&page, self.key_width)?;
                 for i in 0..accessor.count_children() {
                     let child_page = accessor
                         .child_page(i)
@@ -453,7 +455,7 @@ impl UntypedBtreeMut {
                 // No-op
             }
             BRANCH => {
-                let accessor = BranchAccessor::new(&old_page, self.key_width);
+                let accessor = BranchAccessor::new(&old_page, self.key_width)?;
                 let mut mutator = BranchMutator::new(new_page.memory_mut()?);
                 for i in 0..accessor.count_children() {
                     let child = accessor
@@ -818,7 +820,7 @@ impl<K: Key + 'static, V: Value + 'static> BtreeMut<'_, K, V> {
             LEAF => {
                 let value_width = self.value_width();
                 let compression = self.compression();
-                let accessor = LeafAccessor::new(page.memory(), K::fixed_width(), value_width);
+                let accessor = LeafAccessor::new(page.memory(), K::fixed_width(), value_width)?;
                 if let Some(entry_index) = accessor.find_key::<K>(query) {
                     let (start, end) = accessor.value_range(entry_index).ok_or_else(|| {
                         StorageError::invalid_entry_index(page.get_page_number(), entry_index)
@@ -848,7 +850,7 @@ impl<K: Key + 'static, V: Value + 'static> BtreeMut<'_, K, V> {
             }
             BRANCH => {
                 let (child_index, child_page) = {
-                    let accessor = BranchAccessor::new(&page, K::fixed_width());
+                    let accessor = BranchAccessor::new(&page, K::fixed_width())?;
                     accessor.child_for_key::<K>(query)
                 };
                 let child_page_mut = if self.mem.uncommitted(child_page) {
@@ -1097,7 +1099,7 @@ impl RawBtree {
                 } else {
                     return Ok(false);
                 }
-                let accessor = BranchAccessor::new(&page, self.fixed_key_size);
+                let accessor = BranchAccessor::new(&page, self.fixed_key_size)?;
                 for i in 0..accessor.count_children() {
                     let child = accessor
                         .child_page(i)
@@ -1174,7 +1176,7 @@ impl RawBtree {
                         description: "branch page checksum mismatch".to_string(),
                     });
                 }
-                let accessor = BranchAccessor::new(&page, self.fixed_key_size);
+                let accessor = BranchAccessor::new(&page, self.fixed_key_size)?;
                 for i in 0..accessor.count_children() {
                     let child = accessor.child_page(i).ok_or_else(|| {
                         StorageError::Corrupted(format!(
@@ -1228,7 +1230,7 @@ impl RawBtree {
         let page = self.mem.get_page(page_number)?;
         let node_mem = page.memory();
         if node_mem[0] == BRANCH {
-            let accessor = BranchAccessor::new(&page, self.fixed_key_size);
+            let accessor = BranchAccessor::new(&page, self.fixed_key_size)?;
             if let Some(child) = accessor.child_page(0) {
                 return Ok(1 + self.measure_depth(child)?);
             }
@@ -1259,7 +1261,7 @@ impl RawBtree {
                     });
                 }
                 let accessor =
-                    LeafAccessor::new(node_mem, self.fixed_key_size, self.fixed_value_size);
+                    LeafAccessor::new(node_mem, self.fixed_key_size, self.fixed_value_size)?;
                 let num = accessor.num_pairs();
                 for i in 1..num {
                     if let (Some(prev), Some(curr)) = (accessor.entry(i - 1), accessor.entry(i))
@@ -1288,7 +1290,7 @@ impl RawBtree {
                     });
                     return Ok(());
                 }
-                let accessor = BranchAccessor::new(&page, self.fixed_key_size);
+                let accessor = BranchAccessor::new(&page, self.fixed_key_size)?;
                 for i in 0..accessor.count_children() {
                     if let Some(child) = accessor.child_page(i) {
                         self.verify_structure_helper(
@@ -1494,7 +1496,7 @@ impl<K: Key, V: Value> Btree<K, V> {
             LEAF => {
                 self.maybe_verify_page(&page, expected_checksum)?;
                 let accessor =
-                    LeafAccessor::new(page.memory(), K::fixed_width(), self.value_width());
+                    LeafAccessor::new(page.memory(), K::fixed_width(), self.value_width())?;
                 if let Some(entry_index) = accessor.find_key::<K>(query) {
                     let (start, end) = accessor.value_range(entry_index).ok_or_else(|| {
                         StorageError::invalid_entry_index(page.get_page_number(), entry_index)
@@ -1511,7 +1513,7 @@ impl<K: Key, V: Value> Btree<K, V> {
             }
             BRANCH => {
                 self.maybe_verify_page(&page, expected_checksum)?;
-                let accessor = BranchAccessor::new(&page, K::fixed_width());
+                let accessor = BranchAccessor::new(&page, K::fixed_width())?;
                 let (child_index, child_page_num) = accessor.child_for_key::<K>(query);
                 let child_checksum = accessor.child_checksum(child_index).ok_or_else(|| {
                     StorageError::invalid_child_checksum(page.get_page_number(), child_index)
@@ -1554,7 +1556,7 @@ impl<K: Key, V: Value> Btree<K, V> {
             LEAF => {
                 self.maybe_verify_page(&page, expected_checksum)?;
                 let accessor =
-                    LeafAccessor::new(page.memory(), K::fixed_width(), self.value_width());
+                    LeafAccessor::new(page.memory(), K::fixed_width(), self.value_width())?;
                 let (key_range, value_range) = accessor
                     .entry_ranges(0)
                     .ok_or_else(|| StorageError::invalid_entry_index(page.get_page_number(), 0))?;
@@ -1568,7 +1570,7 @@ impl<K: Key, V: Value> Btree<K, V> {
             }
             BRANCH => {
                 self.maybe_verify_page(&page, expected_checksum)?;
-                let accessor = BranchAccessor::new(&page, K::fixed_width());
+                let accessor = BranchAccessor::new(&page, K::fixed_width())?;
                 let child_page = accessor.child_page(0).ok_or_else(|| {
                     StorageError::invalid_child_pointer(page.get_page_number(), 0)
                 })?;
@@ -1612,7 +1614,7 @@ impl<K: Key, V: Value> Btree<K, V> {
             LEAF => {
                 self.maybe_verify_page(&page, expected_checksum)?;
                 let accessor =
-                    LeafAccessor::new(page.memory(), K::fixed_width(), self.value_width());
+                    LeafAccessor::new(page.memory(), K::fixed_width(), self.value_width())?;
                 let last_index = accessor.num_pairs() - 1;
                 let (key_range, value_range) =
                     accessor.entry_ranges(last_index).ok_or_else(|| {
@@ -1628,7 +1630,7 @@ impl<K: Key, V: Value> Btree<K, V> {
             }
             BRANCH => {
                 self.maybe_verify_page(&page, expected_checksum)?;
-                let accessor = BranchAccessor::new(&page, K::fixed_width());
+                let accessor = BranchAccessor::new(&page, K::fixed_width())?;
                 let last_child = accessor.count_children() - 1;
                 let child_page = accessor.child_page(last_child).ok_or_else(|| {
                     StorageError::invalid_child_pointer(page.get_page_number(), last_child)
@@ -1684,12 +1686,12 @@ impl<K: Key, V: Value> Btree<K, V> {
                     match node_mem[0] {
                         LEAF => {
                             eprint!("Leaf[ (page={:?})", page.get_page_number());
-                            LeafAccessor::new(page.memory(), K::fixed_width(), self.value_width())
+                            LeafAccessor::new(page.memory(), K::fixed_width(), self.value_width())?
                                 .print_node::<K, V>(include_values);
                             eprint!("]");
                         }
                         BRANCH => {
-                            let accessor = BranchAccessor::new(&page, K::fixed_width());
+                            let accessor = BranchAccessor::new(&page, K::fixed_width())?;
                             for i in 0..accessor.count_children() {
                                 let child = accessor.child_page(i).ok_or_else(|| {
                                     StorageError::Corrupted(format!(
@@ -1761,7 +1763,7 @@ fn stats_helper(
     let node_mem = page.memory();
     match node_mem[0] {
         LEAF => {
-            let accessor = LeafAccessor::new(page.memory(), fixed_key_size, fixed_value_size);
+            let accessor = LeafAccessor::new(page.memory(), fixed_key_size, fixed_value_size)?;
             let leaf_bytes = accessor.length_of_pairs(0, accessor.num_pairs());
             let overhead_bytes = accessor.total_length() - leaf_bytes;
             let fragmented_bytes = (page.memory().len() - accessor.total_length()) as u64;
@@ -1781,7 +1783,7 @@ fn stats_helper(
             })
         }
         BRANCH => {
-            let accessor = BranchAccessor::new(&page, fixed_key_size);
+            let accessor = BranchAccessor::new(&page, fixed_key_size)?;
             let mut max_child_height = 0;
             let mut leaf_pages = 0;
             let mut branch_pages = 1;

--- a/src/tree_store/btree_base.rs
+++ b/src/tree_store/btree_base.rs
@@ -28,7 +28,7 @@ pub(super) fn leaf_checksum<T: Page>(
     fixed_key_size: Option<usize>,
     fixed_value_size: Option<usize>,
 ) -> Result<Checksum, StorageError> {
-    let accessor = LeafAccessor::new(page.memory(), fixed_key_size, fixed_value_size);
+    let accessor = LeafAccessor::new(page.memory(), fixed_key_size, fixed_value_size)?;
     let last_pair = accessor.num_pairs().checked_sub(1).ok_or_else(|| {
         StorageError::page_corrupted(page.get_page_number(), "leaf page has zero pairs")
     })?;
@@ -49,7 +49,7 @@ pub(super) fn branch_checksum<T: Page>(
     page: &T,
     fixed_key_size: Option<usize>,
 ) -> Result<Checksum, StorageError> {
-    let accessor = BranchAccessor::new(page, fixed_key_size);
+    let accessor = BranchAccessor::new(page, fixed_key_size)?;
     let last_key = accessor.num_keys().checked_sub(1).ok_or_else(|| {
         StorageError::page_corrupted(page.get_page_number(), "branch page has zero keys")
     })?;
@@ -424,7 +424,7 @@ impl<'a, V: Value + 'static> AccessGuardMut<'a, V> {
 
         let key_bytes = {
             let accessor =
-                LeafAccessor::new(self.page.memory(), self.key_width, self.fixed_value_size);
+                LeafAccessor::new(self.page.memory(), self.key_width, self.fixed_value_size)?;
             accessor.key_unchecked(self.entry_index).to_vec()
         };
 
@@ -445,7 +445,7 @@ impl<'a, V: Value + 'static> AccessGuardMut<'a, V> {
             mutator.insert(self.entry_index, true, &key_bytes, &stored_value);
         } else {
             let accessor =
-                LeafAccessor::new(self.page.memory(), self.key_width, self.fixed_value_size);
+                LeafAccessor::new(self.page.memory(), self.key_width, self.fixed_value_size)?;
             let mut builder = LeafBuilder::new(
                 &self.mem,
                 &self.allocated,
@@ -485,7 +485,7 @@ impl<'a, V: Value + 'static> AccessGuardMut<'a, V> {
 
         // Update our page reference to the new page and recalculate offset/length
         let new_accessor =
-            LeafAccessor::new(self.page.memory(), self.key_width, self.fixed_value_size);
+            LeafAccessor::new(self.page.memory(), self.key_width, self.fixed_value_size)?;
         let (new_start, new_end) = new_accessor.value_range(self.entry_index).unwrap();
 
         self.offset = new_start;
@@ -572,15 +572,37 @@ impl<'a> LeafAccessor<'a> {
         page: &'a [u8],
         fixed_key_size: Option<usize>,
         fixed_value_size: Option<usize>,
-    ) -> Self {
+    ) -> core::result::Result<Self, StorageError> {
+        if page.len() < 4 {
+            return Err(StorageError::Corrupted(
+                "Leaf page too small for header".into(),
+            ));
+        }
         debug_assert_eq!(page[0], LEAF);
-        let num_pairs = u16::from_le_bytes(page[2..4].try_into().unwrap()) as usize;
-        LeafAccessor {
+        let num_pairs = u16::from_le_bytes(
+            page[2..4]
+                .try_into()
+                .map_err(|_| StorageError::Corrupted("Leaf page: bad num_pairs".into()))?,
+        ) as usize;
+        let mut min_size = 4usize;
+        if fixed_key_size.is_none() {
+            min_size = min_size.saturating_add(size_of::<u32>().saturating_mul(num_pairs));
+        }
+        if fixed_value_size.is_none() {
+            min_size = min_size.saturating_add(size_of::<u32>().saturating_mul(num_pairs));
+        }
+        if min_size > page.len() {
+            return Err(StorageError::Corrupted(format!(
+                "Leaf page: num_pairs={num_pairs} requires {min_size}B for offset tables, page is {}B",
+                page.len()
+            )));
+        }
+        Ok(LeafAccessor {
             page,
             fixed_key_size,
             fixed_value_size,
             num_pairs,
-        }
+        })
     }
 
     #[cfg(feature = "std")]
@@ -1115,7 +1137,8 @@ impl<'b> LeafMutator<'b> {
         new_key: &[u8],
         new_value: &[u8],
     ) -> bool {
-        let accessor = LeafAccessor::new(page.memory(), fixed_key_size, fixed_value_size);
+        let accessor = LeafAccessor::new(page.memory(), fixed_key_size, fixed_value_size)
+            .expect("internal: constructed page is valid");
         if overwrite {
             let remaining = page.memory().len() - accessor.total_length();
             let required_delta = isize::try_from(new_key.len() + new_value.len()).unwrap()
@@ -1143,7 +1166,8 @@ impl<'b> LeafMutator<'b> {
 
     // Insert the given key, value pair at index i and shift all following pairs to the right
     pub(crate) fn insert(&mut self, i: usize, overwrite: bool, key: &[u8], value: &[u8]) {
-        let accessor = LeafAccessor::new(self.page, self.fixed_key_size, self.fixed_value_size);
+        let accessor = LeafAccessor::new(self.page, self.fixed_key_size, self.fixed_value_size)
+            .expect("internal: constructed page is valid");
         let required_delta = if overwrite {
             isize::try_from(key.len() + value.len()).unwrap()
                 - isize::try_from(accessor.length_of_pairs(i, i + 1)).unwrap()
@@ -1275,7 +1299,8 @@ impl<'b> LeafMutator<'b> {
     }
 
     pub(super) fn remove(&mut self, i: usize) {
-        let accessor = LeafAccessor::new(self.page, self.fixed_key_size, self.fixed_value_size);
+        let accessor = LeafAccessor::new(self.page, self.fixed_key_size, self.fixed_value_size)
+            .expect("internal: constructed page is valid");
         let num_pairs = accessor.num_pairs();
         assert!(i < num_pairs);
         assert!(num_pairs > 1);
@@ -1372,7 +1397,8 @@ impl<'b> LeafMutator<'b> {
         if self.fixed_value_size.is_some() {
             return;
         }
-        let accessor = LeafAccessor::new(self.page, self.fixed_key_size, self.fixed_value_size);
+        let accessor = LeafAccessor::new(self.page, self.fixed_key_size, self.fixed_value_size)
+            .expect("internal: constructed page is valid");
         let num_pairs = accessor.num_pairs();
         let mut offset = 4 + size_of::<u32>() * i;
         if self.fixed_key_size.is_none() {
@@ -1398,15 +1424,41 @@ pub(crate) struct BranchAccessor<'a: 'b, 'b, T: Page + 'a> {
 }
 
 impl<'a: 'b, 'b, T: Page + 'a> BranchAccessor<'a, 'b, T> {
-    pub(crate) fn new(page: &'b T, fixed_key_size: Option<usize>) -> Self {
-        debug_assert_eq!(page.memory()[0], BRANCH);
-        let num_keys = u16::from_le_bytes(page.memory()[2..4].try_into().unwrap()) as usize;
-        BranchAccessor {
+    pub(crate) fn new(
+        page: &'b T,
+        fixed_key_size: Option<usize>,
+    ) -> core::result::Result<Self, StorageError> {
+        let mem = page.memory();
+        if mem.len() < 8 {
+            return Err(StorageError::Corrupted(
+                "Branch page too small for header".into(),
+            ));
+        }
+        debug_assert_eq!(mem[0], BRANCH);
+        let num_keys = u16::from_le_bytes(
+            mem[2..4]
+                .try_into()
+                .map_err(|_| StorageError::Corrupted("Branch page: bad num_keys".into()))?,
+        ) as usize;
+        let num_children = num_keys + 1;
+        let child_table_size =
+            (PageNumber::serialized_size() + size_of::<Checksum>()) * num_children;
+        let mut min_size = 8usize.saturating_add(child_table_size);
+        if fixed_key_size.is_none() {
+            min_size = min_size.saturating_add(size_of::<u32>().saturating_mul(num_keys));
+        }
+        if min_size > mem.len() {
+            return Err(StorageError::Corrupted(format!(
+                "Branch page: num_keys={num_keys} requires {min_size}B for headers, page is {}B",
+                mem.len()
+            )));
+        }
+        Ok(BranchAccessor {
             page,
             num_keys,
             fixed_key_size,
             _page_lifetime: Default::default(),
-        }
+        })
     }
 
     #[cfg(feature = "std")]

--- a/src/tree_store/btree_base.rs
+++ b/src/tree_store/btree_base.rs
@@ -8,6 +8,7 @@ use crate::types::{Key, MutInPlaceValue, Value};
 use crate::{Result, StorageError};
 use alloc::borrow::Cow;
 use alloc::boxed::Box;
+use alloc::format;
 use alloc::sync::Arc;
 use alloc::vec::Vec;
 use core::borrow::Borrow;

--- a/src/tree_store/btree_iters.rs
+++ b/src/tree_store/btree_iters.rs
@@ -54,7 +54,7 @@ impl RangeIterState {
                 entry,
                 parent,
             } => {
-                let accessor = LeafAccessor::new(page.memory(), fixed_key_size, fixed_value_size);
+                let accessor = LeafAccessor::new(page.memory(), fixed_key_size, fixed_value_size)?;
                 let num_pairs = accessor.num_pairs();
                 let next_entry = if reverse {
                     entry.checked_sub(1)
@@ -81,7 +81,7 @@ impl RangeIterState {
                 child,
                 mut parent,
             } => {
-                let accessor = BranchAccessor::new(&page, fixed_key_size);
+                let accessor = BranchAccessor::new(&page, fixed_key_size)?;
                 let child_page_num = accessor.child_page(child).ok_or_else(|| {
                     StorageError::invalid_child_pointer(page.get_page_number(), child)
                 })?;
@@ -130,7 +130,7 @@ impl RangeIterState {
                             child_page.memory(),
                             fixed_key_size,
                             fixed_value_size,
-                        );
+                        )?;
                         let entry = if reverse {
                             child_accessor.num_pairs().saturating_sub(1)
                         } else {
@@ -145,7 +145,7 @@ impl RangeIterState {
                         }))
                     }
                     BRANCH => {
-                        let child_accessor = BranchAccessor::new(&child_page, fixed_key_size);
+                        let child_accessor = BranchAccessor::new(&child_page, fixed_key_size)?;
                         let child = if reverse {
                             child_accessor.count_children().saturating_sub(1)
                         } else {
@@ -181,7 +181,7 @@ impl RangeIterState {
                 ..
             } => {
                 if let Some((key, value)) =
-                    LeafAccessor::new(page.memory(), *fixed_key_size, *fixed_value_size)
+                    LeafAccessor::new(page.memory(), *fixed_key_size, *fixed_value_size)?
                         .entry_ranges(*entry)
                 {
                     Ok(Some(EntryGuard::new(
@@ -798,7 +798,7 @@ fn find_iter_unbounded<K: Key, V: Value>(
     let page_type = page.memory()[0];
     match page_type {
         LEAF => {
-            let accessor = LeafAccessor::new(page.memory(), K::fixed_width(), fixed_value_size);
+            let accessor = LeafAccessor::new(page.memory(), K::fixed_width(), fixed_value_size)?;
             let entry = if reverse {
                 accessor.num_pairs().saturating_sub(1)
             } else {
@@ -813,7 +813,7 @@ fn find_iter_unbounded<K: Key, V: Value>(
             }))
         }
         BRANCH => {
-            let accessor = BranchAccessor::new(&page, K::fixed_width());
+            let accessor = BranchAccessor::new(&page, K::fixed_width())?;
             let child_index = if reverse {
                 accessor.count_children().saturating_sub(1)
             } else {
@@ -877,7 +877,7 @@ fn find_iter_left<K: Key, V: Value>(
     let page_type = page.memory()[0];
     match page_type {
         LEAF => {
-            let accessor = LeafAccessor::new(page.memory(), K::fixed_width(), fixed_value_size);
+            let accessor = LeafAccessor::new(page.memory(), K::fixed_width(), fixed_value_size)?;
             if accessor.num_pairs() == 0 {
                 return Ok((false, None));
             }
@@ -900,7 +900,7 @@ fn find_iter_left<K: Key, V: Value>(
             Ok((include, Some(result)))
         }
         BRANCH => {
-            let accessor = BranchAccessor::new(&page, K::fixed_width());
+            let accessor = BranchAccessor::new(&page, K::fixed_width())?;
             let (child_index, child_page_number) = accessor.child_for_key::<K>(query);
             let child_checksum = accessor.child_checksum(child_index);
             let child_page = manager.get_page(child_page_number)?;
@@ -946,7 +946,7 @@ fn find_iter_right<K: Key, V: Value>(
     let page_type = page.memory()[0];
     match page_type {
         LEAF => {
-            let accessor = LeafAccessor::new(page.memory(), K::fixed_width(), fixed_value_size);
+            let accessor = LeafAccessor::new(page.memory(), K::fixed_width(), fixed_value_size)?;
             if accessor.num_pairs() == 0 {
                 return Ok((false, None));
             }
@@ -969,7 +969,7 @@ fn find_iter_right<K: Key, V: Value>(
             Ok((include, Some(result)))
         }
         BRANCH => {
-            let accessor = BranchAccessor::new(&page, K::fixed_width());
+            let accessor = BranchAccessor::new(&page, K::fixed_width())?;
             let (child_index, child_page_number) = accessor.child_for_key::<K>(query);
             let child_checksum = accessor.child_checksum(child_index);
             let child_page = manager.get_page(child_page_number)?;
@@ -1025,7 +1025,7 @@ fn find_iter_unbounded_raw(
             parent,
         })),
         BRANCH => {
-            let accessor = BranchAccessor::new(&page, fixed_key_size);
+            let accessor = BranchAccessor::new(&page, fixed_key_size)?;
             let child_page_number = accessor
                 .child_page(0)
                 .ok_or_else(|| StorageError::invalid_child_pointer(page.get_page_number(), 0))?;
@@ -1123,8 +1123,14 @@ impl Iterator for RawEntryIter {
                     entry,
                     ..
                 } => {
-                    let accessor =
-                        LeafAccessor::new(page.memory(), *fixed_key_size, *fixed_value_size);
+                    let accessor = match LeafAccessor::new(
+                        page.memory(),
+                        *fixed_key_size,
+                        *fixed_value_size,
+                    ) {
+                        Ok(a) => a,
+                        Err(e) => return Some(Err(e)),
+                    };
                     if let Some((key_range, value_range)) = accessor.entry_ranges(*entry) {
                         return Some(Ok(RawEntryGuard {
                             page: page.clone(),

--- a/src/tree_store/btree_mutator.rs
+++ b/src/tree_store/btree_mutator.rs
@@ -154,7 +154,7 @@ impl<'a, 'b, K: Key, V: Value> MutateHelper<'a, 'b, K, V> {
                 Subtree(page, checksum) => Some(BtreeHeader::new(page, checksum, new_length)),
                 DeletedLeaf => None,
                 PartialLeaf { page, deleted_pair } => {
-                    let accessor = LeafAccessor::new(&page, K::fixed_width(), self.value_width());
+                    let accessor = LeafAccessor::new(&page, K::fixed_width(), self.value_width())?;
                     let mut builder = LeafBuilder::new(
                         &self.mem,
                         &self.allocated,
@@ -203,7 +203,7 @@ impl<'a, 'b, K: Key, V: Value> MutateHelper<'a, 'b, K, V> {
                 Subtree(page, checksum) => Some(BtreeHeader::new(page, checksum, new_length)),
                 DeletedLeaf => None,
                 PartialLeaf { page, deleted_pair } => {
-                    let accessor = LeafAccessor::new(&page, K::fixed_width(), self.value_width());
+                    let accessor = LeafAccessor::new(&page, K::fixed_width(), self.value_width())?;
                     let mut builder = LeafBuilder::new(
                         &self.mem,
                         &self.allocated,
@@ -298,7 +298,7 @@ impl<'a, 'b, K: Key, V: Value> MutateHelper<'a, 'b, K, V> {
             builder.push(key_bytes, value_bytes_ref);
             let page = builder.build()?;
 
-            let accessor = LeafAccessor::new(page.memory(), K::fixed_width(), self.value_width());
+            let accessor = LeafAccessor::new(page.memory(), K::fixed_width(), self.value_width())?;
             let offset = accessor.offset_of_first_value();
             let page_num = page.get_page_number();
             let guard = AccessGuardMutInPlace::new(page, offset, value_bytes_ref.len());
@@ -320,7 +320,7 @@ impl<'a, 'b, K: Key, V: Value> MutateHelper<'a, 'b, K, V> {
         Ok(match node_mem[0] {
             LEAF => {
                 let accessor =
-                    LeafAccessor::new(page.memory(), K::fixed_width(), self.value_width());
+                    LeafAccessor::new(page.memory(), K::fixed_width(), self.value_width())?;
                 let (position, found) = accessor.position::<K>(key);
 
                 // Fast-path to avoid re-building and splitting pages with a single large value
@@ -338,7 +338,7 @@ impl<'a, 'b, K: Key, V: Value> MutateHelper<'a, 'b, K, V> {
                     let new_page = builder.build()?;
                     let new_page_number = new_page.get_page_number();
                     let new_page_accessor =
-                        LeafAccessor::new(new_page.memory(), K::fixed_width(), self.value_width());
+                        LeafAccessor::new(new_page.memory(), K::fixed_width(), self.value_width())?;
                     let offset = new_page_accessor.offset_of_first_value();
                     let guard = AccessGuardMutInPlace::new(new_page, offset, value.len());
                     return if position == 0 {
@@ -398,7 +398,7 @@ impl<'a, 'b, K: Key, V: Value> MutateHelper<'a, 'b, K, V> {
                     );
                     mutator.insert(position, found, key, value);
                     let new_page_accessor =
-                        LeafAccessor::new(page_mut.memory(), K::fixed_width(), self.value_width());
+                        LeafAccessor::new(page_mut.memory(), K::fixed_width(), self.value_width())?;
                     let offset = new_page_accessor.offset_of_value(position).unwrap();
                     let guard = AccessGuardMutInPlace::new(page_mut, offset, value.len());
                     return Ok(Box::new(InsertionResult {
@@ -461,7 +461,7 @@ impl<'a, 'b, K: Key, V: Value> MutateHelper<'a, 'b, K, V> {
 
                     let new_page_number = new_page.get_page_number();
                     let accessor =
-                        LeafAccessor::new(new_page.memory(), K::fixed_width(), self.value_width());
+                        LeafAccessor::new(new_page.memory(), K::fixed_width(), self.value_width())?;
                     let offset = accessor.offset_of_value(position).unwrap();
                     let guard = AccessGuardMutInPlace::new(new_page, offset, value.len());
 
@@ -504,15 +504,18 @@ impl<'a, 'b, K: Key, V: Value> MutateHelper<'a, 'b, K, V> {
 
                     let new_page_number = new_page1.get_page_number();
                     let new_page_number2 = new_page2.get_page_number();
-                    let accessor =
-                        LeafAccessor::new(new_page1.memory(), K::fixed_width(), self.value_width());
+                    let accessor = LeafAccessor::new(
+                        new_page1.memory(),
+                        K::fixed_width(),
+                        self.value_width(),
+                    )?;
                     let division = accessor.num_pairs();
                     let guard = if position < division {
                         let accessor = LeafAccessor::new(
                             new_page1.memory(),
                             K::fixed_width(),
                             self.value_width(),
-                        );
+                        )?;
                         let offset = accessor.offset_of_value(position).unwrap();
                         AccessGuardMutInPlace::new(new_page1, offset, value.len())
                     } else {
@@ -520,7 +523,7 @@ impl<'a, 'b, K: Key, V: Value> MutateHelper<'a, 'b, K, V> {
                             new_page2.memory(),
                             K::fixed_width(),
                             self.value_width(),
-                        );
+                        )?;
                         let offset = accessor.offset_of_value(position - division).unwrap();
                         AccessGuardMutInPlace::new(new_page2, offset, value.len())
                     };
@@ -535,7 +538,7 @@ impl<'a, 'b, K: Key, V: Value> MutateHelper<'a, 'b, K, V> {
                 }
             }
             BRANCH => {
-                let accessor = BranchAccessor::new(&page, K::fixed_width());
+                let accessor = BranchAccessor::new(&page, K::fixed_width())?;
                 let (child_index, child_page) = accessor.child_for_key::<K>(key);
                 let child_checksum = accessor.child_checksum(child_index).unwrap();
                 let sub_result =
@@ -670,7 +673,7 @@ impl<'a, 'b, K: Key, V: Value> MutateHelper<'a, 'b, K, V> {
         match node_mem[0] {
             LEAF => {
                 let accessor =
-                    LeafAccessor::new(page.memory(), K::fixed_width(), self.value_width());
+                    LeafAccessor::new(page.memory(), K::fixed_width(), self.value_width())?;
                 let (position, found) = accessor.position::<K>(key);
                 assert!(found);
                 let old_len = accessor.entry(position).unwrap().value().len();
@@ -680,7 +683,7 @@ impl<'a, 'b, K: Key, V: Value> MutateHelper<'a, 'b, K, V> {
                 mutator.insert(position, true, key, value);
             }
             BRANCH => {
-                let accessor = BranchAccessor::new(&page, K::fixed_width());
+                let accessor = BranchAccessor::new(&page, K::fixed_width())?;
                 let (child_index, child_page) = accessor.child_for_key::<K>(key);
                 self.insert_inplace_helper(self.mem.get_page_mut(child_page)?, key, value)?;
                 let mut mutator = BranchMutator::new(page.memory_mut()?);
@@ -700,7 +703,7 @@ impl<'a, 'b, K: Key, V: Value> MutateHelper<'a, 'b, K, V> {
         checksum: Checksum,
         target: DeleteTarget<'_>,
     ) -> Result<Box<(DeletionResult, Option<AccessGuard<'a, V>>)>> {
-        let accessor = LeafAccessor::new(page.memory(), K::fixed_width(), self.value_width());
+        let accessor = LeafAccessor::new(page.memory(), K::fixed_width(), self.value_width())?;
         let (position, found) = match target {
             DeleteTarget::Key(key) => accessor.position::<K>(key),
             DeleteTarget::First => {
@@ -828,7 +831,7 @@ impl<'a, 'b, K: Key, V: Value> MutateHelper<'a, 'b, K, V> {
             // TODO: can we optimize away this page allocation?
             // The PartialInternal gets returned, and then the caller has to merge it immediately
             let new_page = builder.build()?;
-            let accessor = BranchAccessor::new(&new_page, K::fixed_width());
+            let accessor = BranchAccessor::new(&new_page, K::fixed_width())?;
             // Merge when less than 33% full. Splits occur when a page is full and produce two 50%
             // full pages, so we use 33% instead of 50% to avoid oscillating
             if accessor.total_length() < page_size / 3 {
@@ -846,7 +849,7 @@ impl<'a, 'b, K: Key, V: Value> MutateHelper<'a, 'b, K, V> {
         checksum: Checksum,
         target: DeleteTarget<'_>,
     ) -> Result<Box<(DeletionResult, Option<AccessGuard<'a, V>>)>> {
-        let accessor = BranchAccessor::new(&page, K::fixed_width());
+        let accessor = BranchAccessor::new(&page, K::fixed_width())?;
         let original_page_number = page.get_page_number();
         let (child_index, child_page_number) = match target {
             DeleteTarget::Key(key) => accessor.child_for_key::<K>(key),
@@ -933,7 +936,7 @@ impl<'a, 'b, K: Key, V: Value> MutateHelper<'a, 'b, K, V> {
                 deleted_pair,
             } => {
                 let partial_child_accessor =
-                    LeafAccessor::new(&partial_child_page, K::fixed_width(), self.value_width());
+                    LeafAccessor::new(&partial_child_page, K::fixed_width(), self.value_width())?;
                 debug_assert!(partial_child_accessor.num_pairs() > 1);
 
                 let merge_with = if child_index == 0 { 1 } else { child_index - 1 };
@@ -945,7 +948,7 @@ impl<'a, 'b, K: Key, V: Value> MutateHelper<'a, 'b, K, V> {
                     merge_with_page.memory(),
                     K::fixed_width(),
                     self.value_width(),
-                );
+                )?;
 
                 let single_large_value = merge_with_accessor.num_pairs() == 1
                     && merge_with_accessor.total_length() >= self.mem.get_page_size();
@@ -1034,7 +1037,7 @@ impl<'a, 'b, K: Key, V: Value> MutateHelper<'a, 'b, K, V> {
                 let merge_with_page = self
                     .mem
                     .get_page(accessor.child_page(merge_with).unwrap())?;
-                let merge_with_accessor = BranchAccessor::new(&merge_with_page, K::fixed_width());
+                let merge_with_accessor = BranchAccessor::new(&merge_with_page, K::fixed_width())?;
                 debug_assert!(merge_with < accessor.count_children());
                 for i in 0..accessor.count_children() {
                     if i == child_index {
@@ -1091,12 +1094,12 @@ impl<'a, 'b, K: Key, V: Value> MutateHelper<'a, 'b, K, V> {
             PartialBranch(partial_child, ..) => {
                 let partial_child_page = self.mem.get_page(partial_child)?;
                 let partial_child_accessor =
-                    BranchAccessor::new(&partial_child_page, K::fixed_width());
+                    BranchAccessor::new(&partial_child_page, K::fixed_width())?;
                 let merge_with = if child_index == 0 { 1 } else { child_index - 1 };
                 let merge_with_page = self
                     .mem
                     .get_page(accessor.child_page(merge_with).unwrap())?;
-                let merge_with_accessor = BranchAccessor::new(&merge_with_page, K::fixed_width());
+                let merge_with_accessor = BranchAccessor::new(&merge_with_page, K::fixed_width())?;
                 debug_assert!(merge_with < accessor.count_children());
                 for i in 0..accessor.count_children() {
                     if i == child_index {


### PR DESCRIPTION
## Summary
- Change `LeafAccessor::new()` and `BranchAccessor::new()` to return `Result<Self, StorageError>` with bounds validation
- Corrupted pages now return `StorageError::Corrupted` instead of panicking on out-of-bounds access
- Updated ~65 call sites across 5 files: reader paths use `?`, writer paths use `.expect()`

## Details
- **LeafAccessor**: validates page >= 4 bytes, offset tables for `num_pairs` fit within page
- **BranchAccessor**: validates page >= 8 bytes, child table and key offset table fit within page
- **btree.rs**: 23 call sites (21 `?`, 2 `.expect()` in catch_unwind salvage)
- **btree_iters.rs**: 13 call sites (12 `?`, 1 match pattern)
- **btree_mutator.rs**: 21 call sites (all `?`)
- **multimap_table.rs**: 16+ call sites, `LeafKeyIter` signature updated
- **btree_base.rs**: 9 internal call sites (5 `?`, 4 `.expect()` in mutator/writer paths)

## Test plan
- [x] `cargo check` — compiles clean
- [x] `cargo clippy -- -D warnings` — no warnings
- [x] `cargo fmt --all -- --check` — formatted
- [x] `cargo test --lib` — 231 tests pass
- [x] `cargo test` — 1,437+ tests pass, 0 failures
- [ ] CI: 15 checks (Linux x86/ARM, macOS, Windows, wasm32, MSRV, features)