### PR TITLE
refactor: add StorageError::Internal for invariant violations

### DIFF
--- a/src/composite/query.rs
+++ b/src/composite/query.rs
@@ -235,7 +235,7 @@ impl<'a, P: BlobQueryProvider, R: StorageRead> CompositeQuery<'a, P, R> {
         // 1a: Semantic candidates (IVF-PQ)
         if sem_active {
             let query = self.query_vector.ok_or_else(|| {
-                StorageError::Corrupted(
+                StorageError::Internal(
                     "semantic search enabled but no query vector provided".to_string(),
                 )
             })?;
@@ -243,13 +243,13 @@ impl<'a, P: BlobQueryProvider, R: StorageRead> CompositeQuery<'a, P, R> {
 
             // Vector index search requires a StorageRead implementation.
             let reader = self.storage_reader.ok_or_else(|| {
-                StorageError::Corrupted(
+                StorageError::Internal(
                     "semantic search requires a StorageRead (use with_storage_reader)".to_string(),
                 )
             })?;
 
             let index = self.vector_index.ok_or_else(|| {
-                StorageError::Corrupted(
+                StorageError::Internal(
                     "semantic search enabled but no vector index provided".to_string(),
                 )
             })?;

--- a/src/db.rs
+++ b/src/db.rs
@@ -431,9 +431,9 @@ impl TransactionGuard {
     pub(crate) fn id(&self) -> Result<TransactionId, StorageError> {
         match self {
             Self::Active { transaction_id, .. } => transaction_id.ok_or_else(|| {
-                StorageError::Corrupted(String::from("TransactionGuard::id() called after leak()"))
+                StorageError::Internal(String::from("TransactionGuard::id() called after leak()"))
             }),
-            Self::Verification => Err(StorageError::Corrupted(String::from(
+            Self::Verification => Err(StorageError::Internal(String::from(
                 "TransactionGuard::id() called on Verification guard",
             ))),
         }
@@ -442,11 +442,11 @@ impl TransactionGuard {
     pub(crate) fn leak(&mut self) -> Result<TransactionId, StorageError> {
         match self {
             Self::Active { transaction_id, .. } => transaction_id.take().ok_or_else(|| {
-                StorageError::Corrupted(String::from(
+                StorageError::Internal(String::from(
                     "TransactionGuard::leak() called after prior leak()",
                 ))
             }),
-            Self::Verification => Err(StorageError::Corrupted(String::from(
+            Self::Verification => Err(StorageError::Internal(String::from(
                 "TransactionGuard::leak() called on Verification guard",
             ))),
         }
@@ -993,7 +993,7 @@ impl Database {
                 {
                     let mut table = write_txn.open_table(raw_def).map_err(|e| {
                         DatabaseError::Storage(
-                            e.into_storage_error_or_corrupted("salvage: open_table"),
+                            e.into_storage_error_or_internal("salvage: open_table"),
                         )
                     })?;
                     for (key, value) in &pairs {
@@ -1149,7 +1149,7 @@ impl Database {
 
         let new_roots = Self::do_repair(&mut self.mem, &|_| {}).map_err(|err| match err {
             DatabaseError::Storage(storage_err) => storage_err,
-            _ => StorageError::Corrupted(
+            _ => StorageError::Internal(
                 "unexpected non-storage error during integrity check repair".to_string(),
             ),
         })?;
@@ -1487,10 +1487,10 @@ impl Database {
                 DATA_ALLOCATED_TABLE.name(),
                 TableType::Normal,
             )
-            .map_err(|e| e.into_storage_error_or_corrupted("Allocated pages table corrupted"))?
+            .map_err(|e| e.into_storage_error_or_internal("Allocated pages table corrupted"))?
         {
             let InternalTableDefinition::Normal { table_root, .. } = table_def else {
-                return Err(StorageError::Corrupted(
+                return Err(StorageError::Internal(
                     "unexpected non-normal table type for allocated pages table".to_string(),
                 ));
             };
@@ -1831,7 +1831,7 @@ impl Database {
         )?;
         let Some(allocator_state_table) = system_table_tree
             .get_table::<AllocatorStateKey, &[u8]>(ALLOCATOR_STATE_TABLE_NAME, TableType::Normal)
-            .map_err(|e| e.into_storage_error_or_corrupted("Unexpected TableError"))?
+            .map_err(|e| e.into_storage_error_or_internal("Unexpected TableError"))?
         else {
             return Ok(None);
         };

--- a/src/error.rs
+++ b/src/error.rs
@@ -60,6 +60,10 @@ impl BackendError {
 pub enum StorageError {
     /// The Database is corrupted
     Corrupted(String),
+    /// An internal invariant was violated, indicating a bug in the database engine.
+    /// This is NOT caused by on-disk corruption -- it means the code has a logic error.
+    /// If you encounter this error, please file a bug report.
+    Internal(String),
     /// The value being inserted exceeds the maximum of 3GiB
     ValueTooLarge(usize),
     /// A blob with the given sequence ID was not found in the blob store
@@ -215,6 +219,7 @@ impl From<StorageError> for Error {
     fn from(err: StorageError) -> Error {
         match err {
             StorageError::Corrupted(msg) => Error::Corrupted(msg),
+            StorageError::Internal(msg) => Error::Internal(msg),
             StorageError::ValueTooLarge(x) => Error::ValueTooLarge(x),
             StorageError::BlobNotFound(seq) => Error::BlobNotFound(seq),
             StorageError::BlobChecksumMismatch {
@@ -325,6 +330,9 @@ impl Display for StorageError {
         match self {
             StorageError::Corrupted(msg) => {
                 write!(f, "DB corrupted: {msg}")
+            }
+            StorageError::Internal(msg) => {
+                write!(f, "Internal error (this is a bug): {msg}")
             }
             StorageError::ValueTooLarge(len) => {
                 write!(
@@ -601,7 +609,7 @@ pub enum TableError {
 }
 
 impl TableError {
-    pub(crate) fn into_storage_error_or_corrupted(self, msg: &str) -> StorageError {
+    pub(crate) fn into_storage_error_or_internal(self, msg: &str) -> StorageError {
         match self {
             TableError::TableTypeMismatch { .. }
             | TableError::TableIsMultimap(_)
@@ -610,7 +618,7 @@ impl TableError {
             | TableError::TableDoesNotExist(_)
             | TableError::TableExists(_)
             | TableError::TableAlreadyOpen(_, _) => {
-                StorageError::Corrupted(format!("{msg}: {self}"))
+                StorageError::Internal(format!("{msg}: {self}"))
             }
             TableError::Storage(storage) => storage,
         }
@@ -910,7 +918,7 @@ impl TransactionError {
     pub(crate) fn into_storage_error(self) -> StorageError {
         match self {
             TransactionError::Storage(storage) => storage,
-            _ => StorageError::Corrupted(String::from("unexpected non-storage transaction error")),
+            _ => StorageError::Internal(String::from("unexpected non-storage transaction error")),
         }
     }
 }
@@ -1010,6 +1018,10 @@ pub enum Error {
     TransactionInProgress,
     /// The Database is corrupted
     Corrupted(String),
+    /// An internal invariant was violated, indicating a bug in the database engine.
+    /// This is NOT caused by on-disk corruption -- it means the code has a logic error.
+    /// If you encounter this error, please file a bug report.
+    Internal(String),
     /// The database file is in an old file format and must be manually upgraded
     UpgradeRequired(u8),
     /// The value being inserted exceeds the maximum of 3GiB
@@ -1193,6 +1205,9 @@ impl Display for Error {
         match self {
             Error::Corrupted(msg) => {
                 write!(f, "DB corrupted: {msg}")
+            }
+            Error::Internal(msg) => {
+                write!(f, "Internal error (this is a bug): {msg}")
             }
             Error::UpgradeRequired(actual) => {
                 write!(

--- a/src/incremental.rs
+++ b/src/incremental.rs
@@ -98,7 +98,7 @@ fn table_checksum(txn: &ReadTransaction, name: &str) -> Result<(u128, u64), Stor
             table_root: None, ..
         })) => Ok(EMPTY_CHECKSUM),
         Ok(Some(InternalTableDefinition::Multimap { .. }) | None) => Ok(NO_CHECKSUM),
-        Err(e) => Err(e.into_storage_error_or_corrupted("get table root header")),
+        Err(e) => Err(e.into_storage_error_or_internal("get table root header")),
     }
 }
 
@@ -248,7 +248,7 @@ pub(crate) fn import_incremental(
             let def = TableDefinition::<&[u8], &[u8]>::new(&delta.name);
             let mut table = txn
                 .open_table(def)
-                .map_err(|e| e.into_storage_error_or_corrupted("open table during import"))?;
+                .map_err(|e| e.into_storage_error_or_internal("open table during import"))?;
             for (key, value) in &delta.upserts {
                 table.insert(key.as_slice(), value.as_slice())?;
                 report.entries_upserted += 1;
@@ -264,7 +264,7 @@ pub(crate) fn import_incremental(
         let handle = UntypedTableHandle::new(name.clone());
         let deleted = txn
             .delete_table(handle)
-            .map_err(|e| e.into_storage_error_or_corrupted("delete table during import"))?;
+            .map_err(|e| e.into_storage_error_or_internal("delete table during import"))?;
         if deleted {
             report.tables_dropped += 1;
         }

--- a/src/multimap_table.rs
+++ b/src/multimap_table.rs
@@ -340,7 +340,7 @@ pub(crate) fn relocate_subtrees(
                     );
                     tree.relocate(relocation_map)?;
                     let new_root = tree.get_root().ok_or_else(|| {
-                        StorageError::Corrupted(
+                        StorageError::Internal(
                             "missing subtree root after relocate in relocate_subtrees".to_string(),
                         )
                     })?;
@@ -1267,7 +1267,7 @@ impl<'txn, K: Key + 'static, V: Key + 'static> MultimapTable<'txn, K, V> {
                         let existed = subtree.insert(value.borrow(), &())?.is_some();
                         assert_eq!(existed, found);
                         let subtree_root = subtree.get_root().ok_or_else(|| {
-                            StorageError::Corrupted(
+                            StorageError::Internal(
                                 "missing subtree root after insert in inline-to-subtree conversion"
                                     .to_string(),
                             )
@@ -1290,7 +1290,7 @@ impl<'txn, K: Key + 'static, V: Key + 'static> MultimapTable<'txn, K, V> {
                     drop(guard);
                     let existed = subtree.insert(value.borrow(), &())?.is_some();
                     let subtree_root = subtree.get_root().ok_or_else(|| {
-                        StorageError::Corrupted(
+                        StorageError::Internal(
                             "missing subtree root after insert into existing subtree".to_string(),
                         )
                     })?;
@@ -1333,7 +1333,7 @@ impl<'txn, K: Key + 'static, V: Key + 'static> MultimapTable<'txn, K, V> {
                 );
                 subtree.insert(value.borrow(), &())?;
                 let subtree_root = subtree.get_root().ok_or_else(|| {
-                    StorageError::Corrupted(
+                    StorageError::Internal(
                         "missing subtree root after insert into new subtree".to_string(),
                     )
                 })?;

--- a/src/transaction_tracker.rs
+++ b/src/transaction_tracker.rs
@@ -136,7 +136,7 @@ impl TransactionTracker {
             state = self.live_write_transaction_available.wait(state)?;
         }
         if state.live_write_transaction.is_some() {
-            return Err(StorageError::Corrupted(
+            return Err(StorageError::Internal(
                 "Write transaction still active after condvar wait".into(),
             ));
         }
@@ -194,10 +194,10 @@ impl TransactionTracker {
                 self.live_write_transaction_available.notify_one();
                 Ok(())
             }
-            Some(active_id) => Err(StorageError::Corrupted(format!(
+            Some(active_id) => Err(StorageError::Internal(format!(
                 "end_write_transaction called with id {id:?}, but active transaction is {active_id:?}"
             ))),
-            None => Err(StorageError::Corrupted(format!(
+            None => Err(StorageError::Internal(format!(
                 "end_write_transaction called with id {id:?}, but no write transaction is active"
             ))),
         }
@@ -212,10 +212,10 @@ impl TransactionTracker {
                 state.live_write_transaction = None;
                 Ok(())
             }
-            Some(active_id) => Err(StorageError::Corrupted(format!(
+            Some(active_id) => Err(StorageError::Internal(format!(
                 "end_write_transaction called with id {id:?}, but active transaction is {active_id:?}"
             ))),
-            None => Err(StorageError::Corrupted(format!(
+            None => Err(StorageError::Internal(format!(
                 "end_write_transaction called with id {id:?}, but no write transaction is active"
             ))),
         }
@@ -294,7 +294,7 @@ impl TransactionTracker {
         #[cfg(not(feature = "std"))]
         let mut state = self.state.lock();
         if !state.valid_savepoints.is_empty() {
-            return Err(StorageError::Corrupted(
+            return Err(StorageError::Internal(
                 "restore_savepoint_counter_state called with active savepoints".into(),
             ));
         }

--- a/src/transactions.rs
+++ b/src/transactions.rs
@@ -3493,8 +3493,7 @@ impl ReadTransaction {
             )),
             Ok(None) => Ok(None),
             Err(e) => {
-                Err(e
-                    .into_storage_error_or_internal("Internal error: blob system table corrupted"))
+                Err(e.into_storage_error_or_internal("Internal error: blob system table corrupted"))
             }
         }
     }

--- a/src/transactions.rs
+++ b/src/transactions.rs
@@ -724,7 +724,7 @@ impl<'db> SystemNamespace<'db> {
             .table_tree
             .get_or_create_table::<K, V>(definition.name(), TableType::Normal)
             .map_err(|e| {
-                e.into_storage_error_or_corrupted("Internal error. System table is corrupted")
+                e.into_storage_error_or_internal("Internal error. System table is corrupted")
             })?;
         transaction.dirty.store(true, Ordering::Release);
 
@@ -796,7 +796,7 @@ impl TableNamespace<'_> {
 
     fn set_root(&mut self, root: Option<BtreeHeader>) -> Result<(), StorageError> {
         if !self.open_tables.is_empty() {
-            return Err(StorageError::Corrupted(
+            return Err(StorageError::Internal(
                 "set_root called with open tables".into(),
             ));
         }
@@ -2736,7 +2736,7 @@ impl WriteTransaction {
                 Ok(_) => {}
                 Err(err) => match err {
                     SavepointError::InvalidSavepoint => {
-                        return Err(StorageError::Corrupted(
+                        return Err(StorageError::Internal(
                             "invalid savepoint encountered during transaction abort".to_string(),
                         ));
                     }
@@ -2806,7 +2806,7 @@ impl WriteTransaction {
         let system_tree = system_tables.table_tree.flush_table_root_updates()?;
         system_tree
             .delete_table(ALLOCATOR_STATE_TABLE_NAME, TableType::Normal)
-            .map_err(|e| e.into_storage_error_or_corrupted("Unexpected TableError"))?;
+            .map_err(|e| e.into_storage_error_or_internal("Unexpected TableError"))?;
 
         if self.quick_repair {
             system_tree.create_table_and_flush_table_root(
@@ -3327,7 +3327,7 @@ impl ReadTransaction {
                 self.mem.clone(),
             )?),
             InternalTableDefinition::Multimap { .. } => {
-                Err(TableError::Storage(StorageError::Corrupted(
+                Err(TableError::Storage(StorageError::Internal(
                     "unexpected multimap table type when opening normal table".to_string(),
                 )))
             }
@@ -3379,7 +3379,7 @@ impl ReadTransaction {
                 self.mem.clone(),
             )),
             InternalTableDefinition::Multimap { .. } => {
-                Err(TableError::Storage(StorageError::Corrupted(
+                Err(TableError::Storage(StorageError::Internal(
                     "unexpected multimap table type when opening untyped normal table".to_string(),
                 )))
             }
@@ -3398,7 +3398,7 @@ impl ReadTransaction {
 
         match header {
             InternalTableDefinition::Normal { .. } => {
-                Err(TableError::Storage(StorageError::Corrupted(
+                Err(TableError::Storage(StorageError::Internal(
                     "unexpected normal table type when opening multimap table".to_string(),
                 )))
             }
@@ -3428,7 +3428,7 @@ impl ReadTransaction {
 
         match header {
             InternalTableDefinition::Normal { .. } => {
-                Err(TableError::Storage(StorageError::Corrupted(
+                Err(TableError::Storage(StorageError::Internal(
                     "unexpected normal table type when opening untyped multimap table".to_string(),
                 )))
             }
@@ -3488,13 +3488,13 @@ impl ReadTransaction {
                 )?;
                 Ok(Some(btree))
             }
-            Ok(Some(InternalTableDefinition::Multimap { .. })) => Err(StorageError::Corrupted(
+            Ok(Some(InternalTableDefinition::Multimap { .. })) => Err(StorageError::Internal(
                 "unexpected multimap table type in system table lookup".to_string(),
             )),
             Ok(None) => Ok(None),
             Err(e) => {
                 Err(e
-                    .into_storage_error_or_corrupted("Internal error: blob system table corrupted"))
+                    .into_storage_error_or_internal("Internal error: blob system table corrupted"))
             }
         }
     }
@@ -4242,7 +4242,7 @@ impl crate::storage_traits::StorageWrite for WriteTransaction {
         definition: TableDefinition<K, V>,
     ) -> Result<Self::Table<'_, K, V>> {
         self.open_table(definition)
-            .map_err(|e| e.into_storage_error_or_corrupted("open_storage_table"))
+            .map_err(|e| e.into_storage_error_or_internal("open_storage_table"))
     }
 }
 
@@ -4261,7 +4261,7 @@ impl crate::storage_traits::StorageRead for ReadTransaction {
         definition: TableDefinition<K, V>,
     ) -> Result<Self::Table<'_, K, V>> {
         self.open_table(definition)
-            .map_err(|e| e.into_storage_error_or_corrupted("open_storage_table"))
+            .map_err(|e| e.into_storage_error_or_internal("open_storage_table"))
     }
 }
 

--- a/src/tree_store/btree.rs
+++ b/src/tree_store/btree.rs
@@ -662,7 +662,7 @@ impl<K: Key + 'static, V: Value + 'static> BtreeMut<'_, K, V> {
         );
         operation.insert_inplace(key, value)?;
         if !fake_freed_pages.is_empty() {
-            return Err(StorageError::Corrupted(format!(
+            return Err(StorageError::Internal(format!(
                 "insert_inplace unexpectedly freed {} pages",
                 fake_freed_pages.len()
             )));
@@ -966,7 +966,7 @@ impl<K: Key + 'static, V: Value + 'static> BtreeMut<'_, K, V> {
         for entry in iter {
             let entry = entry?;
             if !predicate(entry.key(), entry.value()) && operation.delete(&entry.key())?.is_none() {
-                return Err(StorageError::Corrupted(String::from(
+                return Err(StorageError::Internal(String::from(
                     "retain_in: delete returned None for existing key",
                 )));
             }

--- a/src/tree_store/page_store/cached_file.rs
+++ b/src/tree_store/page_store/cached_file.rs
@@ -25,7 +25,7 @@ impl WritablePage {
     }
 
     pub(super) fn mem_mut(&mut self) -> core::result::Result<&mut [u8], StorageError> {
-        Arc::get_mut(&mut self.data).ok_or(StorageError::Corrupted(String::from(
+        Arc::get_mut(&mut self.data).ok_or(StorageError::Internal(String::from(
             "WritablePage::mem_mut() called while other Arc references exist",
         )))
     }
@@ -394,7 +394,7 @@ impl PagedCachedFile {
 
         for (offset, buffer) in write_buffer.cache.iter() {
             let raw = buffer.as_ref().ok_or_else(|| {
-                StorageError::Corrupted(String::from(
+                StorageError::Internal(String::from(
                     "flush_write_buffer: write cache entry has no data",
                 ))
             })?;
@@ -402,7 +402,7 @@ impl PagedCachedFile {
         }
         for (offset, buffer) in write_buffer.cache.iter_mut() {
             let buffer = buffer.take().ok_or_else(|| {
-                StorageError::Corrupted(String::from(
+                StorageError::Internal(String::from(
                     "flush_write_buffer: write cache entry has no data during promotion",
                 ))
             })?;
@@ -606,7 +606,7 @@ impl PagedCachedFile {
     // cache_policy takes the existing data as an argument and returns the priority. The priority should be stable and not change after WritablePage is dropped
     pub(super) fn write(&self, offset: u64, len: usize, overwrite: bool) -> Result<WritablePage> {
         if offset % self.page_size != 0 {
-            return Err(StorageError::Corrupted(String::from(
+            return Err(StorageError::Internal(String::from(
                 "write: offset not page-aligned",
             )));
         }
@@ -618,7 +618,7 @@ impl PagedCachedFile {
             let mut lock = self.read_cache[cache_slot].write();
             if let Some(removed) = lock.remove(offset) {
                 if len != removed.len() {
-                    return Err(StorageError::Corrupted(String::from(
+                    return Err(StorageError::Internal(String::from(
                         "write: cache inconsistency, length mismatch for cached page",
                     )));
                 }
@@ -679,7 +679,7 @@ impl PagedCachedFile {
             };
             lock.insert(offset, result);
             lock.take_value(offset).ok_or_else(|| {
-                StorageError::Corrupted(String::from(
+                StorageError::Internal(String::from(
                     "write: take_value failed immediately after insert",
                 ))
             })?

--- a/src/tree_store/page_store/page_manager.rs
+++ b/src/tree_store/page_store/page_manager.rs
@@ -656,7 +656,7 @@ impl TransactionalMemory {
 
     pub(crate) fn clear_cache_and_reload(&mut self) -> Result<bool, DatabaseError> {
         if !self.allocated_since_commit.lock().is_empty() {
-            return Err(StorageError::Corrupted(alloc::string::String::from(
+            return Err(StorageError::Internal(alloc::string::String::from(
                 "Cannot reload: uncommitted page allocations still pending",
             ))
             .into());
@@ -1126,7 +1126,7 @@ impl TransactionalMemory {
 
         let mut state = self.state.lock();
         if state.header.secondary_slot().transaction_id != old_transaction_id {
-            return Err(StorageError::Corrupted(alloc::string::String::from(
+            return Err(StorageError::Internal(alloc::string::String::from(
                 "Secondary slot transaction_id changed unexpectedly during commit",
             )));
         }
@@ -1171,7 +1171,7 @@ impl TransactionalMemory {
         // Without this flag, a crash would leave pages in `unpersisted`
         // allocated but unreferenced, permanently leaking disk space.
         if !self.state.lock().header.recovery_required {
-            return Err(StorageError::Corrupted(alloc::string::String::from(
+            return Err(StorageError::Internal(alloc::string::String::from(
                 "non_durable_commit requires recovery_required flag to be set \
                  for crash-safe page reclamation",
             )));
@@ -1568,7 +1568,7 @@ impl TransactionalMemory {
         new_layout.reduce_last_region(reduce_by);
         state.allocators.resize_to(new_layout);
         if new_layout.len() > layout.len() {
-            return Err(StorageError::Corrupted(alloc::string::String::from(
+            return Err(StorageError::Internal(alloc::string::String::from(
                 "Shrink produced a layout larger than the original",
             )));
         }
@@ -1613,7 +1613,7 @@ impl TransactionalMemory {
             self.page_size,
         );
         if new_layout.len() < layout.len() {
-            return Err(StorageError::Corrupted(alloc::string::String::from(
+            return Err(StorageError::Internal(alloc::string::String::from(
                 "Grow produced a layout smaller than the original",
             )));
         }

--- a/src/tree_store/table_tree.rs
+++ b/src/tree_store/table_tree.rs
@@ -349,9 +349,9 @@ impl TableTree {
         for entry in self.list_tables(TableType::Normal)? {
             let definition = self
                 .get_table_untyped(&entry, TableType::Normal)
-                .map_err(|e| e.into_storage_error_or_corrupted("Internal corruption"))?
+                .map_err(|e| e.into_storage_error_or_internal("Internal corruption"))?
                 .ok_or_else(|| {
-                    StorageError::Corrupted(alloc::string::String::from(
+                    StorageError::Internal(alloc::string::String::from(
                         "listed table not found during page visit",
                     ))
                 })?;
@@ -361,9 +361,9 @@ impl TableTree {
         for entry in self.list_tables(TableType::Multimap)? {
             let definition = self
                 .get_table_untyped(&entry, TableType::Multimap)
-                .map_err(|e| e.into_storage_error_or_corrupted("Internal corruption"))?
+                .map_err(|e| e.into_storage_error_or_internal("Internal corruption"))?
                 .ok_or_else(|| {
-                    StorageError::Corrupted(alloc::string::String::from(
+                    StorageError::Internal(alloc::string::String::from(
                         "listed multimap not found during page visit",
                     ))
                 })?;
@@ -425,9 +425,9 @@ impl TableTreeMut<'_> {
         for entry in self.list_tables(TableType::Normal)? {
             let definition = self
                 .get_table_untyped(&entry, TableType::Normal)
-                .map_err(|e| e.into_storage_error_or_corrupted("Internal corruption"))?
+                .map_err(|e| e.into_storage_error_or_internal("Internal corruption"))?
                 .ok_or_else(|| {
-                    StorageError::Corrupted(alloc::string::String::from(
+                    StorageError::Internal(alloc::string::String::from(
                         "listed table not found during page visit",
                     ))
                 })?;
@@ -437,9 +437,9 @@ impl TableTreeMut<'_> {
         for entry in self.list_tables(TableType::Multimap)? {
             let definition = self
                 .get_table_untyped(&entry, TableType::Multimap)
-                .map_err(|e| e.into_storage_error_or_corrupted("Internal corruption"))?
+                .map_err(|e| e.into_storage_error_or_internal("Internal corruption"))?
                 .ok_or_else(|| {
-                    StorageError::Corrupted(alloc::string::String::from(
+                    StorageError::Internal(alloc::string::String::from(
                         "listed multimap not found during page visit",
                     ))
                 })?;
@@ -500,7 +500,7 @@ impl TableTreeMut<'_> {
                 .tree
                 .get(&name.as_str())?
                 .ok_or_else(|| {
-                    StorageError::Corrupted(alloc::format!(
+                    StorageError::Internal(alloc::format!(
                         "pending table '{name}' not found in table tree"
                     ))
                 })?
@@ -575,7 +575,7 @@ impl TableTreeMut<'_> {
         f: impl FnOnce(&mut BtreeMut<K, V>) -> Result,
     ) -> Result {
         if !self.pending_table_updates.is_empty() {
-            return Err(crate::StorageError::Corrupted(alloc::string::String::from(
+            return Err(crate::StorageError::Internal(alloc::string::String::from(
                 "open_table_and_flush_table_root called with pending updates",
             )));
         }
@@ -597,13 +597,13 @@ impl TableTreeMut<'_> {
             .tree
             .get(&name)?
             .ok_or_else(|| {
-                StorageError::Corrupted(alloc::format!("table '{name}' missing after insert"))
+                StorageError::Internal(alloc::format!("table '{name}' missing after insert"))
             })?
             .value()
         {
             InternalTableDefinition::Normal { table_root, .. } => table_root,
             InternalTableDefinition::Multimap { .. } => {
-                return Err(crate::StorageError::Corrupted(alloc::string::String::from(
+                return Err(crate::StorageError::Internal(alloc::string::String::from(
                     "expected Normal table but found Multimap",
                 )));
             }
@@ -643,12 +643,12 @@ impl TableTreeMut<'_> {
         f: impl FnOnce(&mut Self, &mut BtreeMut<K, V>) -> Result,
     ) -> Result {
         if !self.pending_table_updates.is_empty() {
-            return Err(crate::StorageError::Corrupted(alloc::string::String::from(
+            return Err(crate::StorageError::Internal(alloc::string::String::from(
                 "create_table_and_flush_table_root called with pending updates",
             )));
         }
         if self.tree.get(&name)?.is_some() {
-            return Err(crate::StorageError::Corrupted(alloc::format!(
+            return Err(crate::StorageError::Internal(alloc::format!(
                 "create_table_and_flush_table_root: table '{name}' already exists"
             )));
         }
@@ -759,13 +759,13 @@ impl TableTreeMut<'_> {
                     .insert(new_name.to_string(), update);
             }
             if self.tree.remove(&name)?.is_none() {
-                return Err(StorageError::Corrupted(alloc::format!(
+                return Err(StorageError::Internal(alloc::format!(
                     "rename_table: table '{name}' disappeared during rename"
                 ))
                 .into());
             }
             if self.tree.insert(&new_name, &definition)?.is_some() {
-                return Err(StorageError::Corrupted(alloc::format!(
+                return Err(StorageError::Internal(alloc::format!(
                     "rename_table: destination '{new_name}' appeared during rename"
                 ))
                 .into());


### PR DESCRIPTION
## Summary

- Add `StorageError::Internal(String)` variant to distinguish internal code bugs from genuine on-disk corruption (`StorageError::Corrupted`)
- Reclassify ~38 sites from `Corrupted` to `Internal` across 9 source files
- Rename `into_storage_error_or_corrupted` -> `into_storage_error_or_internal` (15 call sites)
- Mirror `Internal` variant in the `Error` superset enum with `From` impl and `Display`

### Decision criteria
- **Keep Corrupted**: Error reachable because on-disk data is damaged (bad checksums, invalid magic bytes, truncated pages)
- **Change to Internal**: Guards an internal invariant that should never be violated if code is correct -- indicates a bug

### Files changed
| File | Internal sites | Pattern |
|------|---------------|---------|
| `transaction_tracker.rs` | 6 | Lock/state invariant violations |
| `db.rs` | 6 | Guard misuse, schema invariants |
| `transactions.rs` | 7 | Open tables, savepoint state, type mismatches |
| `cached_file.rs` | 6 | Cache coherence, ownership, alignment |
| `page_manager.rs` | 5 | Uncommitted state, slot invariants, layout |
| `btree.rs` | 2 | Algorithm invariants |
| `multimap_table.rs` | 4 | Missing subtree root after relocate/insert |
| `table_tree.rs` | 12 | Table def missing after open/insert + rename sites |
| `composite/query.rs` | 3 | Builder API contract violations |

## Test plan
- [x] `cargo clippy --all --all-features -- -Dwarnings` passes
- [x] `cargo clippy --all --no-default-features -- -Dwarnings` passes (no_std)
- [x] `cargo test --all --all-features` passes