### PR TITLE
feat(observer): DatabaseObserver trait + DbMetrics counters

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -69,6 +69,8 @@ std = []
 logging = ["dep:log"]
 # Enable cache hit metrics
 cache_metrics = []
+# Enable database-wide metrics (transaction counts, write amplification, etc.)
+metrics = ["cache_metrics"]
 # Enable LZ4 page compression
 compression_lz4 = ["dep:lz4_flex"]
 # Enable zstd page compression

--- a/src/db.rs
+++ b/src/db.rs
@@ -3,6 +3,9 @@ use crate::cdc::CdcConfig;
 use crate::error::{BackendError, TransactionError};
 #[cfg(feature = "std")]
 use crate::group_commit::{GroupCommitError, GroupCommitter, WriteBatch};
+#[cfg(feature = "metrics")]
+use crate::observer::DbMetrics;
+use crate::observer::{DatabaseObserver, default_observer};
 use crate::sealed::Sealed;
 use crate::transaction_tracker::{TransactionId, TransactionTracker};
 use crate::transactions::{
@@ -541,7 +544,13 @@ impl ReadableDatabase for ReadOnlyDatabase {
 
         let guard = TransactionGuard::new_read(id, self.transaction_tracker.clone());
 
-        ReadTransaction::new(self.mem.clone(), guard)
+        ReadTransaction::new(
+            self.mem.clone(),
+            guard,
+            default_observer(),
+            #[cfg(feature = "metrics")]
+            Arc::new(DbMetrics::new()),
+        )
     }
 
     fn cache_stats(&self) -> CacheStats {
@@ -666,6 +675,9 @@ pub struct Database {
     blob_dedup_config: BlobDedupConfig,
     cdc_config: CdcConfig,
     history_retention: u64,
+    observer: Arc<dyn DatabaseObserver>,
+    #[cfg(feature = "metrics")]
+    db_metrics: Arc<DbMetrics>,
     #[cfg(feature = "std")]
     group_committer: GroupCommitter,
 }
@@ -673,9 +685,24 @@ pub struct Database {
 impl ReadableDatabase for Database {
     fn begin_read(&self) -> Result<ReadTransaction, TransactionError> {
         let guard = self.allocate_read_transaction()?;
+        let txn_id = guard.id().ok();
         #[cfg(feature = "logging")]
-        debug!("Beginning read transaction id={:?}", guard.id().ok());
-        ReadTransaction::new(self.get_memory(), guard)
+        debug!("Beginning read transaction id={txn_id:?}");
+        let txn = ReadTransaction::new(
+            self.get_memory(),
+            guard,
+            Arc::clone(&self.observer),
+            #[cfg(feature = "metrics")]
+            Arc::clone(&self.db_metrics),
+        )?;
+        if let Some(id) = txn_id {
+            self.observer.on_read_begin(id.raw_id());
+            #[cfg(feature = "metrics")]
+            self.db_metrics
+                .read_txn_opened
+                .fetch_add(1, portable_atomic::Ordering::Relaxed);
+        }
+        Ok(txn)
     }
 
     fn cache_stats(&self) -> CacheStats {
@@ -1707,6 +1734,8 @@ impl Database {
         history_retention: u64,
         read_verification: ReadVerification,
         read_verification_callback: Option<Arc<ReadVerificationCallback>>,
+        observer: Arc<dyn DatabaseObserver>,
+        #[cfg(feature = "metrics")] db_metrics: Arc<DbMetrics>,
     ) -> Result<Self, DatabaseError> {
         #[cfg(feature = "logging")]
         let file_path = format!("{:?}", &file);
@@ -1762,6 +1791,9 @@ impl Database {
             blob_dedup_config: blob_dedup_config.clone(),
             cdc_config,
             history_retention,
+            observer,
+            #[cfg(feature = "metrics")]
+            db_metrics,
             #[cfg(feature = "std")]
             group_committer: GroupCommitter::new(),
         };
@@ -1892,8 +1924,22 @@ impl Database {
             self.blob_dedup_config.clone(),
             self.cdc_config.clone(),
             self.history_retention,
+            Arc::clone(&self.observer),
+            #[cfg(feature = "metrics")]
+            Arc::clone(&self.db_metrics),
         )
         .map_err(|e| e.into())
+    }
+
+    /// Returns the observer registered with this database.
+    pub fn observer(&self) -> &Arc<dyn DatabaseObserver> {
+        &self.observer
+    }
+
+    /// Returns the database metrics counters.
+    #[cfg(feature = "metrics")]
+    pub fn metrics(&self) -> &DbMetrics {
+        &self.db_metrics
     }
 
     /// Begin a read transaction at a specific historical transaction ID.
@@ -1914,7 +1960,14 @@ impl Database {
         let user_root = snapshot.user_root();
         let guard = self.allocate_read_transaction()?;
         drop(lookup_txn);
-        ReadTransaction::new_historical(self.mem.clone(), guard, user_root)
+        ReadTransaction::new_historical(
+            self.mem.clone(),
+            guard,
+            user_root,
+            Arc::clone(&self.observer),
+            #[cfg(feature = "metrics")]
+            Arc::clone(&self.db_metrics),
+        )
     }
 
     /// Begin a read transaction at the latest snapshot whose timestamp is <= the given
@@ -1945,7 +1998,14 @@ impl Database {
         ))?;
         let guard = self.allocate_read_transaction()?;
         drop(lookup_txn);
-        ReadTransaction::new_historical(self.mem.clone(), guard, best_root)
+        ReadTransaction::new_historical(
+            self.mem.clone(),
+            guard,
+            best_root,
+            Arc::clone(&self.observer),
+            #[cfg(feature = "metrics")]
+            Arc::clone(&self.db_metrics),
+        )
     }
 
     /// List all retained transaction snapshots.
@@ -2187,10 +2247,17 @@ impl CompactionHandle<'_> {
         txn.set_shrink_policy(ShrinkPolicy::Maximum);
         txn.commit().map_err(|e| e.into_storage_error())?;
 
-        Ok(CompactionProgress {
+        let progress = CompactionProgress {
             pages_relocated: 1, // at least one batch was relocated
             complete: false,
-        })
+        };
+        self.db.observer.on_compaction_step(&progress);
+        #[cfg(feature = "metrics")]
+        self.db
+            .db_metrics
+            .compaction_pages_relocated
+            .fetch_add(1, portable_atomic::Ordering::Relaxed);
+        Ok(progress)
     }
 
     /// Runs compaction to completion, returning the total number of steps performed.
@@ -2203,6 +2270,7 @@ impl CompactionHandle<'_> {
             }
             steps += 1;
         }
