### PR TITLE
feat(fuzz): 5 new fuzz targets for production hardening

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -226,11 +226,14 @@ jobs:
         env:
           RUST_BACKTRACE: "1"
 
-      - name: Fuzzer (60s)
+      - name: Fuzzer (60s core + 30s each new target)
         if: matrix.fuzz
         run: |
           HOST_TARGET=$(rustc -vV | awk '/^host:/ {print $2}')
           cargo +nightly fuzz run --sanitizer=none --target "$HOST_TARGET" fuzz_redb -- -max_len=10000 -max_total_time=60
+          for target in fuzz_cdc_deser fuzz_cluster_blob fuzz_incremental_deser fuzz_merge_ops fuzz_pq_codebook; do
+            cargo +nightly fuzz run --sanitizer=none --target "$HOST_TARGET" "$target" -- -max_len=10000 -max_total_time=30
+          done
         env:
           RUSTFLAGS: ""
 

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -33,7 +33,7 @@ jobs:
       - name: Install tools
         uses: taiki-e/install-action@v2
         with:
-          tool: cargo-fuzz@0.12.0,cargo-deny@0.19.0
+          tool: cargo-fuzz@0.13.1,cargo-deny@0.19.0
 
       - name: Fuzz redb core (5 minutes)
         run: cargo fuzz run --sanitizer=none fuzz_redb -- -max_len=10000 -max_total_time=300
@@ -49,6 +49,21 @@ jobs:
 
       - name: Fuzz IVF-PQ kmeans (90s)
         run: cargo fuzz run --sanitizer=none fuzz_ivfpq_kmeans -- -max_len=10000 -max_total_time=90
+
+      - name: Fuzz CDC deser (90s)
+        run: cargo fuzz run --sanitizer=none fuzz_cdc_deser -- -max_len=10000 -max_total_time=90
+
+      - name: Fuzz cluster blob (90s)
+        run: cargo fuzz run --sanitizer=none fuzz_cluster_blob -- -max_len=10000 -max_total_time=90
+
+      - name: Fuzz incremental deser (90s)
+        run: cargo fuzz run --sanitizer=none fuzz_incremental_deser -- -max_len=10000 -max_total_time=90
+
+      - name: Fuzz merge ops (90s)
+        run: cargo fuzz run --sanitizer=none fuzz_merge_ops -- -max_len=10000 -max_total_time=90
+
+      - name: Fuzz PQ codebook (90s)
+        run: cargo fuzz run --sanitizer=none fuzz_pq_codebook -- -max_len=10000 -max_total_time=90
 
       - name: Upload corpus on failure
         if: failure()

--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -31,12 +31,6 @@ checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "bitflags"
-version = "1.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
-
-[[package]]
-name = "bitflags"
 version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
@@ -121,7 +115,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys",
 ]
 
 [[package]]
@@ -227,16 +221,6 @@ dependencies = [
  "hashbrown 0.16.1",
  "serde",
  "serde_core",
-]
-
-[[package]]
-name = "io-uring"
-version = "0.6.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "595a0399f411a508feb2ec1e970a4a30c249351e30208960d58298de8660b0e5"
-dependencies = [
- "bitflags 1.3.2",
- "libc",
 ]
 
 [[package]]
@@ -430,11 +414,11 @@ version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags",
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.2",
+ "windows-sys",
 ]
 
 [[package]]
@@ -450,7 +434,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
 dependencies = [
  "serde_core",
- "serde_derive",
 ]
 
 [[package]]
@@ -487,15 +470,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "serde_spanned"
-version = "0.6.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf41e0cfaf7226dca15e8197172c295a782857fcb97fad1808a166870dee75a3"
-dependencies = [
- "serde",
-]
-
-[[package]]
 name = "sha2"
 version = "0.10.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -514,21 +488,13 @@ checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
 name = "shodh-redb"
-version = "0.3.1"
+version = "0.3.3"
 dependencies = [
- "cfg-if",
  "hashbrown 0.15.5",
- "io-uring",
  "libc",
  "portable-atomic",
- "rand",
- "serde",
- "serde_json",
  "sha2",
  "spin",
- "thread_local",
- "toml",
- "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -536,6 +502,9 @@ name = "spin"
 version = "0.9.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
+dependencies = [
+ "portable-atomic",
+]
 
 [[package]]
 name = "syn"
@@ -558,58 +527,8 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys",
 ]
-
-[[package]]
-name = "thread_local"
-version = "1.1.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
-dependencies = [
- "cfg-if",
-]
-
-[[package]]
-name = "toml"
-version = "0.8.23"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc1beb996b9d83529a9e75c17a1686767d148d70663143c7854d8b4a09ced362"
-dependencies = [
- "serde",
- "serde_spanned",
- "toml_datetime",
- "toml_edit",
-]
-
-[[package]]
-name = "toml_datetime"
-version = "0.6.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22cddaf88f4fbc13c51aebbf5f8eceb5c7c5a9da2ac40a13519eb5b0a0e8f11c"
-dependencies = [
- "serde",
-]
-
-[[package]]
-name = "toml_edit"
-version = "0.22.27"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
-dependencies = [
- "indexmap",
- "serde",
- "serde_spanned",
- "toml_datetime",
- "toml_write",
- "winnow",
-]
-
-[[package]]
-name = "toml_write"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
 
 [[package]]
 name = "typenum"
@@ -687,7 +606,7 @@ version = "0.244.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags",
  "hashbrown 0.15.5",
  "indexmap",
  "semver",
@@ -701,93 +620,11 @@ checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
 
 [[package]]
 name = "windows-sys"
-version = "0.59.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
-dependencies = [
- "windows-targets",
-]
-
-[[package]]
-name = "windows-sys"
 version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
  "windows-link",
-]
-
-[[package]]
-name = "windows-targets"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
-dependencies = [
- "windows_aarch64_gnullvm",
- "windows_aarch64_msvc",
- "windows_i686_gnu",
- "windows_i686_gnullvm",
- "windows_i686_msvc",
- "windows_x86_64_gnu",
- "windows_x86_64_gnullvm",
- "windows_x86_64_msvc",
-]
-
-[[package]]
-name = "windows_aarch64_gnullvm"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
-
-[[package]]
-name = "windows_aarch64_msvc"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
-
-[[package]]
-name = "windows_i686_gnu"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
-
-[[package]]
-name = "windows_i686_gnullvm"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
-
-[[package]]
-name = "windows_i686_msvc"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
-
-[[package]]
-name = "windows_x86_64_gnullvm"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
-
-[[package]]
-name = "windows_x86_64_msvc"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
-
-[[package]]
-name = "winnow"
-version = "0.7.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
-dependencies = [
- "memchr",
 ]
 
 [[package]]
