### PR TITLE
refactor: reclassify ~25 Corrupted misuses to typed error variants

### DIFF
--- a/src/composite/query.rs
+++ b/src/composite/query.rs
@@ -451,29 +451,28 @@ impl<'a, P: BlobQueryProvider, R: StorageRead> CompositeQuery<'a, P, R> {
 
     fn validate(&self) -> crate::Result<()> {
         if !self.weights.any_active() {
-            return Err(StorageError::Corrupted(
-                "CompositeQuery: at least one signal must have weight > 0".to_string(),
+            return Err(StorageError::invalid_config(
+                "CompositeQuery: at least one signal must have weight > 0",
             ));
         }
         if self.weights.semantic > 0.0 && self.query_vector.is_none() {
-            return Err(StorageError::Corrupted(
-                "CompositeQuery: semantic signal requires a query vector".to_string(),
+            return Err(StorageError::invalid_config(
+                "CompositeQuery: semantic signal requires a query vector",
             ));
         }
         if self.weights.semantic > 0.0 && self.vector_index.is_none() {
-            return Err(StorageError::Corrupted(
-                "CompositeQuery: semantic signal requires an IVF-PQ index".to_string(),
+            return Err(StorageError::invalid_config(
+                "CompositeQuery: semantic signal requires an IVF-PQ index",
             ));
         }
         if self.weights.semantic > 0.0 && self.storage_reader.is_none() {
-            return Err(StorageError::Corrupted(
-                "CompositeQuery: semantic signal requires a StorageRead (use with_storage_reader)"
-                    .to_string(),
+            return Err(StorageError::invalid_config(
+                "CompositeQuery: semantic signal requires a StorageRead (use with_storage_reader)",
             ));
         }
         if self.weights.causal > 0.0 && self.causal_root.is_none() {
-            return Err(StorageError::Corrupted(
-                "CompositeQuery: causal signal requires a root blob_id".to_string(),
+            return Err(StorageError::invalid_config(
+                "CompositeQuery: causal signal requires a root blob_id",
             ));
         }
         // When temporal is the only active signal, time_range is required to
@@ -484,13 +483,13 @@ impl<'a, P: BlobQueryProvider, R: StorageRead> CompositeQuery<'a, P, R> {
             && self.weights.causal <= 0.0
             && self.time_range.is_none()
         {
-            return Err(StorageError::Corrupted(
-                "CompositeQuery: temporal-only signal requires a time_range".to_string(),
+            return Err(StorageError::invalid_config(
+                "CompositeQuery: temporal-only signal requires a time_range",
             ));
         }
         if self.top_k == 0 {
-            return Err(StorageError::Corrupted(
-                "CompositeQuery: top_k must be >= 1".to_string(),
+            return Err(StorageError::invalid_config(
+                "CompositeQuery: top_k must be >= 1",
             ));
         }
         Ok(())

--- a/src/db.rs
+++ b/src/db.rs
@@ -1139,8 +1139,8 @@ impl Database {
         let allocator_hash = self.mem.allocator_hash();
         let mut was_clean = Arc::get_mut(&mut self.mem)
             .ok_or_else(|| {
-                DatabaseError::Storage(StorageError::Corrupted(
-                    "check_integrity() requires exclusive database access, but other references to the memory exist".into(),
+                DatabaseError::Storage(StorageError::invalid_config(
+                    "check_integrity() requires exclusive database access, but other references to the memory exist",
                 ))
             })?
             .clear_cache_and_reload()?;

--- a/src/incremental.rs
+++ b/src/incremental.rs
@@ -309,7 +309,7 @@ impl IncrementalSnapshot {
 #[cfg(feature = "std")]
 fn check_bounds(payload: &[u8], pos: usize, need: usize) -> Result<(), StorageError> {
     if pos.checked_add(need).is_none_or(|end| end > payload.len()) {
-        return Err(StorageError::Corrupted(alloc::format!(
+        return Err(StorageError::format_error(alloc::format!(
             "incremental snapshot truncated: need {} bytes at offset {}, have {}",
             need,
             pos,
@@ -385,9 +385,7 @@ impl IncrementalSnapshot {
     #[allow(clippy::cast_possible_truncation)]
     pub fn from_bytes(data: &[u8]) -> Result<Self, StorageError> {
         if data.len() < HEADER_SIZE + SHA256_SIZE {
-            return Err(StorageError::Corrupted(
-                "incremental delta too short".into(),
-            ));
+            return Err(StorageError::format_error("incremental delta too short"));
         }
 
         // Verify SHA-256 footer
@@ -395,8 +393,8 @@ impl IncrementalSnapshot {
         let stored_hash = &data[data.len() - SHA256_SIZE..];
         let computed_hash = Sha256::digest(payload);
         if computed_hash.as_slice() != stored_hash {
-            return Err(StorageError::Corrupted(
-                "incremental delta SHA-256 mismatch".into(),
+            return Err(StorageError::format_error(
+                "incremental delta SHA-256 mismatch",
             ));
         }
 
@@ -406,17 +404,15 @@ impl IncrementalSnapshot {
         check_bounds(payload, pos, 8)?;
         let magic = &payload[pos..pos + 8];
         if magic != DELTA_MAGIC {
-            return Err(StorageError::Corrupted(
-                "incremental delta bad magic".into(),
-            ));
+            return Err(StorageError::format_error("incremental delta bad magic"));
         }
         pos += 8;
 
         check_bounds(payload, pos, 4)?;
         let version = payload[pos];
         if version != DELTA_VERSION {
-            return Err(StorageError::Corrupted(
-                "incremental delta unsupported version".into(),
+            return Err(StorageError::format_error(
+                "incremental delta unsupported version",
             ));
         }
         pos += 1 + 3; // version + padding
@@ -437,9 +433,8 @@ impl IncrementalSnapshot {
             let name_len = u16::from_le_bytes(payload[pos..pos + 2].try_into().unwrap()) as usize;
             pos += 2;
             check_bounds(payload, pos, name_len)?;
-            let name = core::str::from_utf8(&payload[pos..pos + name_len]).map_err(|_| {
-                StorageError::Corrupted("incremental delta invalid table name".into())
-            })?;
+            let name = core::str::from_utf8(&payload[pos..pos + name_len])
+                .map_err(|_| StorageError::format_error("incremental delta invalid table name"))?;
             pos += name_len;
 
             check_bounds(payload, pos, 8)?;
@@ -479,8 +474,8 @@ impl IncrementalSnapshot {
                 combined.extend_from_slice(&value);
                 let computed_checksum = hash128_with_seed(&combined, XXH3_SEED);
                 if stored_checksum != computed_checksum {
-                    return Err(StorageError::Corrupted(
-                        "incremental delta entry checksum mismatch".into(),
+                    return Err(StorageError::format_error(
+                        "incremental delta entry checksum mismatch",
                     ));
                 }
 
@@ -517,7 +512,7 @@ impl IncrementalSnapshot {
             pos += 2;
             check_bounds(payload, pos, name_len)?;
             let name = core::str::from_utf8(&payload[pos..pos + name_len]).map_err(|_| {
-                StorageError::Corrupted("incremental delta invalid dropped table name".into())
+                StorageError::format_error("incremental delta invalid dropped table name")
             })?;
             pos += name_len;
             dropped_tables.push(name.to_string());

--- a/src/transaction_tracker.rs
+++ b/src/transaction_tracker.rs
@@ -27,9 +27,7 @@ impl TransactionId {
     }
 
     pub(crate) fn next(self) -> Result<TransactionId> {
-        let value = self.0.checked_add(1).ok_or_else(|| {
-            StorageError::Corrupted(format!("TransactionId overflow at {}", self.0))
-        })?;
+        let value = self.0.checked_add(1).ok_or(StorageError::OutOfSpace)?;
         Ok(TransactionId(value))
     }
 
@@ -45,9 +43,7 @@ pub(crate) struct SavepointId(pub u64);
 
 impl SavepointId {
     pub(crate) fn next(self) -> Result<SavepointId> {
-        let value = self.0.checked_add(1).ok_or_else(|| {
-            StorageError::Corrupted(format!("SavepointId overflow at {}", self.0))
-        })?;
+        let value = self.0.checked_add(1).ok_or(StorageError::OutOfSpace)?;
         Ok(SavepointId(value))
     }
 }

--- a/src/tree_store/page_store/compression.rs
+++ b/src/tree_store/page_store/compression.rs
@@ -17,7 +17,6 @@
 use crate::{Result, StorageError};
 use alloc::borrow::Cow;
 use alloc::format;
-use alloc::string::ToString;
 use alloc::vec::Vec;
 
 /// User-facing compression configuration.
@@ -71,16 +70,14 @@ impl CompressionConfig {
             #[cfg(feature = "compression_zstd")]
             2 => Ok(Self::Zstd { level: 0 }),
             #[cfg(not(feature = "compression_lz4"))]
-            1 => Err(StorageError::Corrupted(
-                "database uses LZ4 compression but compression_lz4 feature is not enabled"
-                    .to_string(),
+            1 => Err(StorageError::invalid_config(
+                "database uses LZ4 compression but compression_lz4 feature is not enabled",
             )),
             #[cfg(not(feature = "compression_zstd"))]
-            2 => Err(StorageError::Corrupted(
-                "database uses zstd compression but compression_zstd feature is not enabled"
-                    .to_string(),
+            2 => Err(StorageError::invalid_config(
+                "database uses zstd compression but compression_zstd feature is not enabled",
             )),
-            other => Err(StorageError::Corrupted(format!(
+            other => Err(StorageError::format_error(format!(
                 "unknown compression algorithm in header: {other}"
             ))),
         }
@@ -172,8 +169,8 @@ pub(crate) fn decompress_value(data: &[u8]) -> Result<Cow<'_, [u8]>> {
     }
 
     if data.len() < VALUE_ENVELOPE_SIZE {
-        return Err(StorageError::Corrupted(
-            "compressed value too short for envelope header".to_string(),
+        return Err(StorageError::format_error(
+            "compressed value too short for envelope header",
         ));
     }
 
@@ -212,14 +209,14 @@ pub(crate) fn decompress_value(data: &[u8]) -> Result<Cow<'_, [u8]>> {
             Ok(Cow::Owned(decompressed))
         }
         #[cfg(not(feature = "compression_lz4"))]
-        0x02 => Err(StorageError::Corrupted(
-            "value uses LZ4 compression but compression_lz4 feature is not enabled".to_string(),
+        0x02 => Err(StorageError::invalid_config(
+            "value uses LZ4 compression but compression_lz4 feature is not enabled",
         )),
         #[cfg(not(feature = "compression_zstd"))]
-        0x04 => Err(StorageError::Corrupted(
-            "value uses zstd compression but compression_zstd feature is not enabled".to_string(),
+        0x04 => Err(StorageError::invalid_config(
+            "value uses zstd compression but compression_zstd feature is not enabled",
         )),
-        _ => Err(StorageError::Corrupted(format!(
+        _ => Err(StorageError::format_error(format!(
             "unknown value compression algorithm bits: {algo_bits:#04x}"
         ))),
     }

--- a/src/tree_store/page_store/header.rs
+++ b/src/tree_store/page_store/header.rs
@@ -384,7 +384,7 @@ impl TransactionHeader {
             }
             FILE_FORMAT_VERSION3 | FILE_FORMAT_VERSION4 | FILE_FORMAT_VERSION5 => {}
             _ => {
-                return Err(StorageError::Corrupted(format!(
+                return Err(StorageError::format_error(format!(
                     "Expected file format version <= {FILE_FORMAT_VERSION5}, found {version}",
                 ))
                 .into());


### PR DESCRIPTION
## Summary
- Reclassify 25 `StorageError::Corrupted` uses that were misclassified
- Configuration validation → `InvalidConfiguration` (11 sites)
- Format/deserialization validation → `FormatError` (12 sites)
- ID space exhaustion → `OutOfSpace` (2 sites)

## Changes by file
- **composite/query.rs**: 7 `validate()` checks → `InvalidConfiguration`
- **transaction_tracker.rs**: TransactionId/SavepointId overflow → `OutOfSpace`
- **incremental.rs**: 8 delta format checks → `FormatError`
- **header.rs**: unknown file format version → `FormatError`
- **compression.rs**: missing feature → `InvalidConfiguration` (4), unknown algo → `FormatError` (2)
- **db.rs**: exclusive access requirement → `InvalidConfiguration`

## Test plan
- [x] `cargo clippy -- -D warnings` — clean
- [x] `cargo fmt --all -- --check` — formatted
- [x] `cargo test --lib` — 231 tests pass
- [ ] CI: 15 checks