+        self.db.observer.on_compaction_complete(steps);
         Ok(steps)
     }
 }
@@ -2294,6 +2362,7 @@ pub struct Builder {
     history_retention: u64,
     read_verification: ReadVerification,
     read_verification_callback: Option<Arc<ReadVerificationCallback>>,
+    observer: Option<Arc<dyn DatabaseObserver>>,
 }
 
 impl Builder {
@@ -2322,6 +2391,7 @@ impl Builder {
             history_retention: 0,
             read_verification: ReadVerification::None,
             read_verification_callback: None,
+            observer: None,
         };
 
         result.set_cache_size(1024 * 1024 * 1024);
@@ -2340,6 +2410,17 @@ impl Builder {
         callback: impl Fn(&mut RepairSession) + 'static,
     ) -> &mut Self {
         self.repair_callback = Box::new(callback);
+        self
+    }
+
+    /// Register an observer for database lifecycle events.
+    ///
+    /// The observer receives synchronous callbacks on the committing/reading
+    /// thread. Implementations must not block, panic, or perform fallible I/O.
+    ///
+    /// See [`DatabaseObserver`] for the full list of events.
+    pub fn set_observer(&mut self, observer: impl DatabaseObserver) -> &mut Self {
+        self.observer = Some(Arc::new(observer));
         self
     }
 
@@ -2514,6 +2595,9 @@ impl Builder {
             self.history_retention,
             self.read_verification,
             self.read_verification_callback.clone(),
+            self.resolve_observer(),
+            #[cfg(feature = "metrics")]
+            Self::resolve_metrics(),
         )
     }
 
@@ -2537,6 +2621,9 @@ impl Builder {
             self.history_retention,
             self.read_verification,
             self.read_verification_callback.clone(),
+            self.resolve_observer(),
+            #[cfg(feature = "metrics")]
+            Self::resolve_metrics(),
         )
     }
 
@@ -2584,6 +2671,9 @@ impl Builder {
             self.history_retention,
             self.read_verification,
             self.read_verification_callback.clone(),
+            self.resolve_observer(),
+            #[cfg(feature = "metrics")]
+            Self::resolve_metrics(),
         )
     }
 
@@ -2607,7 +2697,21 @@ impl Builder {
             self.history_retention,
             self.read_verification,
             self.read_verification_callback.clone(),
+            self.resolve_observer(),
+            #[cfg(feature = "metrics")]
+            Self::resolve_metrics(),
         )