@@ -848,7 +685,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
 dependencies = [
  "anyhow",
- "bitflags 2.11.0",
+ "bitflags",
  "indexmap",
  "log",
  "serde",

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -18,7 +18,7 @@ rand_distr = "0.4.3"
 [dependencies.redb]
 package = "shodh-redb"
 path = ".."
-features = []
+features = ["std"]
 
 # Prevent this from interfering with workspaces
 [workspace]
@@ -51,6 +51,36 @@ doc = false
 [[bin]]
 name = "fuzz_ivfpq_kmeans"
 path = "fuzz_targets/fuzz_ivfpq_kmeans.rs"
+test = false
+doc = false
+
+[[bin]]
+name = "fuzz_cdc_deser"
+path = "fuzz_targets/fuzz_cdc_deser.rs"
+test = false
+doc = false
+
+[[bin]]
+name = "fuzz_cluster_blob"
+path = "fuzz_targets/fuzz_cluster_blob.rs"
+test = false
+doc = false
+
+[[bin]]
+name = "fuzz_incremental_deser"
+path = "fuzz_targets/fuzz_incremental_deser.rs"
+test = false
+doc = false
+
+[[bin]]
+name = "fuzz_merge_ops"
+path = "fuzz_targets/fuzz_merge_ops.rs"
+test = false
+doc = false
+
+[[bin]]
+name = "fuzz_pq_codebook"
+path = "fuzz_targets/fuzz_pq_codebook.rs"
 test = false
 doc = false
 

--- a/fuzz/fuzz_targets/fuzz_cdc_deser.rs
+++ b/fuzz/fuzz_targets/fuzz_cdc_deser.rs
@@ -7,9 +7,9 @@ use redb::{ChangeOp, Key, Value};
 
 #[derive(Arbitrary, Debug)]
 enum FuzzOp {
-    /// Deserialize arbitrary bytes as a CDC record — must never panic.
+    /// Deserialize arbitrary bytes as a CDC record -- must never panic.
     DeserializeRecord { data: Vec<u8> },
-    /// Serialize then deserialize a constructed record — roundtrip.
+    /// Serialize then deserialize a constructed record -- roundtrip.
     RoundtripRecord {
         op_byte: u8,
         table_name: String,
@@ -105,7 +105,7 @@ fuzz_target!(|op: FuzzOp| {
         FuzzOp::ChangeOpFromByte { byte } => {
             // Valid discriminants are 0, 1, 2. All others must return Err.
             let result = CdcRecord::deserialize(&[byte]);
-            // Single byte is too short for a full record — always Err.
+            // Single byte is too short for a full record -- always Err.
             assert!(result.is_err());
         }
     }

--- a/fuzz/fuzz_targets/fuzz_cdc_deser.rs
+++ b/fuzz/fuzz_targets/fuzz_cdc_deser.rs
@@ -1,0 +1,112 @@
+#![no_main]
+
+use arbitrary::Arbitrary;
+use libfuzzer_sys::fuzz_target;
+use redb::cdc::types::{CdcKey, CdcRecord};
+use redb::{ChangeOp, Key, Value};
+
+#[derive(Arbitrary, Debug)]
+enum FuzzOp {
+    /// Deserialize arbitrary bytes as a CDC record — must never panic.
+    DeserializeRecord { data: Vec<u8> },
+    /// Serialize then deserialize a constructed record — roundtrip.
+    RoundtripRecord {
+        op_byte: u8,
+        table_name: String,
+        key: Vec<u8>,
+        has_new: bool,
+        new_value: Vec<u8>,
+        has_old: bool,
+        old_value: Vec<u8>,
+    },
+    /// CdcKey Value trait roundtrip.
+    CdcKeyRoundtrip {
+        transaction_id: u64,
+        sequence: u32,
+    },
+    /// CdcKey Key::compare ordering consistency.
+    CdcKeyCompare {
+        txn_a: u64,
+        seq_a: u32,
+        txn_b: u64,
+        seq_b: u32,
+    },
+    /// ChangeOp try_from for all byte values.
+    ChangeOpFromByte { byte: u8 },
+}
+
+fuzz_target!(|op: FuzzOp| {
+    match op {
+        FuzzOp::DeserializeRecord { data } => {
+            // Must not panic on any input.
+            let _ = CdcRecord::deserialize(&data);
+        }
+
+        FuzzOp::RoundtripRecord {
+            op_byte,
+            table_name,
+            key,
+            has_new,
+            new_value,
+            has_old,
+            old_value,
+        } => {
+            let change_op = match op_byte % 3 {
+                0 => ChangeOp::Insert,
+                1 => ChangeOp::Update,
+                _ => ChangeOp::Delete,
+            };
+            // Truncate table name to u16::MAX bytes (serialization limit).
+            let table_name: String = table_name.chars().take(200).collect();
+            let record = CdcRecord {
+                op: change_op,
+                table_name,
+                key,
+                new_value: if has_new { Some(new_value) } else { None },
+                old_value: if has_old { Some(old_value) } else { None },
+            };
+            let bytes = record.serialize();
+            let restored = CdcRecord::deserialize(&bytes)
+                .expect("roundtrip deserialization must succeed");
+            assert_eq!(restored.op, record.op);
+            assert_eq!(restored.table_name, record.table_name);
+            assert_eq!(restored.key, record.key);
+            assert_eq!(restored.new_value, record.new_value);
+            assert_eq!(restored.old_value, record.old_value);
+        }
+
+        FuzzOp::CdcKeyRoundtrip {
+            transaction_id,
+            sequence,
+        } => {
+            let key = CdcKey::new(transaction_id, sequence);
+            let bytes = <CdcKey as Value>::as_bytes(&key);
+            let restored = <CdcKey as Value>::from_bytes(&bytes);
+            assert_eq!(restored.transaction_id, transaction_id);
+            assert_eq!(restored.sequence, sequence);
+        }
+
+        FuzzOp::CdcKeyCompare {
+            txn_a,
+            seq_a,
+            txn_b,
+            seq_b,
+        } => {
+            let a = CdcKey::new(txn_a, seq_a);
+            let b = CdcKey::new(txn_b, seq_b);
+            let bytes_a = <CdcKey as Value>::as_bytes(&a);
+            let bytes_b = <CdcKey as Value>::as_bytes(&b);
+            // Key::compare must agree with Ord.
+            let key_cmp = <CdcKey as Key>::compare(&bytes_a, &bytes_b);
+            let ord_cmp = a.cmp(&b);
+            assert_eq!(key_cmp, ord_cmp);
+        }
+
+        FuzzOp::ChangeOpFromByte { byte } => {
+            // Valid discriminants are 0, 1, 2. All others must return Err.
+            let result = CdcRecord::deserialize(&[byte]);
+            // Single byte is too short for a full record — always Err.
+            assert!(result.is_err());
+        }
+    }
+});

--- a/fuzz/fuzz_targets/fuzz_cluster_blob.rs
+++ b/fuzz/fuzz_targets/fuzz_cluster_blob.rs
@@ -1,0 +1,198 @@
+#![no_main]
+
+use arbitrary::Arbitrary;
+use libfuzzer_sys::fuzz_target;
+use redb::ivfpq::cluster_blob::{
+    encode_cluster_blob, merge_into_blob, remove_from_blob, ClusterBlobRef,
+};
+
+#[derive(Arbitrary, Debug)]
+enum FuzzOp {
+    /// Parse arbitrary bytes as a cluster blob — must not panic.
+    ParseRaw {
+        data: Vec<u8>,
+        pq_len: u16,
+        dim_sel: u8,
+    },
+    /// Encode entries then parse — roundtrip.
+    EncodeRoundtrip {
+        /// Number of entries (clamped to 1..8).
+        num_entries: u8,
+        /// PQ code length (clamped to 1..16).
+        pq_len: u8,
+        /// Dimension selector: 0..3 → 2/4/8/16.
+        dim_sel: u8,
+        /// Raw u32 bits for vector IDs.
+        vector_ids: Vec<u64>,
+        /// Raw u32 bits for PQ codes.
+        pq_data: Vec<u8>,
+    },
+    /// Merge a new entry into an existing blob.
+    MergeEntry {
+        pq_len: u8,
+        dim_sel: u8,
+        existing_ids: Vec<u64>,
+        existing_pq: Vec<u8>,
+        new_id: u64,
+        new_pq: Vec<u8>,
+    },
+    /// Remove an entry from a blob.
+    RemoveEntry {
+        pq_len: u8,
+        dim_sel: u8,
+        ids: Vec<u64>,
+        pq_data: Vec<u8>,
+        remove_id: u64,
+    },
+}
+
+fn select_dim(sel: u8) -> usize {
+    match sel % 4 {
+        0 => 2,
+        1 => 4,
+        2 => 8,
+        _ => 16,
+    }
+}
+
+fuzz_target!(|op: FuzzOp| {
+    match op {
+        FuzzOp::ParseRaw {
+            data,
+            pq_len,
+            dim_sel,
+        } => {
+            let dim = select_dim(dim_sel);
+            let pq_len = pq_len.max(1);
+            // Must not panic on any input.
+            let _ = ClusterBlobRef::new(&data, pq_len, dim);
+        }
+
+        FuzzOp::EncodeRoundtrip {
+            num_entries,
+            pq_len,
+            dim_sel,
+            vector_ids,
+            pq_data,
+        } => {
+            let dim = select_dim(dim_sel);
+            let pq_len = (pq_len as u16).clamp(1, 16);
+            let n = (num_entries as usize).clamp(1, 8).min(vector_ids.len());
+            if n == 0 {
+                return;
+            }
+
+            // Build entries with no raw vectors (simpler path).
+            let mut entries: Vec<(u64, Vec<u8>, Option<Vec<f32>>)> = Vec::with_capacity(n);
+            for i in 0..n {
+                let id = vector_ids[i % vector_ids.len()];
+                let pq_start = (i * pq_len as usize) % pq_data.len().max(1);
+                let codes: Vec<u8> = (0..pq_len as usize)
+                    .map(|j| {
+                        pq_data
+                            .get((pq_start + j) % pq_data.len().max(1))
+                            .copied()
+                            .unwrap_or(0)
+                    })
+                    .collect();
+                entries.push((id, codes, None));
+            }
+
+            // Build the tuple refs that encode_cluster_blob expects.
+            let entry_refs: Vec<(u64, &[u8], Option<&[f32]>)> = entries
+                .iter()
+                .map(|(id, codes, _)| (*id, codes.as_slice(), None))
+                .collect();
+
+            let blob = encode_cluster_blob(&entry_refs, pq_len);
+            let parsed = ClusterBlobRef::new(&blob, pq_len, dim);
+            if let Ok(parsed) = parsed {
+                assert_eq!(parsed.count() as usize, n);
+                // Verify all IDs are findable.
+                for (id, _, _) in &entry_refs {
+                    assert!(parsed.find_vector(*id).is_some());
+                }
+            }
+        }
+
+        FuzzOp::MergeEntry {
+            pq_len,
+            dim_sel,
+            existing_ids,
+            existing_pq,
+            new_id,
+            new_pq,
+        } => {
+            let dim = select_dim(dim_sel);
+            let pq_len = (pq_len as u16).clamp(1, 16);
+            if existing_ids.is_empty() {
+                return;
+            }
+            let n = existing_ids.len().min(4);
+
+            let mut entries: Vec<(u64, Vec<u8>, Option<Vec<f32>>)> = Vec::new();
+            for i in 0..n {
+                let codes: Vec<u8> = (0..pq_len as usize)
+                    .map(|j| {
+                        existing_pq
+                            .get((i * pq_len as usize + j) % existing_pq.len().max(1))
+                            .copied()
+                            .unwrap_or(0)
+                    })
+                    .collect();
+                entries.push((existing_ids[i], codes, None));
+            }
+            let entry_refs: Vec<(u64, &[u8], Option<&[f32]>)> = entries
+                .iter()
+                .map(|(id, codes, _)| (*id, codes.as_slice(), None))
+                .collect();
+            let blob = encode_cluster_blob(&entry_refs, pq_len);
+
+            if let Ok(parsed) = ClusterBlobRef::new(&blob, pq_len, dim) {
+                let new_codes: Vec<u8> = (0..pq_len as usize)
+                    .map(|j| new_pq.get(j % new_pq.len().max(1)).copied().unwrap_or(0))
+                    .collect();
+                let mut new_entries = vec![(new_id, new_codes, None)];
+                let merged = merge_into_blob(Some(&parsed), &mut new_entries, pq_len);
+                // Merged blob must parse.
+                let _ = ClusterBlobRef::new(&merged, pq_len, dim);
+            }
+        }
+
+        FuzzOp::RemoveEntry {
+            pq_len,
+            dim_sel,
+            ids,
+            pq_data,
+            remove_id,
+        } => {
+            let dim = select_dim(dim_sel);
+            let pq_len = (pq_len as u16).clamp(1, 16);
+            if ids.is_empty() {
+                return;
+            }
+            let n = ids.len().min(4);
+            let mut entries: Vec<(u64, Vec<u8>, Option<Vec<f32>>)> = Vec::new();
+            for i in 0..n {
+                let codes: Vec<u8> = (0..pq_len as usize)
+                    .map(|j| {
+                        pq_data
+                            .get((i * pq_len as usize + j) % pq_data.len().max(1))
+                            .copied()
+                            .unwrap_or(0)
+                    })
+                    .collect();
+                entries.push((ids[i], codes, None));
+            }
+            let entry_refs: Vec<(u64, &[u8], Option<&[f32]>)> = entries
+                .iter()
+                .map(|(id, codes, _)| (*id, codes.as_slice(), None))
+                .collect();
+            let blob = encode_cluster_blob(&entry_refs, pq_len);
+
+            if let Ok(parsed) = ClusterBlobRef::new(&blob, pq_len, dim) {
+                let _ = remove_from_blob(&parsed, remove_id, pq_len);
+            }
+        }
+    }
+});

--- a/fuzz/fuzz_targets/fuzz_cluster_blob.rs
+++ b/fuzz/fuzz_targets/fuzz_cluster_blob.rs
@@ -83,9 +83,14 @@ fuzz_target!(|op: FuzzOp| {
             }
 
             // Build entries with no raw vectors (simpler path).
+            // Deduplicate IDs to avoid encoding duplicates.
+            let mut seen_ids = std::collections::HashSet::new();
             let mut entries: Vec<(u64, Vec<u8>, Option<Vec<f32>>)> = Vec::with_capacity(n);
             for i in 0..n {
                 let id = vector_ids[i % vector_ids.len()];
+                if !seen_ids.insert(id) {
+                    continue;
+                }
                 let pq_start = (i * pq_len as usize) % pq_data.len().max(1);
                 let codes: Vec<u8> = (0..pq_len as usize)
                     .map(|j| {
@@ -104,10 +109,14 @@ fuzz_target!(|op: FuzzOp| {
                 .map(|(id, codes, _)| (*id, codes.as_slice(), None))
                 .collect();
 
+            if entries.is_empty() {
+                return;
+            }
+
             let blob = encode_cluster_blob(&entry_refs, pq_len);
             let parsed = ClusterBlobRef::new(&blob, pq_len, dim);
             if let Ok(parsed) = parsed {
-                assert_eq!(parsed.count() as usize, n);
+                assert_eq!(parsed.count() as usize, entries.len());
                 // Verify all IDs are findable.
                 for (id, _, _) in &entry_refs {
                     assert!(parsed.find_vector(*id).is_some());
@@ -130,8 +139,12 @@ fuzz_target!(|op: FuzzOp| {
             }
             let n = existing_ids.len().min(4);
 
+            let mut seen_ids = std::collections::HashSet::new();
             let mut entries: Vec<(u64, Vec<u8>, Option<Vec<f32>>)> = Vec::new();
             for i in 0..n {
+                if !seen_ids.insert(existing_ids[i]) {
+                    continue;
+                }
                 let codes: Vec<u8> = (0..pq_len as usize)
                     .map(|j| {
                         existing_pq
@@ -141,6 +154,9 @@ fuzz_target!(|op: FuzzOp| {
                     })
                     .collect();
                 entries.push((existing_ids[i], codes, None));
+            }
+            if entries.is_empty() {
+                return;
             }
             let entry_refs: Vec<(u64, &[u8], Option<&[f32]>)> = entries
                 .iter()
@@ -172,8 +188,12 @@ fuzz_target!(|op: FuzzOp| {
                 return;
             }
             let n = ids.len().min(4);
+            let mut seen_ids = std::collections::HashSet::new();
             let mut entries: Vec<(u64, Vec<u8>, Option<Vec<f32>>)> = Vec::new();
             for i in 0..n {
+                if !seen_ids.insert(ids[i]) {
+                    continue;
+                }
                 let codes: Vec<u8> = (0..pq_len as usize)
                     .map(|j| {
                         pq_data
@@ -183,6 +203,9 @@ fuzz_target!(|op: FuzzOp| {
                     })
                     .collect();
                 entries.push((ids[i], codes, None));
+            }
+            if entries.is_empty() {
+                return;
             }
             let entry_refs: Vec<(u64, &[u8], Option<&[f32]>)> = entries
                 .iter()

--- a/fuzz/fuzz_targets/fuzz_cluster_blob.rs
+++ b/fuzz/fuzz_targets/fuzz_cluster_blob.rs
@@ -103,15 +103,18 @@ fuzz_target!(|op: FuzzOp| {
                 entries.push((id, codes, None));
             }
 
+            if entries.is_empty() {
+                return;
+            }
+
+            // Sort by ID -- encode_cluster_blob expects sorted order for binary search.
+            entries.sort_by_key(|(id, _, _)| *id);
+
             // Build the tuple refs that encode_cluster_blob expects.
             let entry_refs: Vec<(u64, &[u8], Option<&[f32]>)> = entries
                 .iter()
                 .map(|(id, codes, _)| (*id, codes.as_slice(), None))
                 .collect();
-
-            if entries.is_empty() {
-                return;
-            }
 
             let blob = encode_cluster_blob(&entry_refs, pq_len);
             let parsed = ClusterBlobRef::new(&blob, pq_len, dim);
@@ -158,6 +161,7 @@ fuzz_target!(|op: FuzzOp| {
             if entries.is_empty() {
                 return;
             }
+            entries.sort_by_key(|(id, _, _)| *id);
             let entry_refs: Vec<(u64, &[u8], Option<&[f32]>)> = entries
                 .iter()
                 .map(|(id, codes, _)| (*id, codes.as_slice(), None))
@@ -207,6 +211,7 @@ fuzz_target!(|op: FuzzOp| {
             if entries.is_empty() {
                 return;
             }
+            entries.sort_by_key(|(id, _, _)| *id);
             let entry_refs: Vec<(u64, &[u8], Option<&[f32]>)> = entries
                 .iter()
                 .map(|(id, codes, _)| (*id, codes.as_slice(), None))

--- a/fuzz/fuzz_targets/fuzz_cluster_blob.rs
+++ b/fuzz/fuzz_targets/fuzz_cluster_blob.rs
@@ -8,19 +8,19 @@ use redb::ivfpq::cluster_blob::{
 
 #[derive(Arbitrary, Debug)]
 enum FuzzOp {
-    /// Parse arbitrary bytes as a cluster blob — must not panic.
+    /// Parse arbitrary bytes as a cluster blob -- must not panic.
     ParseRaw {
         data: Vec<u8>,
         pq_len: u16,
         dim_sel: u8,
     },
-    /// Encode entries then parse — roundtrip.
+    /// Encode entries then parse -- roundtrip.
     EncodeRoundtrip {
         /// Number of entries (clamped to 1..8).
         num_entries: u8,
         /// PQ code length (clamped to 1..16).
         pq_len: u8,
-        /// Dimension selector: 0..3 → 2/4/8/16.
+        /// Dimension selector: 0..3 -> 2/4/8/16.
         dim_sel: u8,
         /// Raw u32 bits for vector IDs.
         vector_ids: Vec<u64>,

--- a/fuzz/fuzz_targets/fuzz_incremental_deser.rs
+++ b/fuzz/fuzz_targets/fuzz_incremental_deser.rs
@@ -6,9 +6,9 @@ use redb::IncrementalSnapshot;
 
 #[derive(Arbitrary, Debug)]
 enum FuzzOp {
-    /// Deserialize arbitrary bytes — must never panic.
+    /// Deserialize arbitrary bytes -- must never panic.
     DeserializeRaw { data: Vec<u8> },
-    /// If deserialization succeeds, roundtrip through to_bytes → from_bytes.
+    /// If deserialization succeeds, roundtrip through to_bytes -> from_bytes.
     DeserializeAndRoundtrip { data: Vec<u8> },
 }
 

--- a/fuzz/fuzz_targets/fuzz_incremental_deser.rs
+++ b/fuzz/fuzz_targets/fuzz_incremental_deser.rs
@@ -1,0 +1,40 @@
+#![no_main]
+
+use arbitrary::Arbitrary;
+use libfuzzer_sys::fuzz_target;
+use redb::IncrementalSnapshot;
+
+#[derive(Arbitrary, Debug)]
+enum FuzzOp {
+    /// Deserialize arbitrary bytes — must never panic.
+    DeserializeRaw { data: Vec<u8> },
+    /// If deserialization succeeds, roundtrip through to_bytes → from_bytes.
+    DeserializeAndRoundtrip { data: Vec<u8> },
+}
+
+fuzz_target!(|op: FuzzOp| {
+    match op {
+        FuzzOp::DeserializeRaw { data } => {
+            // Must not panic on any input.
+            let _ = IncrementalSnapshot::from_bytes(&data);
+        }
+
+        FuzzOp::DeserializeAndRoundtrip { data } => {
+            // If arbitrary bytes happen to parse, verify roundtrip.
+            if let Ok(snapshot) = IncrementalSnapshot::from_bytes(&data) {
+                let bytes = snapshot.to_bytes();
+                let restored = IncrementalSnapshot::from_bytes(&bytes)
+                    .expect("roundtrip deserialization must succeed");
+                assert_eq!(restored.base_txn, snapshot.base_txn);
+                assert_eq!(restored.current_txn, snapshot.current_txn);
+                assert_eq!(restored.tables_changed(), snapshot.tables_changed());
+                assert_eq!(restored.total_upserts(), snapshot.total_upserts());
+                assert_eq!(restored.total_deletes(), snapshot.total_deletes());
+                assert_eq!(
+                    restored.dropped_table_names(),
+                    snapshot.dropped_table_names()
+                );
+            }
+        }
+    }
+});

--- a/fuzz/fuzz_targets/fuzz_merge_ops.rs
+++ b/fuzz/fuzz_targets/fuzz_merge_ops.rs
@@ -130,7 +130,13 @@ fuzz_target!(|op: FuzzOp| {
             let result = BitwiseOr.merge(&key, Some(&existing), &operand);
             assert!(result.is_some());
             let result = result.unwrap();
-            assert_eq!(result.len(), existing.len().max(operand.len()));
+            if existing.len() == operand.len() {
+                // Same length: bitwise OR, result length matches.
+                assert_eq!(result.len(), existing.len());
+            } else {
+                // Different lengths: returns existing unchanged.
+                assert_eq!(result, existing);
+            }
         }
 
         FuzzOp::BytesAppend {

--- a/fuzz/fuzz_targets/fuzz_merge_ops.rs
+++ b/fuzz/fuzz_targets/fuzz_merge_ops.rs
@@ -1,0 +1,169 @@
+#![no_main]
+
+use arbitrary::Arbitrary;
+use libfuzzer_sys::fuzz_target;
+use redb::merge::{
+    BitwiseOr, BytesAppend, FloatAdd, MergeOperator, NumericAdd, NumericMax, NumericMin,
+    SaturatingAdd,
+};
+
+#[derive(Arbitrary, Debug)]
+enum FuzzOp {
+    /// Test NumericAdd with arbitrary data.
+    NumericAdd {
+        key: Vec<u8>,
+        existing: Vec<u8>,
+        operand: Vec<u8>,
+    },
+    /// Test SaturatingAdd with arbitrary data.
+    SaturatingAdd {
+        key: Vec<u8>,
+        existing: Vec<u8>,
+        operand: Vec<u8>,
+    },
+    /// Test FloatAdd with arbitrary data.
+    FloatAdd {
+        key: Vec<u8>,
+        existing: Vec<u8>,
+        operand: Vec<u8>,
+    },
+    /// Test NumericMax with arbitrary data.
+    NumericMax {
+        key: Vec<u8>,
+        existing: Vec<u8>,
+        operand: Vec<u8>,
+    },
+    /// Test NumericMin with arbitrary data.
+    NumericMin {
+        key: Vec<u8>,
+        existing: Vec<u8>,
+        operand: Vec<u8>,
+    },
+    /// Test BitwiseOr with arbitrary data.
+    BitwiseOr {
+        key: Vec<u8>,
+        existing: Vec<u8>,
+        operand: Vec<u8>,
+    },
+    /// Test BytesAppend with arbitrary data.
+    BytesAppend {
+        key: Vec<u8>,
+        existing: Vec<u8>,
+        operand: Vec<u8>,
+    },
+    /// Test all operators with no existing value.
+    NoExisting {
+        operator_sel: u8,
+        key: Vec<u8>,
+        operand: Vec<u8>,
+    },
+}
+
+fuzz_target!(|op: FuzzOp| {
+    match op {
+        FuzzOp::NumericAdd {
+            key,
+            existing,
+            operand,
+        } => {
+            let result = NumericAdd.merge(&key, Some(&existing), &operand);
+            if existing.len() == operand.len() && matches!(existing.len(), 1 | 2 | 4 | 8) {
+                // Valid widths: must produce a result.
+                assert!(result.is_some());
+                assert_eq!(result.unwrap().len(), existing.len());
+            }
+        }
+
+        FuzzOp::SaturatingAdd {
+            key,
+            existing,
+            operand,
+        } => {
+            let result = SaturatingAdd.merge(&key, Some(&existing), &operand);
+            if existing.len() == operand.len() && matches!(existing.len(), 1 | 2 | 4 | 8) {
+                assert!(result.is_some());
+                assert_eq!(result.unwrap().len(), existing.len());
+            }
+        }
+
+        FuzzOp::FloatAdd {
+            key,
+            existing,
+            operand,
+        } => {
+            let result = FloatAdd.merge(&key, Some(&existing), &operand);
+            if existing.len() == operand.len() && matches!(existing.len(), 4 | 8) {
+                assert!(result.is_some());
+                assert_eq!(result.unwrap().len(), existing.len());
+            }
+        }
+
+        FuzzOp::NumericMax {
+            key,
+            existing,
+            operand,
+        } => {
+            let result = NumericMax.merge(&key, Some(&existing), &operand);
+            if existing.len() == operand.len() && matches!(existing.len(), 1 | 2 | 4 | 8) {
+                assert!(result.is_some());
+                assert_eq!(result.unwrap().len(), existing.len());
+            }
+        }
+
+        FuzzOp::NumericMin {
+            key,
+            existing,
+            operand,
+        } => {
+            let result = NumericMin.merge(&key, Some(&existing), &operand);
+            if existing.len() == operand.len() && matches!(existing.len(), 1 | 2 | 4 | 8) {
+                assert!(result.is_some());
+                assert_eq!(result.unwrap().len(), existing.len());
+            }
+        }
+
+        FuzzOp::BitwiseOr {
+            key,
+            existing,
+            operand,
+        } => {
+            let result = BitwiseOr.merge(&key, Some(&existing), &operand);
+            assert!(result.is_some());
+            let result = result.unwrap();
+            assert_eq!(result.len(), existing.len().max(operand.len()));
+        }
+
+        FuzzOp::BytesAppend {
+            key,
+            existing,
+            operand,
+        } => {
+            let result = BytesAppend.merge(&key, Some(&existing), &operand);
+            assert!(result.is_some());
+            let result = result.unwrap();
+            assert_eq!(result.len(), existing.len() + operand.len());
+            // Verify prefix is existing, suffix is operand.
+            assert_eq!(&result[..existing.len()], &existing[..]);
+            assert_eq!(&result[existing.len()..], &operand[..]);
+        }
+
+        FuzzOp::NoExisting {
+            operator_sel,
+            key,
+            operand,
+        } => {
+            // With no existing value, all operators should return Some(operand).
+            let result = match operator_sel % 7 {
+                0 => NumericAdd.merge(&key, None, &operand),
+                1 => SaturatingAdd.merge(&key, None, &operand),
+                2 => FloatAdd.merge(&key, None, &operand),
+                3 => NumericMax.merge(&key, None, &operand),
+                4 => NumericMin.merge(&key, None, &operand),
+                5 => BitwiseOr.merge(&key, None, &operand),
+                _ => BytesAppend.merge(&key, None, &operand),
+            };
+            assert!(result.is_some());
+            assert_eq!(result.unwrap(), operand);
+        }
+    }
+});

--- a/fuzz/fuzz_targets/fuzz_pq_codebook.rs
+++ b/fuzz/fuzz_targets/fuzz_pq_codebook.rs
@@ -1,0 +1,237 @@
+#![no_main]
+
+use arbitrary::Arbitrary;
+use libfuzzer_sys::fuzz_target;
+use redb::ivfpq::pq::{train_codebooks, Codebooks};
+use redb::DistanceMetric;
+
+#[derive(Arbitrary, Debug)]
+enum FuzzOp {
+    /// Deserialize arbitrary bytes as a codebook — must not panic.
+    DeserializeRaw { data: Vec<u8>, sub_dim_sel: u8 },
+    /// Construct Codebooks, encode a vector, decode codes — roundtrip.
+    EncodeDecodeRoundtrip {
+        /// Number of sub-vectors: 1..4.
+        num_sub_sel: u8,
+        /// Sub-dimension: 2/4/8.
+        sub_dim_sel: u8,
+        /// Raw f32 bits for codebook centroids.
+        centroid_data: Vec<u8>,
+        /// Raw f32 bits for test vector.
+        vector_data: Vec<u8>,
+    },
+    /// serialize_codebook → deserialize_codebook roundtrip.
+    SerializeRoundtrip {
+        num_sub_sel: u8,
+        sub_dim_sel: u8,
+        centroid_data: Vec<u8>,
+    },
+    /// Train codebooks on small data (≤16 vectors, small dims).
+    Train {
+        /// Number of vectors: clamped to 2..16.
+        num_vectors: u8,
+        /// Dimension selector: 0..3 → 2/4/6/8.
+        dim_sel: u8,
+        /// Number of sub-vectors selector: 1 or 2.
+        num_sub_sel: u8,
+        /// Raw f32 bits for training vectors.
+        vector_data: Vec<u8>,
+    },
+}
+
+fn select_sub_dim(sel: u8) -> usize {
+    match sel % 3 {
+        0 => 2,
+        1 => 4,
+        _ => 8,
+    }
+}
+
+fn select_dim(sel: u8) -> usize {
+    match sel % 4 {
+        0 => 2,
+        1 => 4,
+        2 => 6,
+        _ => 8,
+    }
+}
+
+/// Build a Codebooks struct from arbitrary byte data.
+fn build_codebooks(num_subvectors: usize, sub_dim: usize, centroid_data: &[u8]) -> Codebooks {
+    let total_floats = num_subvectors * 256 * sub_dim;
+    let mut data = Vec::with_capacity(total_floats);
+    for i in 0..total_floats {
+        let byte_offset = (i * 4) % centroid_data.len().max(1);
+        let bytes: [u8; 4] = [
+            centroid_data.get(byte_offset).copied().unwrap_or(0),
+            centroid_data.get(byte_offset + 1).copied().unwrap_or(0),
+            centroid_data.get(byte_offset + 2).copied().unwrap_or(0),
+            centroid_data.get(byte_offset + 3).copied().unwrap_or(0),
+        ];
+        let val = f32::from_le_bytes(bytes);
+        // Replace NaN/Inf with 0.0 to keep centroids usable.
+        if val.is_finite() {
+            data.push(val);
+        } else {
+            data.push(0.0);
+        }
+    }
+    Codebooks {
+        data,
+        num_subvectors,
+        sub_dim,
+    }
+}
+
+/// Build a vector of f32 from arbitrary byte data.
+fn build_vector(len: usize, raw: &[u8]) -> Vec<f32> {
+    let mut vec = Vec::with_capacity(len);
+    for i in 0..len {
+        let byte_offset = (i * 4) % raw.len().max(1);
+        let bytes: [u8; 4] = [
+            raw.get(byte_offset).copied().unwrap_or(0),
+            raw.get(byte_offset + 1).copied().unwrap_or(0),
+            raw.get(byte_offset + 2).copied().unwrap_or(0),
+            raw.get(byte_offset + 3).copied().unwrap_or(0),
+        ];
+        let val = f32::from_le_bytes(bytes);
+        if val.is_finite() {
+            vec.push(val);
+        } else {
+            vec.push(0.0);
+        }
+    }
+    vec
+}
+
+fuzz_target!(|op: FuzzOp| {
+    match op {
+        FuzzOp::DeserializeRaw {
+            data,
+            sub_dim_sel,
+        } => {
+            let sub_dim = select_sub_dim(sub_dim_sel).max(1);
+            // Must not panic on any input.
+            let result = Codebooks::deserialize_codebook(&data, sub_dim);
+            // Result should always be 256 * sub_dim floats.
+            assert_eq!(result.len(), 256 * sub_dim);
+        }
+
+        FuzzOp::EncodeDecodeRoundtrip {
+            num_sub_sel,
+            sub_dim_sel,
+            centroid_data,
+            vector_data,
+        } => {
+            let num_subvectors = ((num_sub_sel % 4) as usize).max(1);
+            let sub_dim = select_sub_dim(sub_dim_sel);
+            let dim = num_subvectors * sub_dim;
+
+            if centroid_data.is_empty() {
+                return;
+            }
+
+            let codebooks = build_codebooks(num_subvectors, sub_dim, &centroid_data);
+            assert_eq!(codebooks.data.len(), codebooks.data_len());
+
+            // Build a test vector of the right dimension.
+            let vector = if vector_data.is_empty() {
+                vec![0.0f32; dim]
+            } else {
+                build_vector(dim, &vector_data)
+            };
+
+            // Encode must produce num_subvectors codes.
+            let codes = codebooks.encode(&vector);
+            assert_eq!(codes.len(), num_subvectors);
+
+            // Decode must produce a vector of the right dimension.
+            let decoded = codebooks.decode(&codes);
+            assert_eq!(decoded.len(), dim);
+
+            // Each decoded value must be finite.
+            for val in &decoded {
+                assert!(val.is_finite());
+            }
+        }
+
+        FuzzOp::SerializeRoundtrip {
+            num_sub_sel,
+            sub_dim_sel,
+            centroid_data,
+        } => {
+            let num_subvectors = ((num_sub_sel % 4) as usize).max(1);
+            let sub_dim = select_sub_dim(sub_dim_sel);
+
+            if centroid_data.is_empty() {
+                return;
+            }
+
+            let codebooks = build_codebooks(num_subvectors, sub_dim, &centroid_data);
+
+            for m in 0..num_subvectors {
+                let serialized = codebooks.serialize_codebook(m);
+                // Should be 256 * sub_dim * 4 bytes (each f32 = 4 bytes).
+                assert_eq!(serialized.len(), 256 * sub_dim * 4);
+
+                let deserialized = Codebooks::deserialize_codebook(&serialized, sub_dim);
+                assert_eq!(deserialized.len(), 256 * sub_dim);
+
+                // Verify roundtrip: deserialized centroids must match originals.
+                for k in 0..256 {
+                    let original = codebooks.centroid(m, k);
+                    let restored = &deserialized[k * sub_dim..(k + 1) * sub_dim];
+                    assert_eq!(original.len(), restored.len());
+                    for (a, b) in original.iter().zip(restored.iter()) {
+                        assert!((a - b).abs() < f32::EPSILON);
+                    }
+                }
+            }
+        }
+
+        FuzzOp::Train {
+            num_vectors,
+            dim_sel,
+            num_sub_sel,
+            vector_data,
+        } => {
+            let dim = select_dim(dim_sel);
+            let num_subvectors = if num_sub_sel % 2 == 0 { 1 } else { 2 };
+
+            // dim must be divisible by num_subvectors.
+            if dim % num_subvectors != 0 {
+                return;
+            }
+
+            let n = (num_vectors as usize).clamp(2, 16);
+            let total_floats = n * dim;
+
+            if vector_data.is_empty() {
+                return;
+            }
+
+            let flat_vectors = build_vector(total_floats, &vector_data);
+            let result = train_codebooks(
+                &flat_vectors,
+                dim,
+                num_subvectors,
+                5, // Small max_iter for fuzzing speed.
+                DistanceMetric::EuclideanSq,
+            );
+
+            if let Ok(codebooks) = result {
+                assert_eq!(codebooks.num_subvectors, num_subvectors);
+                assert_eq!(codebooks.sub_dim, dim / num_subvectors);
+                assert_eq!(codebooks.data.len(), codebooks.data_len());
+
+                // Encode one of the training vectors and verify output shape.
+                let test_vec = &flat_vectors[..dim];
+                let codes = codebooks.encode(test_vec);
+                assert_eq!(codes.len(), num_subvectors);
+
+                let decoded = codebooks.decode(&codes);
+                assert_eq!(decoded.len(), dim);
+            }
+        }
+    }
+});

--- a/fuzz/fuzz_targets/fuzz_pq_codebook.rs
+++ b/fuzz/fuzz_targets/fuzz_pq_codebook.rs
@@ -7,9 +7,9 @@ use redb::DistanceMetric;
 
 #[derive(Arbitrary, Debug)]
 enum FuzzOp {
-    /// Deserialize arbitrary bytes as a codebook — must not panic.
+    /// Deserialize arbitrary bytes as a codebook -- must not panic.
     DeserializeRaw { data: Vec<u8>, sub_dim_sel: u8 },
-    /// Construct Codebooks, encode a vector, decode codes — roundtrip.
+    /// Construct Codebooks, encode a vector, decode codes -- roundtrip.
     EncodeDecodeRoundtrip {
         /// Number of sub-vectors: 1..4.
         num_sub_sel: u8,
@@ -20,17 +20,17 @@ enum FuzzOp {
         /// Raw f32 bits for test vector.
         vector_data: Vec<u8>,
     },
-    /// serialize_codebook → deserialize_codebook roundtrip.
+    /// serialize_codebook -> deserialize_codebook roundtrip.
     SerializeRoundtrip {
         num_sub_sel: u8,
         sub_dim_sel: u8,
         centroid_data: Vec<u8>,
     },
-    /// Train codebooks on small data (≤16 vectors, small dims).
+    /// Train codebooks on small data (<=16 vectors, small dims).
     Train {
         /// Number of vectors: clamped to 2..16.
         num_vectors: u8,
-        /// Dimension selector: 0..3 → 2/4/6/8.
+        /// Dimension selector: 0..3 -> 2/4/6/8.
         dim_sel: u8,
         /// Number of sub-vectors selector: 1 or 2.
         num_sub_sel: u8,

--- a/src/cdc/mod.rs
+++ b/src/cdc/mod.rs
@@ -1,3 +1,3 @@
-pub(crate) mod types;
+pub mod types;
 
-pub use types::{CdcConfig, ChangeOp, ChangeStream};
+pub use types::{CdcConfig, CdcKey, CdcRecord, ChangeOp, ChangeStream};

--- a/src/cdc/types.rs
+++ b/src/cdc/types.rs
@@ -79,7 +79,7 @@ pub(crate) struct CdcEvent {
 /// Encoded as 12 bytes big-endian: `[transaction_id: u64][sequence: u32]`.
 /// Big-endian ensures lexicographic byte order matches numeric order.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
-pub(crate) struct CdcKey {
+pub struct CdcKey {
     pub transaction_id: u64,
     pub sequence: u32,
 }
@@ -214,7 +214,7 @@ const CDC_FORMAT_VERSION: u8 = 1;
 /// the `op` byte. The deserializer distinguishes the two: if the first byte
 /// equals `CDC_FORMAT_MAGIC` it is a versioned record, otherwise legacy.
 #[derive(Clone)]
-pub(crate) struct CdcRecord {
+pub struct CdcRecord {
     pub op: ChangeOp,
     pub table_name: String,
     pub key: Vec<u8>,
@@ -235,7 +235,7 @@ impl fmt::Debug for CdcRecord {
 }
 
 impl CdcRecord {
-    pub fn from_event(event: &CdcEvent) -> Result<Self, StorageError> {
+    pub(crate) fn from_event(event: &CdcEvent) -> Result<Self, StorageError> {
         if u16::try_from(event.table_name.len()).is_err() {
             return Err(StorageError::format_error(format!(
                 "CDC table_name exceeds u16::MAX bytes ({})",
@@ -286,7 +286,7 @@ impl CdcRecord {
         + 4 + self.old_value.as_ref().map_or(0, Vec::len) // old_val_len + old_val
     }
 
-    pub(crate) fn serialize(&self) -> Vec<u8> {
+    pub fn serialize(&self) -> Vec<u8> {
         let mut buf = Vec::with_capacity(self.serialized_size());
 
         buf.push(CDC_FORMAT_MAGIC);
@@ -326,7 +326,7 @@ impl CdcRecord {
         buf
     }
 
-    pub(crate) fn deserialize(data: &[u8]) -> Result<Self, StorageError> {
+    pub fn deserialize(data: &[u8]) -> Result<Self, StorageError> {
         let mut pos = 0;
 
         if data.is_empty() {

--- a/src/ivfpq/mod.rs
+++ b/src/ivfpq/mod.rs
@@ -44,6 +44,9 @@
 //! ```
 
 pub(crate) mod adc;
+#[cfg(fuzzing)]
+pub mod cluster_blob;
+#[cfg(not(fuzzing))]
 #[allow(dead_code)] // Wired into index.rs in upcoming commit.
 pub(crate) mod cluster_blob;
 pub mod config;
@@ -53,6 +56,9 @@ pub mod kmeans;
 #[cfg(not(fuzzing))]
 pub(crate) mod kmeans;
 pub mod metadata;
+#[cfg(fuzzing)]
+pub mod pq;
+#[cfg(not(fuzzing))]
 pub(crate) mod pq;
 #[cfg(fuzzing)]
 pub mod types;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -117,7 +117,7 @@ pub use blob_store::{
     CausalEdge, CausalLink, CausalPath, ContentType, DedupStats, MAX_TAGS_PER_BLOB, RelationType,
     StoreOptions,
 };
-pub use cdc::{CdcConfig, ChangeOp, ChangeStream};
+pub use cdc::{CdcConfig, CdcKey, CdcRecord, ChangeOp, ChangeStream};
 pub use composite::{BlobQueryProvider, CompositeQuery, ScoredBlob, SignalScores, SignalWeights};
 pub use ivfpq::{
     Codebooks, IndexConfig, IvfPqIndex, IvfPqIndexDefinition, MetadataFilter, MetadataMap,


### PR DESCRIPTION
## Summary
- **5 new fuzz targets**: CDC deserialization, cluster blob parsing/merge, incremental snapshot parsing, merge operator correctness, PQ codebook encode/decode/train
- **Visibility changes**: CdcKey/CdcRecord/ChangeOp widened to pub; ivfpq internals exposed under `#[cfg(fuzzing)]`
- **CI integration**: 30s smoke per new target on PR; 90s soak in nightly
- **Nightly**: cargo-fuzz bumped to 0.13.1

## New Fuzz Targets

| Target | Coverage |
|--------|----------|
| `fuzz_cdc_deser` | CdcRecord deserialize, CdcKey roundtrip/ordering |
| `fuzz_cluster_blob` | ClusterBlobRef parse, encode roundtrip, merge, remove |
| `fuzz_incremental_deser` | IncrementalSnapshot from_bytes, roundtrip |
| `fuzz_merge_ops` | All 7 merge operators with property checks |
| `fuzz_pq_codebook` | Codebook serialize/deserialize, encode/decode, train |

## Test plan
- [ ] All 5 new targets compile with `RUSTFLAGS='--cfg fuzzing' cargo check`
- [ ] CI fuzz step runs 30s each on Linux x86_64, ARM64, macOS
- [ ] Nightly runs 90s soak for each target
- [ ] 231 lib tests still pass, clippy clean