+    }
+
+    fn resolve_observer(&self) -> Arc<dyn DatabaseObserver> {
+        self.observer
+            .as_ref()
+            .map_or_else(default_observer, Arc::clone)
+    }
+
+    #[cfg(feature = "metrics")]
+    fn resolve_metrics() -> Arc<DbMetrics> {
+        Arc::new(DbMetrics::new())
     }
 }
 

--- a/src/ivfpq/index.rs
+++ b/src/ivfpq/index.rs
@@ -1,11 +1,15 @@
 use alloc::collections::BinaryHeap;
 use alloc::string::String;
+use alloc::sync::Arc;
 use alloc::vec;
 use alloc::vec::Vec;
 use core::cmp::Ordering as CmpOrdering;
 
 use crate::TableDefinition;
 use crate::error::StorageError;
+use crate::observer::DatabaseObserver;
+#[cfg(feature = "metrics")]
+use crate::observer::DbMetrics;
 use crate::storage_traits::{ReadTable, StorageRead, StorageWrite, WriteTable};
 use crate::vector_ops::{DistanceMetric, Neighbor, l2_normalize};
 
@@ -122,11 +126,19 @@ pub struct IvfPqIndex<'txn, T: StorageWrite> {
     codebooks: Option<Codebooks>,
     /// Tracks whether config has been modified since last persist.
     config_dirty: bool,
+    observer: Arc<dyn DatabaseObserver>,
+    #[cfg(feature = "metrics")]
+    db_metrics: Arc<DbMetrics>,
 }
 
 impl<'txn, T: StorageWrite> IvfPqIndex<'txn, T> {
     /// Open or create. Called by `WriteTransaction::open_ivfpq_index`.
-    pub(crate) fn open(txn: &'txn T, definition: &IvfPqIndexDefinition) -> crate::Result<Self> {
+    pub(crate) fn open(
+        txn: &'txn T,
+        definition: &IvfPqIndexDefinition,
+        observer: Arc<dyn DatabaseObserver>,
+        #[cfg(feature = "metrics")] db_metrics: Arc<DbMetrics>,
+    ) -> crate::Result<Self> {
         let name = String::from(definition.name());
 
         let mn = meta_name(&name);
@@ -178,6 +190,9 @@ impl<'txn, T: StorageWrite> IvfPqIndex<'txn, T> {
             centroids: None,
             codebooks: None,
             config_dirty: false,
+            observer,
+            #[cfg(feature = "metrics")]
+            db_metrics,
         })
     }
 
@@ -354,7 +369,9 @@ impl<'txn, T: StorageWrite> IvfPqIndex<'txn, T> {
             flat.extend_from_slice(&vec);
             count += 1;
         }
-        progress(&TrainProgress::CollectingVectors { count });
+        let p = TrainProgress::CollectingVectors { count };
+        progress(&p);
+        self.observer.on_train_progress(&self.name, &p);
 
         let n = flat.len() / dim;
         if n == 0 {
@@ -364,10 +381,12 @@ impl<'txn, T: StorageWrite> IvfPqIndex<'txn, T> {
             )));
         }
 
-        progress(&TrainProgress::TrainingCentroids {
+        let p = TrainProgress::TrainingCentroids {
             num_clusters,
             num_vectors: n,
-        });
+        };
+        progress(&p);
+        self.observer.on_train_progress(&self.name, &p);
         let centroid_data = kmeans::kmeans(&flat, dim, num_clusters, max_iter, self.config.metric);
 
         let actual_k = centroid_data.len() / dim;
@@ -377,7 +396,9 @@ impl<'txn, T: StorageWrite> IvfPqIndex<'txn, T> {
             self.config.num_clusters = actual_k as u32;
         }
 
-        progress(&TrainProgress::ComputingResiduals { num_vectors: n });
+        let p = TrainProgress::ComputingResiduals { num_vectors: n };
+        progress(&p);
+        self.observer.on_train_progress(&self.name, &p);
         let mut residuals = Vec::with_capacity(flat.len());
         for i in 0..n {
             let vec_slice = &flat[i * dim..(i + 1) * dim];
@@ -394,7 +415,9 @@ impl<'txn, T: StorageWrite> IvfPqIndex<'txn, T> {
             }
         }
 
-        progress(&TrainProgress::TrainingCodebooks { num_subvectors });
+        let p = TrainProgress::TrainingCodebooks { num_subvectors };
+        progress(&p);
+        self.observer.on_train_progress(&self.name, &p);
         let codebooks_trained = pq::train_codebooks(
             &residuals,
             dim,
@@ -405,7 +428,9 @@ impl<'txn, T: StorageWrite> IvfPqIndex<'txn, T> {
 
         self.clear_stale_training_data(old_k, actual_k)?;
 
-        progress(&TrainProgress::Persisting);
+        let p = TrainProgress::Persisting;
+        progress(&p);
+        self.observer.on_train_progress(&self.name, &p);
         {
             let tn = centroids_name(&self.name);
             let def = TableDefinition::<u32, &[u8]>::new_internal(&tn);
@@ -436,7 +461,9 @@ impl<'txn, T: StorageWrite> IvfPqIndex<'txn, T> {
         self.centroids = Some(centroid_data);
         self.codebooks = Some(codebooks_trained);
 
-        progress(&TrainProgress::Done);
+        let p = TrainProgress::Done;
+        progress(&p);
+        self.observer.on_train_progress(&self.name, &p);
         Ok(())
     }
 
@@ -832,6 +859,11 @@ impl<'txn, T: StorageWrite> IvfPqIndex<'txn, T> {
             }
         }
 
+        #[cfg(feature = "metrics")]
+        self.db_metrics
+            .vector_searches
+            .fetch_add(1, portable_atomic::Ordering::Relaxed);
+
         if want_rerank {
             let sorted = heap.into_sorted();
             rerank_from_vectors_table_write(self.txn, q, &sorted, &self.name, dim, metric, params.k)
@@ -1107,6 +1139,8 @@ pub struct ReadOnlyIvfPqIndex {
     name: String,
     centroids: Vec<f32>,
     codebooks: Codebooks,
+    #[cfg(feature = "metrics")]
+    db_metrics: Arc<DbMetrics>,
 }
 
 impl ReadOnlyIvfPqIndex {
@@ -1114,6 +1148,7 @@ impl ReadOnlyIvfPqIndex {
     pub(crate) fn open<R: StorageRead>(
         txn: &R,
         definition: &IvfPqIndexDefinition,
+        #[cfg(feature = "metrics")] db_metrics: Arc<DbMetrics>,
     ) -> crate::Result<Self> {
         let name = String::from(definition.name());
 
@@ -1182,6 +1217,8 @@ impl ReadOnlyIvfPqIndex {
             name,
             centroids,
             codebooks,
+            #[cfg(feature = "metrics")]
+            db_metrics,
         })
     }
 
@@ -1290,6 +1327,11 @@ impl ReadOnlyIvfPqIndex {
                 }
             }
         }
+
+        #[cfg(feature = "metrics")]
+        self.db_metrics
+            .vector_searches
+            .fetch_add(1, portable_atomic::Ordering::Relaxed);
 
         if want_rerank {
             let sorted = heap.into_sorted();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -127,6 +127,9 @@ pub use merge::{
     BitwiseOr, BytesAppend, FloatAdd, FnMergeOperator, MergeOperator, NumericAdd, NumericMax,
     NumericMin, SaturatingAdd, merge_fn,
 };
+#[cfg(feature = "metrics")]
+pub use observer::DbMetrics;
+pub use observer::{CommitInfo, DatabaseObserver};
 pub use probe_select::DiversityConfig;
 pub use temporal::HybridLogicalClock;
 #[cfg(feature = "std")]
@@ -159,6 +162,7 @@ pub mod ivfpq;
 mod legacy_tuple_types;
 pub mod merge;
 mod multimap_table;
+pub mod observer;
 pub mod probe_select;
 mod sealed;
 pub mod storage_traits;

--- a/src/observer.rs
+++ b/src/observer.rs
@@ -1,0 +1,224 @@
+//! Database observability infrastructure.
+//!
+//! The [`DatabaseObserver`] trait provides push-based event callbacks for
+//! monitoring database operations. Implement this trait and register it via
+//! [`Builder::set_observer`](crate::Builder::set_observer) to receive
+//! notifications about transaction lifecycle, compaction, training, and more.
+//!
+//! All methods have default no-op implementations. Override only what you need.
+//!
+//! The [`DbMetrics`] struct (behind the `metrics` feature) provides atomic
+//! counters for pull-based monitoring.
+
+use alloc::sync::Arc;
+
+use crate::db::CompactionProgress;
+use crate::ivfpq::index::TrainProgress;
+
+/// Information about a committed write transaction.
+#[derive(Debug, Clone)]
+pub struct CommitInfo {
+    /// Unique transaction ID.
+    pub transaction_id: u64,
+    /// Number of dirty pages written in this transaction.
+    pub dirty_page_count: u64,
+    /// Whether two-phase commit was used.
+    pub two_phase: bool,
+    /// Time spent in the commit path (including fsync).
+    #[cfg(feature = "std")]
+    pub commit_duration: core::time::Duration,
+}
+
+/// Events emitted by the database for observability.
+///
+/// All methods have default no-op implementations. Override only what you need.
+/// The observer is called synchronously on the committing/reading thread.
+/// Implementations MUST NOT block, panic, or perform I/O that could fail.
+pub trait DatabaseObserver: Send + Sync + 'static {
+    /// A write transaction was committed successfully.
+    fn on_write_commit(&self, _info: &CommitInfo) {}
+
+    /// A write transaction was aborted (explicit abort or drop without commit).
+    fn on_write_abort(&self, _transaction_id: u64) {}
+
+    /// A read transaction was opened.
+    fn on_read_begin(&self, _transaction_id: u64) {}
+
+    /// A read transaction was dropped.
+    fn on_read_end(&self, _transaction_id: u64) {}
+
+    /// A page compaction step completed.
+    fn on_compaction_step(&self, _progress: &CompactionProgress) {}
+
+    /// Page compaction finished (all pages relocated).
+    fn on_compaction_complete(&self, _total_pages_relocated: u64) {}
+
+    /// IVF-PQ training progress update.
+    fn on_train_progress(&self, _index_name: &str, _progress: &TrainProgress) {}
+
+    /// A blob was written to the store.
+    fn on_blob_write(&self, _blob_id: u64, _size_bytes: u64) {}
+
+    /// A blob was deduplicated (existing content reused, bytes saved).
+    fn on_blob_dedup(&self, _blob_id: u64, _saved_bytes: u64) {}
+
+    /// A page checksum verification failed.
+    fn on_checksum_failure(&self, _page_number: u64) {}
+}
+
+/// Zero-sized no-op observer. Used as the default when no observer is registered.
+/// The compiler devirtualizes calls to this, making it truly zero-cost.
+pub(crate) struct NoopObserver;
+
+impl DatabaseObserver for NoopObserver {}
+
+/// Returns the default observer (no-op).
+pub(crate) fn default_observer() -> Arc<dyn DatabaseObserver> {
+    Arc::new(NoopObserver)
+}
+
+/// Atomic counters for database-wide metrics.
+///
+/// Accessible via [`Database::metrics()`](crate::Database::metrics) when the
+/// `metrics` feature is enabled. All counters are monotonically increasing
+/// and use relaxed ordering for minimal overhead.
+#[cfg(feature = "metrics")]
+pub struct DbMetrics {
+    /// Number of write transactions committed.
+    pub(crate) write_txn_committed: portable_atomic::AtomicU64,
+    /// Number of write transactions aborted.
+    pub(crate) write_txn_aborted: portable_atomic::AtomicU64,
+    /// Number of read transactions opened.
+    pub(crate) read_txn_opened: portable_atomic::AtomicU64,
+    /// Number of read transactions closed.
+    pub(crate) read_txn_closed: portable_atomic::AtomicU64,
+    /// Total pages allocated across all transactions.
+    pub(crate) pages_allocated: portable_atomic::AtomicU64,
+    /// Total pages freed across all transactions.
+    pub(crate) pages_freed: portable_atomic::AtomicU64,
+    /// Logical bytes written (user data).
+    pub(crate) bytes_written_logical: portable_atomic::AtomicU64,
+    /// Physical bytes written (actual I/O). Divide by logical for write amplification.
+    pub(crate) bytes_written_physical: portable_atomic::AtomicU64,
+    /// Number of blob write operations.
+    pub(crate) blob_writes: portable_atomic::AtomicU64,
+    /// Number of blob dedup hits (content already existed).
+    pub(crate) blob_dedup_hits: portable_atomic::AtomicU64,
+    /// Number of vector search operations.
+    pub(crate) vector_searches: portable_atomic::AtomicU64,
+    /// Total pages relocated by compaction.
+    pub(crate) compaction_pages_relocated: portable_atomic::AtomicU64,
+}
+
+#[cfg(feature = "metrics")]
+impl DbMetrics {
+    pub(crate) fn new() -> Self {
+        Self {
+            write_txn_committed: portable_atomic::AtomicU64::new(0),
+            write_txn_aborted: portable_atomic::AtomicU64::new(0),
+            read_txn_opened: portable_atomic::AtomicU64::new(0),
+            read_txn_closed: portable_atomic::AtomicU64::new(0),
+            pages_allocated: portable_atomic::AtomicU64::new(0),
+            pages_freed: portable_atomic::AtomicU64::new(0),
+            bytes_written_logical: portable_atomic::AtomicU64::new(0),
+            bytes_written_physical: portable_atomic::AtomicU64::new(0),
+            blob_writes: portable_atomic::AtomicU64::new(0),
+            blob_dedup_hits: portable_atomic::AtomicU64::new(0),
+            vector_searches: portable_atomic::AtomicU64::new(0),
+            compaction_pages_relocated: portable_atomic::AtomicU64::new(0),
+        }
+    }
+
+    /// Number of write transactions committed.
+    pub fn write_txn_committed(&self) -> u64 {
+        self.write_txn_committed
+            .load(portable_atomic::Ordering::Relaxed)
+    }
+
+    /// Number of write transactions aborted.
+    pub fn write_txn_aborted(&self) -> u64 {
+        self.write_txn_aborted
+            .load(portable_atomic::Ordering::Relaxed)
+    }
+
+    /// Number of read transactions opened.
+    pub fn read_txn_opened(&self) -> u64 {
+        self.read_txn_opened
+            .load(portable_atomic::Ordering::Relaxed)
+    }
+
+    /// Number of read transactions closed.
+    pub fn read_txn_closed(&self) -> u64 {
+        self.read_txn_closed
+            .load(portable_atomic::Ordering::Relaxed)
+    }
+
+    /// Total pages allocated.
+    pub fn pages_allocated(&self) -> u64 {
+        self.pages_allocated
+            .load(portable_atomic::Ordering::Relaxed)
+    }
+
+    /// Total pages freed.
+    pub fn pages_freed(&self) -> u64 {
+        self.pages_freed.load(portable_atomic::Ordering::Relaxed)
+    }
+
+    /// Logical bytes written (user data).
+    pub fn bytes_written_logical(&self) -> u64 {
+        self.bytes_written_logical
+            .load(portable_atomic::Ordering::Relaxed)
+    }
+
+    /// Physical bytes written to storage.
+    pub fn bytes_written_physical(&self) -> u64 {
+        self.bytes_written_physical
+            .load(portable_atomic::Ordering::Relaxed)
+    }
+
+    /// Number of blob write operations.
+    pub fn blob_writes(&self) -> u64 {
+        self.blob_writes.load(portable_atomic::Ordering::Relaxed)
+    }
+
+    /// Number of blob dedup hits.
+    pub fn blob_dedup_hits(&self) -> u64 {
+        self.blob_dedup_hits
+            .load(portable_atomic::Ordering::Relaxed)
+    }
+
+    /// Number of vector search operations.
+    pub fn vector_searches(&self) -> u64 {
+        self.vector_searches
+            .load(portable_atomic::Ordering::Relaxed)
+    }
+
+    /// Total pages relocated by compaction.
+    pub fn compaction_pages_relocated(&self) -> u64 {
+        self.compaction_pages_relocated
+            .load(portable_atomic::Ordering::Relaxed)
+    }
+}
+
+#[cfg(feature = "metrics")]
+impl core::fmt::Debug for DbMetrics {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("DbMetrics")
+            .field("write_txn_committed", &self.write_txn_committed())
+            .field("write_txn_aborted", &self.write_txn_aborted())
+            .field("read_txn_opened", &self.read_txn_opened())
+            .field("read_txn_closed", &self.read_txn_closed())
+            .field("pages_allocated", &self.pages_allocated())
+            .field("pages_freed", &self.pages_freed())
+            .field("bytes_written_logical", &self.bytes_written_logical())
+            .field("bytes_written_physical", &self.bytes_written_physical())
+            .field("blob_writes", &self.blob_writes())
+            .field("blob_dedup_hits", &self.blob_dedup_hits())
+            .field("vector_searches", &self.vector_searches())
+            .field(
+                "compaction_pages_relocated",
+                &self.compaction_pages_relocated(),
+            )
+            .finish()
+    }
+}

--- a/src/transactions.rs
+++ b/src/transactions.rs
@@ -1517,7 +1517,14 @@ impl WriteTransaction {
         &self,
         definition: &crate::ivfpq::config::IvfPqIndexDefinition,
     ) -> Result<crate::ivfpq::index::IvfPqIndex<'_, Self>, TableError> {
-        crate::ivfpq::index::IvfPqIndex::open(self, definition).map_err(TableError::Storage)
+        crate::ivfpq::index::IvfPqIndex::open(
+            self,
+            definition,
+            Arc::clone(&self.observer),
+            #[cfg(feature = "metrics")]
+            Arc::clone(&self.db_metrics),
+        )
+        .map_err(TableError::Storage)
     }
 
     /// Open the given table
@@ -3422,7 +3429,13 @@ impl ReadTransaction {
         &self,
         definition: &crate::ivfpq::config::IvfPqIndexDefinition,
     ) -> Result<crate::ivfpq::index::ReadOnlyIvfPqIndex, TableError> {
-        crate::ivfpq::index::ReadOnlyIvfPqIndex::open(self, definition).map_err(TableError::Storage)
+        crate::ivfpq::index::ReadOnlyIvfPqIndex::open(
+            self,
+            definition,
+            #[cfg(feature = "metrics")]
+            Arc::clone(&self.db_metrics),
+        )
+        .map_err(TableError::Storage)
     }
 
     /// Open the given table without a type

--- a/src/transactions.rs
+++ b/src/transactions.rs
@@ -985,9 +985,13 @@ pub struct WriteTransaction {
     pub(crate) cdc_log: Option<Mutex<Vec<CdcEvent>>>,
     cdc_config: CdcConfig,
     history_retention: u64,
+    observer: Arc<dyn crate::observer::DatabaseObserver>,
+    #[cfg(feature = "metrics")]
+    db_metrics: Arc<crate::observer::DbMetrics>,
 }
 
 impl WriteTransaction {
+    #[allow(clippy::too_many_arguments)]
     pub(crate) fn new(
         guard: TransactionGuard,
         transaction_tracker: Arc<TransactionTracker>,
@@ -995,6 +999,8 @@ impl WriteTransaction {
         blob_dedup_config: BlobDedupConfig,
         cdc_config: CdcConfig,
         history_retention: u64,
+        observer: Arc<dyn crate::observer::DatabaseObserver>,
+        #[cfg(feature = "metrics")] db_metrics: Arc<crate::observer::DbMetrics>,
     ) -> Result<Self> {
         let transaction_id = guard.id()?;
         let guard = Arc::new(guard);
@@ -1029,6 +1035,9 @@ impl WriteTransaction {
             },
             cdc_config,
             history_retention,
+            observer,
+            #[cfg(feature = "metrics")]
+            db_metrics,
         })
     }
 
@@ -1661,6 +1670,7 @@ impl WriteTransaction {
             None
         };
 
+        let mut dedup_saved = 0u64;
         let blob_ref = if let Some(existing) = dedup_hit
             && existing.checksum == checksum
             && existing.length == data.len() as u64
@@ -1669,6 +1679,7 @@ impl WriteTransaction {
             // checksum + length confirmed. Without the secondary check a
             // SHA-256 collision (or corrupted dedup index entry) would
             // silently bind the new blob_id to wrong physical data.
+            dedup_saved = existing.length;
             BlobRef {
                 offset: existing.offset,
                 length: existing.length,
@@ -1787,6 +1798,22 @@ impl WriteTransaction {
         // 9. Update pending blob state for commit
         self.mem.set_pending_blob_state(blob_state);
         self.dirty.store(true, Ordering::Release);
+
+        // 10. Observer / metrics
+        if dedup_saved > 0 {
+            self.observer.on_blob_dedup(blob_id.sequence, dedup_saved);
+            #[cfg(feature = "metrics")]
+            self.db_metrics
+                .blob_dedup_hits
+                .fetch_add(1, portable_atomic::Ordering::Relaxed);
+        } else {
+            self.observer
+                .on_blob_write(blob_id.sequence, blob_ref.length);
+            #[cfg(feature = "metrics")]
+            self.db_metrics
+                .blob_writes
+                .fetch_add(1, portable_atomic::Ordering::Relaxed);
+        }
 
         Ok(blob_id)
     }
@@ -2473,6 +2500,9 @@ impl WriteTransaction {
     }
 
     fn commit_inner(&mut self) -> Result<(), CommitError> {
+        #[cfg(feature = "std")]
+        let commit_start = std::time::Instant::now();
+
         // Quick-repair requires 2-phase commit
         if self.quick_repair {
             self.two_phase_commit = true;
@@ -2501,6 +2531,7 @@ impl WriteTransaction {
         let (user_root, allocated_pages, data_freed) =
             self.tables.lock().table_tree.flush_and_close()?;
 
+        let dirty_page_count = allocated_pages.len() as u64;
         self.store_data_freed_pages(data_freed)?;
         self.store_allocated_pages(allocated_pages.into_iter().collect())?;
         self.flush_cdc_log()?;
@@ -2534,6 +2565,19 @@ impl WriteTransaction {
             "Finished commit of transaction id={:?}",
             self.transaction_id
         );
+
+        let info = crate::observer::CommitInfo {
+            transaction_id: self.transaction_id.raw_id(),
+            dirty_page_count,
+            two_phase: self.two_phase_commit,
+            #[cfg(feature = "std")]
+            commit_duration: commit_start.elapsed(),
+        };
+        self.observer.on_write_commit(&info);
+        #[cfg(feature = "metrics")]
+        self.db_metrics
+            .write_txn_committed
+            .fetch_add(1, portable_atomic::Ordering::Relaxed);
 
         Ok(())
     }
@@ -2749,6 +2793,13 @@ impl WriteTransaction {
         self.mem.rollback_uncommitted_writes()?;
         #[cfg(feature = "logging")]
         debug!("Finished abort of transaction id={:?}", self.transaction_id);
+
+        self.observer.on_write_abort(self.transaction_id.raw_id());
+        #[cfg(feature = "metrics")]
+        self.db_metrics
+            .write_txn_aborted
+            .fetch_add(1, portable_atomic::Ordering::Relaxed);
+
         Ok(())
     }
 
@@ -3273,19 +3324,30 @@ impl Drop for WriteTransaction {
 pub struct ReadTransaction {
     mem: Arc<TransactionalMemory>,
     tree: TableTree,
+    transaction_id: Option<u64>,
+    observer: Arc<dyn crate::observer::DatabaseObserver>,
+    #[cfg(feature = "metrics")]
+    db_metrics: Arc<crate::observer::DbMetrics>,
 }
 
 impl ReadTransaction {
     pub(crate) fn new(
         mem: Arc<TransactionalMemory>,
         guard: TransactionGuard,
+        observer: Arc<dyn crate::observer::DatabaseObserver>,
+        #[cfg(feature = "metrics")] db_metrics: Arc<crate::observer::DbMetrics>,
     ) -> Result<Self, TransactionError> {
         let root_page = mem.get_data_root();
+        let txn_id = guard.id().ok().map(|id| id.raw_id());
         let guard = Arc::new(guard);
         Ok(Self {
             mem: mem.clone(),
             tree: TableTree::new(root_page, PageHint::Clean, guard, mem)
                 .map_err(TransactionError::Storage)?,
+            transaction_id: txn_id,
+            observer,
+            #[cfg(feature = "metrics")]
+            db_metrics,
         })
     }
 
@@ -3294,12 +3356,19 @@ impl ReadTransaction {
         mem: Arc<TransactionalMemory>,
         guard: TransactionGuard,
         user_root: Option<BtreeHeader>,
+        observer: Arc<dyn crate::observer::DatabaseObserver>,
+        #[cfg(feature = "metrics")] db_metrics: Arc<crate::observer::DbMetrics>,
     ) -> Result<Self, TransactionError> {
+        let txn_id = guard.id().ok().map(|id| id.raw_id());
         let guard = Arc::new(guard);
         Ok(Self {
             mem: mem.clone(),
             tree: TableTree::new(user_root, PageHint::Clean, guard, mem)
                 .map_err(TransactionError::Storage)?,
+            transaction_id: txn_id,
+            observer,
+            #[cfg(feature = "metrics")]
+            db_metrics,
         })
     }
 
@@ -4217,6 +4286,18 @@ impl ReadTransaction {
         }
         // No-op, just drop ourself
         Ok(())
+    }
+}
+
+impl Drop for ReadTransaction {
+    fn drop(&mut self) {
+        if let Some(id) = self.transaction_id {
+            self.observer.on_read_end(id);
+            #[cfg(feature = "metrics")]
+            self.db_metrics
+                .read_txn_closed
+                .fetch_add(1, portable_atomic::Ordering::Relaxed);
+        }
     }
 }
 


### PR DESCRIPTION
## Summary

- Add `DatabaseObserver` trait with 10 push-based lifecycle hooks (commit, abort, read begin/end, compaction step/complete, blob write/dedup, checksum failure, train progress)
- Add `DbMetrics` struct (behind `metrics` feature) with 12 `AtomicU64` counters for pull-based monitoring
- Wire observer into `Database`, `WriteTransaction`, `ReadTransaction`, `CompactionHandle`, and blob `store_blob` path
- `Builder::set_observer()` to register custom observers; `NoopObserver` ZST default is devirtualized to zero-cost
- New `metrics` feature flag (implies `cache_metrics`)

## Test plan

- [x] `cargo clippy --all-features -- -D warnings` clean
- [x] `cargo test --all-features` (1374+ tests pass)
- [x] `cargo test --features metrics` passes
- [x] `cargo check` (default features) passes
- [x] `cargo fmt --all -- --check` clean