### PR TITLE
feat(ci): Criterion benchmarks + performance regression gate

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -1,0 +1,75 @@
+name: Benchmarks
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+
+concurrency:
+  group: bench-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  bench:
+    name: Criterion Benchmarks
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Cache
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/bin/
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+            target/
+          key: bench-${{ runner.os }}-${{ hashFiles('**/Cargo.toml', '**/Cargo.lock') }}
+          restore-keys: bench-${{ runner.os }}-
+
+      - name: Install Rust
+        run: rustup component add rustfmt
+
+      - name: Run Criterion benchmarks
+        run: |
+          cargo bench --bench criterion_kv \
+                      --bench criterion_blob \
+                      --bench criterion_vector_ops \
+                      --bench criterion_ivfpq \
+                      -p shodh-redb \
+                      -- --output-format bencher 2>/dev/null | grep "^test " | tee bench_output.txt
+        env:
+          RUSTFLAGS: ""
+
+      - name: Restore baseline
+        if: github.event_name == 'pull_request'
+        uses: actions/cache/restore@v4
+        with:
+          path: .bench_baseline.json
+          key: bench-baseline-${{ runner.os }}
+          restore-keys: bench-baseline-${{ runner.os }}
+
+      - name: Benchmark comparison
+        uses: benchmark-action/github-action-benchmark@v1
+        with:
+          name: shodh-redb benchmarks
+          tool: cargo
+          output-file-path: bench_output.txt
+          external-data-json-path: .bench_baseline.json
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          auto-push: false
+          comment-on-alert: true
+          alert-threshold: "115%"
+          fail-on-alert: true
+          fail-threshold: "150%"
+          comment-always: ${{ github.event_name == 'pull_request' }}
+          alert-comment-cc-users: "@varun29ankuS"
+
+      - name: Save baseline
+        if: github.event_name == 'push' && github.ref == 'refs/heads/master'
+        uses: actions/cache/save@v4
+        with:
+          path: .bench_baseline.json
+          key: bench-baseline-${{ runner.os }}

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -38,6 +38,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "anes"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
+
+[[package]]
 name = "anstream"
 version = "0.6.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -143,7 +149,7 @@ dependencies = [
  "bitflags 2.11.0",
  "cexpr",
  "clang-sys",
- "itertools",
+ "itertools 0.12.1",
  "lazy_static",
  "lazycell",
  "proc-macro2",
@@ -291,6 +297,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "cast"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
+
+[[package]]
 name = "cc"
 version = "1.2.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -345,6 +357,33 @@ dependencies = [
  "num-traits",
  "wasm-bindgen",
  "windows-link",
+]
+
+[[package]]
+name = "ciborium"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42e69ffd6f0917f5c029256a24d0161db17cea3997d185db0d35926308770f0e"
+dependencies = [
+ "ciborium-io",
+ "ciborium-ll",
+ "serde",
+]
+
+[[package]]
+name = "ciborium-io"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05afea1e0a06c9be33d539b876f1ce3692f4afea2cb41f740e7743225ed1c757"
+
+[[package]]
+name = "ciborium-ll"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57663b653d948a338bfb3eeba9bb2fd5fcfaecb9e199e87e1eda4d9e8b240fd9"
+dependencies = [
+ "ciborium-io",
+ "half",
 ]
 
 [[package]]
@@ -455,6 +494,40 @@ dependencies = [
 ]
 
 [[package]]
+name = "criterion"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2b12d017a929603d80db1831cd3a24082f8137ce19c69e6447f54f5fc8d692f"
+dependencies = [
+ "anes",
+ "cast",
+ "ciborium",
+ "clap",
+ "criterion-plot",
+ "is-terminal",
+ "itertools 0.10.5",
+ "num-traits",
+ "once_cell",
+ "oorandom",
+ "regex",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "tinytemplate",
+ "walkdir",
+]
+
+[[package]]
+name = "criterion-plot"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b50826342786a51a89e2da3a28f1c32b06e387201bc2d19791f622c673706b1"
+dependencies = [
+ "cast",
+ "itertools 0.10.5",
+]
+
+[[package]]
 name = "crossbeam-epoch"
 version = "0.9.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -510,6 +583,12 @@ checksum = "acdd7c62a3665c7f6830a51635d9ac9b23ed385797f70a83bb8bafe9c572ab2b"
 dependencies = [
  "winapi",
 ]
+
+[[package]]
+name = "crunchy"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
 name = "crypto-common"
@@ -813,6 +892,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "17e2ac29387b1aa07a1e448f7bb4f35b500787971e965b02842b900afa5c8f6f"
 
 [[package]]
+name = "half"
+version = "2.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ea2d84b969582b4b1864a92dc5d27cd2b77b622a8d79306834f1be5ba20d84b"
+dependencies = [
+ "cfg-if",
+ "crunchy",
+ "zerocopy",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -899,6 +989,12 @@ dependencies = [
  "serde",
  "serde_json",
 ]
+
+[[package]]
+name = "hermit-abi"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
 
 [[package]]
 name = "iana-time-zone"
@@ -1084,10 +1180,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "is-terminal"
+version = "0.4.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
+dependencies = [
+ "hermit-abi",
+ "libc",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "is_terminal_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
+
+[[package]]
+name = "itertools"
+version = "0.10.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
+dependencies = [
+ "either",
+]
 
 [[package]]
 name = "itertools"
@@ -1375,6 +1491,12 @@ name = "once_cell_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
+
+[[package]]
+name = "oorandom"
+version = "11.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
 
 [[package]]
 name = "page_size"
@@ -2065,6 +2187,7 @@ version = "0.4.0"
 dependencies = [
  "bincode 2.0.1",
  "chrono",
+ "criterion",
  "hashbrown 0.15.5",
  "io-uring 0.6.4",
  "libc",
@@ -2303,6 +2426,16 @@ checksum = "42d3e9c45c09de15d06dd8acf5f4e0e399e85927b7f00711024eb7ae10fa4869"
 dependencies = [
  "displaydoc",
  "zerovec",
+]
+
+[[package]]
+name = "tinytemplate"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be4d6b5f19ff7664e8c98d03e2139cb510db9b0a60b55f8e8709b689d939b6bc"
+dependencies = [
+ "serde",
+ "serde_json",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -60,6 +60,23 @@ redb2_6 = { version = "=2.6.0", package = "redb" }
 bincode = "2.0.1"
 uuid = { version= "1.17.0", features = ["v4"] }
 shodh-redb-derive = { version = "0.1.0", path = "./crates/redb-derive" }
+criterion = { version = "0.5", default-features = false }
+
+[[bench]]
+name = "criterion_kv"
+harness = false
+
+[[bench]]
+name = "criterion_blob"
+harness = false
+
+[[bench]]
+name = "criterion_vector_ops"
+harness = false
+
+[[bench]]
+name = "criterion_ivfpq"
+harness = false
 
 [features]
 default = ["std"]

--- a/benches/criterion_blob.rs
+++ b/benches/criterion_blob.rs
@@ -1,8 +1,6 @@
 //! Criterion benchmarks for blob store operations: store and read.
 
-use criterion::{
-    BatchSize, BenchmarkId, Criterion, Throughput, criterion_group, criterion_main,
-};
+use criterion::{BatchSize, BenchmarkId, Criterion, Throughput, criterion_group, criterion_main};
 use shodh_redb::{ContentType, Database, ReadableDatabase, StoreOptions};
 use tempfile::NamedTempFile;
 
@@ -15,11 +13,7 @@ fn make_blob_data(size: usize) -> Vec<u8> {
 // ---------------------------------------------------------------------------
 
 fn bench_store_blob(c: &mut Criterion) {
-    let sizes: &[(usize, &str)] = &[
-        (1024, "1KiB"),
-        (64 * 1024, "64KiB"),
-        (1024 * 1024, "1MiB"),
-    ];
+    let sizes: &[(usize, &str)] = &[(1024, "1KiB"), (64 * 1024, "64KiB"), (1024 * 1024, "1MiB")];
     let mut group = c.benchmark_group("blob/store");
     for &(size, label) in sizes {
         let data = make_blob_data(size);
@@ -58,11 +52,7 @@ fn bench_store_blob(c: &mut Criterion) {
 // ---------------------------------------------------------------------------
 
 fn bench_get_blob(c: &mut Criterion) {
-    let sizes: &[(usize, &str)] = &[
-        (1024, "1KiB"),
-        (64 * 1024, "64KiB"),
-        (1024 * 1024, "1MiB"),
-    ];
+    let sizes: &[(usize, &str)] = &[(1024, "1KiB"), (64 * 1024, "64KiB"), (1024 * 1024, "1MiB")];
     let mut group = c.benchmark_group("blob/get");
     for &(size, label) in sizes {
         let data = make_blob_data(size);

--- a/benches/criterion_blob.rs
+++ b/benches/criterion_blob.rs
@@ -1,0 +1,104 @@
+//! Criterion benchmarks for blob store operations: store and read.
+
+use criterion::{
+    BatchSize, BenchmarkId, Criterion, Throughput, criterion_group, criterion_main,
+};
+use shodh_redb::{ContentType, Database, ReadableDatabase, StoreOptions};
+use tempfile::NamedTempFile;
+
+fn make_blob_data(size: usize) -> Vec<u8> {
+    (0..size).map(|i| (i & 0xFF) as u8).collect()
+}
+
+// ---------------------------------------------------------------------------
+// Store blob
+// ---------------------------------------------------------------------------
+
+fn bench_store_blob(c: &mut Criterion) {
+    let sizes: &[(usize, &str)] = &[
+        (1024, "1KiB"),
+        (64 * 1024, "64KiB"),
+        (1024 * 1024, "1MiB"),
+    ];
+    let mut group = c.benchmark_group("blob/store");
+    for &(size, label) in sizes {
+        let data = make_blob_data(size);
+        group.throughput(Throughput::Bytes(size as u64));
+        group.bench_with_input(BenchmarkId::new("store_blob", label), &size, |b, _| {
+            b.iter_batched(
+                || {
+                    let f = NamedTempFile::new().unwrap();
+                    let db = Database::builder()
+                        .set_blob_dedup(true)
+                        .create(f.path())
+                        .unwrap();
+                    (f, db)
+                },
+                |(_f, db)| {
+                    let txn = db.begin_write().unwrap();
+                    let _id = txn
+                        .store_blob(
+                            &data,
+                            ContentType::OctetStream,
+                            "bench",
+                            StoreOptions::default(),
+                        )
+                        .unwrap();
+                    txn.commit().unwrap();
+                },
+                BatchSize::PerIteration,
+            );
+        });
+    }
+    group.finish();
+}
+
+// ---------------------------------------------------------------------------
+// Read blob
+// ---------------------------------------------------------------------------
+
+fn bench_get_blob(c: &mut Criterion) {
+    let sizes: &[(usize, &str)] = &[
+        (1024, "1KiB"),
+        (64 * 1024, "64KiB"),
+        (1024 * 1024, "1MiB"),
+    ];
+    let mut group = c.benchmark_group("blob/get");
+    for &(size, label) in sizes {
+        let data = make_blob_data(size);
+        // Pre-populate a DB with one blob of this size
+        let f = NamedTempFile::new().unwrap();
+        let db = Database::builder()
+            .set_blob_dedup(true)
+            .create(f.path())
+            .unwrap();
+        let blob_id = {
+            let txn = db.begin_write().unwrap();
+            let id = txn
+                .store_blob(
+                    &data,
+                    ContentType::OctetStream,
+                    "bench",
+                    StoreOptions::default(),
+                )
+                .unwrap();
+            txn.commit().unwrap();
+            id
+        };
+
+        group.throughput(Throughput::Bytes(size as u64));
+        group.bench_with_input(BenchmarkId::new("get_blob", label), &size, |b, _| {
+            b.iter(|| {
+                let rtxn = db.begin_read().unwrap();
+                let (got, _meta) = rtxn.get_blob(&blob_id).unwrap().unwrap();
+                got
+            });
+        });
+        drop(db);
+        drop(f);
+    }
+    group.finish();
+}
+
+criterion_group!(benches, bench_store_blob, bench_get_blob);
+criterion_main!(benches);

--- a/benches/criterion_ivfpq.rs
+++ b/benches/criterion_ivfpq.rs
@@ -1,0 +1,115 @@
+//! Criterion benchmarks for IVF-PQ index: insert_batch and search.
+//!
+//! Training is done in setup (outside the timed region) since it is a one-time
+//! cost, not the hot path we want to gate on.
+
+use criterion::{
+    BatchSize, BenchmarkId, Criterion, Throughput, criterion_group, criterion_main,
+};
+use shodh_redb::{Database, DistanceMetric, IvfPqIndexDefinition, ReadableDatabase, SearchParams};
+use tempfile::NamedTempFile;
+
+const DIM: u32 = 128;
+const NUM_CLUSTERS: u32 = 16;
+const NUM_SUBVECTORS: u32 = 16;
+const INDEX_DEF: IvfPqIndexDefinition = IvfPqIndexDefinition::new(
+    "bench_idx",
+    DIM,
+    NUM_CLUSTERS,
+    NUM_SUBVECTORS,
+    DistanceMetric::EuclideanSq,
+)
+.with_raw_vectors();
+
+fn make_vector(id: u64, dim: usize) -> Vec<f32> {
+    (0..dim)
+        .map(|j| ((id.wrapping_mul(7).wrapping_add(j as u64 * 11).wrapping_add(13)) % 1000) as f32 * 0.001 - 0.5)
+        .collect()
+}
+
+fn create_trained_db() -> (NamedTempFile, Database) {
+    let f = NamedTempFile::new().unwrap();
+    let db = Database::create(f.path()).unwrap();
+    let dim = DIM as usize;
+    {
+        let txn = db.begin_write().unwrap();
+        let mut idx = txn.open_ivfpq_index(&INDEX_DEF).unwrap();
+        let training: Vec<(u64, Vec<f32>)> = (0..200u64)
+            .map(|id| (id, make_vector(id, dim)))
+            .collect();
+        idx.train(training.into_iter(), 10).unwrap();
+        drop(idx);
+        txn.commit().unwrap();
+    }
+    (f, db)
+}
+
+// ---------------------------------------------------------------------------
+// Insert batch
+// ---------------------------------------------------------------------------
+
+fn bench_insert_batch(c: &mut Criterion) {
+    let dim = DIM as usize;
+    let mut group = c.benchmark_group("ivfpq/insert_batch");
+
+    for &n in &[10u64, 100, 1000] {
+        let vectors: Vec<(u64, Vec<f32>)> = (0..n)
+            .map(|id| (id + 10_000, make_vector(id + 10_000, dim)))
+            .collect();
+        group.throughput(Throughput::Elements(n));
+        group.bench_with_input(BenchmarkId::from_parameter(n), &n, |b, _| {
+            b.iter_batched(
+                || {
+                    // Setup: create a trained DB (not timed)
+                    let (f, db) = create_trained_db();
+                    (f, db, vectors.clone())
+                },
+                |(_f, db, vecs)| {
+                    let txn = db.begin_write().unwrap();
+                    let mut idx = txn.open_ivfpq_index(&INDEX_DEF).unwrap();
+                    idx.insert_batch(vecs.into_iter()).unwrap();
+                    drop(idx);
+                    txn.commit().unwrap();
+                },
+                BatchSize::LargeInput,
+            );
+        });
+    }
+    group.finish();
+}
+
+// ---------------------------------------------------------------------------
+// Search
+// ---------------------------------------------------------------------------
+
+fn bench_search(c: &mut Criterion) {
+    let dim = DIM as usize;
+    // Build one trained + populated DB outside measurement loop
+    let (_f, db) = create_trained_db();
+    {
+        let txn = db.begin_write().unwrap();
+        let mut idx = txn.open_ivfpq_index(&INDEX_DEF).unwrap();
+        let vecs: Vec<(u64, Vec<f32>)> = (0..500u64)
+            .map(|id| (id, make_vector(id, dim)))
+            .collect();
+        idx.insert_batch(vecs.into_iter()).unwrap();
+        drop(idx);
+        txn.commit().unwrap();
+    }
+
+    let query = make_vector(9999, dim);
+    let params = SearchParams::top_k(10);
+
+    let mut group = c.benchmark_group("ivfpq/search");
+    group.bench_function("search_500vecs_k10", |b| {
+        b.iter(|| {
+            let rtxn = db.begin_read().unwrap();
+            let idx = rtxn.open_ivfpq_index(&INDEX_DEF).unwrap();
+            idx.search(&rtxn, &query, &params).unwrap()
+        });
+    });
+    group.finish();
+}
+
+criterion_group!(benches, bench_insert_batch, bench_search);
+criterion_main!(benches);

--- a/benches/criterion_ivfpq.rs
+++ b/benches/criterion_ivfpq.rs
@@ -3,9 +3,7 @@
 //! Training is done in setup (outside the timed region) since it is a one-time
 //! cost, not the hot path we want to gate on.
 
-use criterion::{
-    BatchSize, BenchmarkId, Criterion, Throughput, criterion_group, criterion_main,
-};
+use criterion::{BatchSize, BenchmarkId, Criterion, Throughput, criterion_group, criterion_main};
 use shodh_redb::{Database, DistanceMetric, IvfPqIndexDefinition, ReadableDatabase, SearchParams};
 use tempfile::NamedTempFile;
 
@@ -23,7 +21,14 @@ const INDEX_DEF: IvfPqIndexDefinition = IvfPqIndexDefinition::new(
 
 fn make_vector(id: u64, dim: usize) -> Vec<f32> {
     (0..dim)
-        .map(|j| ((id.wrapping_mul(7).wrapping_add(j as u64 * 11).wrapping_add(13)) % 1000) as f32 * 0.001 - 0.5)
+        .map(|j| {
+            ((id.wrapping_mul(7)
+                .wrapping_add(j as u64 * 11)
+                .wrapping_add(13))
+                % 1000) as f32
+                * 0.001
+                - 0.5
+        })
         .collect()
 }
 
@@ -34,9 +39,8 @@ fn create_trained_db() -> (NamedTempFile, Database) {
     {
         let txn = db.begin_write().unwrap();
         let mut idx = txn.open_ivfpq_index(&INDEX_DEF).unwrap();
-        let training: Vec<(u64, Vec<f32>)> = (0..200u64)
-            .map(|id| (id, make_vector(id, dim)))
-            .collect();
+        let training: Vec<(u64, Vec<f32>)> =
+            (0..200u64).map(|id| (id, make_vector(id, dim))).collect();
         idx.train(training.into_iter(), 10).unwrap();
         drop(idx);
         txn.commit().unwrap();
@@ -89,9 +93,7 @@ fn bench_search(c: &mut Criterion) {
     {
         let txn = db.begin_write().unwrap();
         let mut idx = txn.open_ivfpq_index(&INDEX_DEF).unwrap();
-        let vecs: Vec<(u64, Vec<f32>)> = (0..500u64)
-            .map(|id| (id, make_vector(id, dim)))
-            .collect();
+        let vecs: Vec<(u64, Vec<f32>)> = (0..500u64).map(|id| (id, make_vector(id, dim))).collect();
         idx.insert_batch(vecs.into_iter()).unwrap();
         drop(idx);
         txn.commit().unwrap();

--- a/benches/criterion_kv.rs
+++ b/benches/criterion_kv.rs
@@ -2,9 +2,7 @@
 //!
 //! Uses Durability::None to isolate B-tree performance from fsync noise.
 
-use criterion::{
-    BatchSize, BenchmarkId, Criterion, Throughput, criterion_group, criterion_main,
-};
+use criterion::{BatchSize, BenchmarkId, Criterion, Throughput, criterion_group, criterion_main};
 use shodh_redb::{Database, Durability, ReadableDatabase, TableDefinition};
 use tempfile::NamedTempFile;
 
@@ -15,7 +13,9 @@ fn make_value(seed: u64) -> [u8; VALUE_SIZE] {
     let mut buf = [0u8; VALUE_SIZE];
     let mut state = seed;
     for b in buf.iter_mut() {
-        state = state.wrapping_mul(6364136223846793005).wrapping_add(1442695040888963407);
+        state = state
+            .wrapping_mul(6364136223846793005)
+            .wrapping_add(1442695040888963407);
         *b = (state >> 33) as u8;
     }
     buf

--- a/benches/criterion_kv.rs
+++ b/benches/criterion_kv.rs
@@ -1,0 +1,128 @@
+//! Criterion benchmarks for B-tree KV operations: insert, get, range scan.
+//!
+//! Uses Durability::None to isolate B-tree performance from fsync noise.
+
+use criterion::{
+    BatchSize, BenchmarkId, Criterion, Throughput, criterion_group, criterion_main,
+};
+use shodh_redb::{Database, Durability, ReadableDatabase, TableDefinition};
+use tempfile::NamedTempFile;
+
+const TABLE: TableDefinition<u64, &[u8]> = TableDefinition::new("bench_kv");
+const VALUE_SIZE: usize = 150;
+
+fn make_value(seed: u64) -> [u8; VALUE_SIZE] {
+    let mut buf = [0u8; VALUE_SIZE];
+    let mut state = seed;
+    for b in buf.iter_mut() {
+        state = state.wrapping_mul(6364136223846793005).wrapping_add(1442695040888963407);
+        *b = (state >> 33) as u8;
+    }
+    buf
+}
+
+fn create_populated_db(n: u64) -> (NamedTempFile, Database) {
+    let f = NamedTempFile::new().unwrap();
+    let db = Database::builder()
+        .set_cache_size(4 * 1024 * 1024)
+        .create(f.path())
+        .unwrap();
+    let mut txn = db.begin_write().unwrap();
+    txn.set_durability(Durability::None).unwrap();
+    {
+        let mut table = txn.open_table(TABLE).unwrap();
+        for i in 0..n {
+            let val = make_value(i);
+            table.insert(&i, val.as_ref()).unwrap();
+        }
+    }
+    txn.commit().unwrap();
+    (f, db)
+}
+
+// ---------------------------------------------------------------------------
+// Insert
+// ---------------------------------------------------------------------------
+
+fn bench_insert(c: &mut Criterion) {
+    let mut group = c.benchmark_group("kv/insert");
+    for &n in &[100u64, 1_000, 10_000] {
+        group.throughput(Throughput::Elements(n));
+        group.bench_with_input(BenchmarkId::from_parameter(n), &n, |b, &n| {
+            b.iter_batched(
+                || {
+                    let f = NamedTempFile::new().unwrap();
+                    let db = Database::builder()
+                        .set_cache_size(4 * 1024 * 1024)
+                        .create(f.path())
+                        .unwrap();
+                    (f, db)
+                },
+                |(_f, db)| {
+                    let mut txn = db.begin_write().unwrap();
+                    txn.set_durability(Durability::None).unwrap();
+                    {
+                        let mut table = txn.open_table(TABLE).unwrap();
+                        for i in 0..n {
+                            let val = make_value(i);
+                            table.insert(&i, val.as_ref()).unwrap();
+                        }
+                    }
+                    txn.commit().unwrap();
+                },
+                BatchSize::PerIteration,
+            );
+        });
+    }
+    group.finish();
+}
+
+// ---------------------------------------------------------------------------
+// Point get
+// ---------------------------------------------------------------------------
+
+fn bench_get(c: &mut Criterion) {
+    let (_f, db) = create_populated_db(10_000);
+
+    let mut group = c.benchmark_group("kv/get");
+    group.throughput(Throughput::Elements(1));
+    group.bench_function("random_get_10k", |b| {
+        let mut key = 0u64;
+        b.iter(|| {
+            let rtxn = db.begin_read().unwrap();
+            let table = rtxn.open_table(TABLE).unwrap();
+            let _ = table.get(&key).unwrap();
+            key = (key.wrapping_add(7919)) % 10_000;
+        });
+    });
+    group.finish();
+}
+
+// ---------------------------------------------------------------------------
+// Range scan
+// ---------------------------------------------------------------------------
+
+fn bench_range_scan(c: &mut Criterion) {
+    let (_f, db) = create_populated_db(10_000);
+
+    let mut group = c.benchmark_group("kv/range_scan");
+    group.throughput(Throughput::Elements(100));
+    group.bench_function("scan_100_from_10k", |b| {
+        let mut start = 0u64;
+        b.iter(|| {
+            let rtxn = db.begin_read().unwrap();
+            let table = rtxn.open_table(TABLE).unwrap();
+            let mut count = 0u64;
+            for entry in table.range(start..start + 100).unwrap() {
+                let _ = entry.unwrap();
+                count += 1;
+            }
+            start = (start.wrapping_add(137)) % 9_900;
+            count
+        });
+    });
+    group.finish();
+}
+
+criterion_group!(benches, bench_insert, bench_get, bench_range_scan);
+criterion_main!(benches);

--- a/benches/criterion_vector_ops.rs
+++ b/benches/criterion_vector_ops.rs
@@ -3,9 +3,7 @@
 //! Ported from crates/redb-bench/benches/vector_ops_benchmark.rs into Criterion
 //! for statistical regression detection in CI.
 
-use criterion::{
-    BatchSize, BenchmarkId, Criterion, Throughput, criterion_group, criterion_main,
-};
+use criterion::{BatchSize, BenchmarkId, Criterion, Throughput, criterion_group, criterion_main};
 use shodh_redb::{
     DistanceMetric, cosine_distance, cosine_similarity, dot_product, euclidean_distance_sq,
     hamming_distance, l2_norm, l2_normalize, manhattan_distance, nearest_k, quantize_binary,
@@ -245,17 +243,13 @@ fn bench_nearest_k(c: &mut Criterion) {
             .collect();
         let q = query.clone();
         group.throughput(Throughput::Elements(n));
-        group.bench_with_input(
-            BenchmarkId::new("cosine_k10", n),
-            &n,
-            |bench, _| {
-                bench.iter_batched(
-                    || (db.clone(), q.clone()),
-                    |(db, q)| nearest_k(db.into_iter(), &q, 10, cosine_distance),
-                    BatchSize::LargeInput,
-                );
-            },
-        );
+        group.bench_with_input(BenchmarkId::new("cosine_k10", n), &n, |bench, _| {
+            bench.iter_batched(
+                || (db.clone(), q.clone()),
+                |(db, q)| nearest_k(db.into_iter(), &q, 10, cosine_distance),
+                BatchSize::LargeInput,
+            );
+        });
     }
     group.finish();
 }

--- a/benches/criterion_vector_ops.rs
+++ b/benches/criterion_vector_ops.rs
@@ -1,0 +1,279 @@
+//! Criterion benchmarks for vector distance functions and related operations.
+//!
+//! Ported from crates/redb-bench/benches/vector_ops_benchmark.rs into Criterion
+//! for statistical regression detection in CI.
+
+use criterion::{
+    BatchSize, BenchmarkId, Criterion, Throughput, criterion_group, criterion_main,
+};
+use shodh_redb::{
+    DistanceMetric, cosine_distance, cosine_similarity, dot_product, euclidean_distance_sq,
+    hamming_distance, l2_norm, l2_normalize, manhattan_distance, nearest_k, quantize_binary,
+    quantize_scalar, sq_euclidean_distance_sq,
+};
+
+fn make_f32_vecs(dim: usize) -> (Vec<f32>, Vec<f32>) {
+    let a: Vec<f32> = (0..dim)
+        .map(|i| ((i * 7 + 13) % 1000) as f32 * 0.001 - 0.5)
+        .collect();
+    let b: Vec<f32> = (0..dim)
+        .map(|i| ((i * 11 + 37) % 1000) as f32 * 0.001 - 0.5)
+        .collect();
+    (a, b)
+}
+
+fn make_u8_vecs(dim: usize) -> (Vec<u8>, Vec<u8>) {
+    let a: Vec<u8> = (0..dim).map(|i| ((i * 37 + 13) & 0xFF) as u8).collect();
+    let b: Vec<u8> = (0..dim).map(|i| ((i * 53 + 7) & 0xFF) as u8).collect();
+    (a, b)
+}
+
+// ---------------------------------------------------------------------------
+// Distance functions
+// ---------------------------------------------------------------------------
+
+fn bench_dot_product(c: &mut Criterion) {
+    let mut group = c.benchmark_group("vector_ops/dot_product");
+    for &dim in &[128usize, 384, 768, 1536] {
+        let (a, b) = make_f32_vecs(dim);
+        group.throughput(Throughput::Bytes((dim * 4 * 2) as u64));
+        group.bench_with_input(BenchmarkId::from_parameter(dim), &dim, |bench, _| {
+            bench.iter(|| dot_product(&a, &b));
+        });
+    }
+    group.finish();
+}
+
+fn bench_euclidean(c: &mut Criterion) {
+    let mut group = c.benchmark_group("vector_ops/euclidean_distance_sq");
+    for &dim in &[128usize, 384, 768, 1536] {
+        let (a, b) = make_f32_vecs(dim);
+        group.throughput(Throughput::Bytes((dim * 4 * 2) as u64));
+        group.bench_with_input(BenchmarkId::from_parameter(dim), &dim, |bench, _| {
+            bench.iter(|| euclidean_distance_sq(&a, &b));
+        });
+    }
+    group.finish();
+}
+
+fn bench_cosine_similarity(c: &mut Criterion) {
+    let mut group = c.benchmark_group("vector_ops/cosine_similarity");
+    for &dim in &[128usize, 384, 768, 1536] {
+        let (a, b) = make_f32_vecs(dim);
+        group.throughput(Throughput::Bytes((dim * 4 * 2) as u64));
+        group.bench_with_input(BenchmarkId::from_parameter(dim), &dim, |bench, _| {
+            bench.iter(|| cosine_similarity(&a, &b));
+        });
+    }
+    group.finish();
+}
+
+fn bench_cosine_distance(c: &mut Criterion) {
+    let mut group = c.benchmark_group("vector_ops/cosine_distance");
+    for &dim in &[128usize, 384, 768, 1536] {
+        let (a, b) = make_f32_vecs(dim);
+        group.throughput(Throughput::Bytes((dim * 4 * 2) as u64));
+        group.bench_with_input(BenchmarkId::from_parameter(dim), &dim, |bench, _| {
+            bench.iter(|| cosine_distance(&a, &b));
+        });
+    }
+    group.finish();
+}
+
+fn bench_manhattan(c: &mut Criterion) {
+    let mut group = c.benchmark_group("vector_ops/manhattan_distance");
+    for &dim in &[128usize, 384, 768, 1536] {
+        let (a, b) = make_f32_vecs(dim);
+        group.throughput(Throughput::Bytes((dim * 4 * 2) as u64));
+        group.bench_with_input(BenchmarkId::from_parameter(dim), &dim, |bench, _| {
+            bench.iter(|| manhattan_distance(&a, &b));
+        });
+    }
+    group.finish();
+}
+
+fn bench_hamming(c: &mut Criterion) {
+    let mut group = c.benchmark_group("vector_ops/hamming_distance");
+    for &dim in &[48usize, 96, 192, 384] {
+        let (a, b) = make_u8_vecs(dim);
+        group.throughput(Throughput::Bytes((dim * 2) as u64));
+        group.bench_with_input(BenchmarkId::from_parameter(dim), &dim, |bench, _| {
+            bench.iter(|| hamming_distance(&a, &b));
+        });
+    }
+    group.finish();
+}
+
+// ---------------------------------------------------------------------------
+// DistanceMetric.compute dispatch
+// ---------------------------------------------------------------------------
+
+fn bench_metric_dispatch(c: &mut Criterion) {
+    let dim = 384usize;
+    let (a, b) = make_f32_vecs(dim);
+    let metrics = [
+        ("Cosine", DistanceMetric::Cosine),
+        ("EuclideanSq", DistanceMetric::EuclideanSq),
+        ("DotProduct", DistanceMetric::DotProduct),
+        ("Manhattan", DistanceMetric::Manhattan),
+    ];
+    let mut group = c.benchmark_group("vector_ops/metric_dispatch_384");
+    group.throughput(Throughput::Bytes((dim * 4 * 2) as u64));
+    for (name, metric) in &metrics {
+        let a = a.clone();
+        let b = b.clone();
+        let m = *metric;
+        group.bench_function(*name, move |bench| {
+            bench.iter(|| m.compute(&a, &b));
+        });
+    }
+    group.finish();
+}
+
+// ---------------------------------------------------------------------------
+// Normalization
+// ---------------------------------------------------------------------------
+
+fn bench_l2_norm(c: &mut Criterion) {
+    let mut group = c.benchmark_group("vector_ops/l2_norm");
+    for &dim in &[128usize, 384, 768, 1536] {
+        let (a, _) = make_f32_vecs(dim);
+        group.throughput(Throughput::Bytes((dim * 4) as u64));
+        group.bench_with_input(BenchmarkId::from_parameter(dim), &dim, |bench, _| {
+            bench.iter(|| l2_norm(&a));
+        });
+    }
+    group.finish();
+}
+
+fn bench_l2_normalize(c: &mut Criterion) {
+    let mut group = c.benchmark_group("vector_ops/l2_normalize");
+    for &dim in &[128usize, 384, 768, 1536] {
+        let (a, _) = make_f32_vecs(dim);
+        group.throughput(Throughput::Bytes((dim * 4) as u64));
+        group.bench_with_input(BenchmarkId::from_parameter(dim), &dim, |bench, _| {
+            bench.iter_batched(
+                || a.clone(),
+                |mut v| {
+                    l2_normalize(&mut v);
+                    v
+                },
+                BatchSize::SmallInput,
+            );
+        });
+    }
+    group.finish();
+}
+
+// ---------------------------------------------------------------------------
+// Quantization
+// ---------------------------------------------------------------------------
+
+fn bench_quantize_binary(c: &mut Criterion) {
+    let mut group = c.benchmark_group("vector_ops/quantize_binary");
+    for &dim in &[128usize, 384, 768, 1536] {
+        let (a, _) = make_f32_vecs(dim);
+        group.throughput(Throughput::Bytes((dim * 4) as u64));
+        group.bench_with_input(BenchmarkId::from_parameter(dim), &dim, |bench, _| {
+            bench.iter(|| quantize_binary(&a));
+        });
+    }
+    group.finish();
+}
+
+fn bench_quantize_scalar(c: &mut Criterion) {
+    let dim = 384usize;
+    let arr: [f32; 384] = {
+        let mut a = [0.0f32; 384];
+        for (i, v) in a.iter_mut().enumerate() {
+            *v = ((i * 7 + 13) % 1000) as f32 * 0.001 - 0.5;
+        }
+        a
+    };
+    let mut group = c.benchmark_group("vector_ops/quantize_scalar");
+    group.throughput(Throughput::Bytes((dim * 4) as u64));
+    group.bench_function("dim_384", |bench| {
+        bench.iter(|| quantize_scalar(&arr));
+    });
+    group.finish();
+}
+
+fn bench_sq_euclidean(c: &mut Criterion) {
+    let dim = 384usize;
+    let query: [f32; 384] = {
+        let mut a = [0.0f32; 384];
+        for (i, v) in a.iter_mut().enumerate() {
+            *v = ((i * 11 + 37) % 1000) as f32 * 0.001 - 0.5;
+        }
+        a
+    };
+    let arr: [f32; 384] = {
+        let mut a = [0.0f32; 384];
+        for (i, v) in a.iter_mut().enumerate() {
+            *v = ((i * 7 + 13) % 1000) as f32 * 0.001 - 0.5;
+        }
+        a
+    };
+    let sq = quantize_scalar(&arr);
+    let mut group = c.benchmark_group("vector_ops/sq_euclidean_distance_sq");
+    group.throughput(Throughput::Bytes((dim + dim * 4) as u64));
+    group.bench_function("dim_384", |bench| {
+        bench.iter(|| sq_euclidean_distance_sq(&query, &sq));
+    });
+    group.finish();
+}
+
+// ---------------------------------------------------------------------------
+// Brute-force nearest_k
+// ---------------------------------------------------------------------------
+
+fn bench_nearest_k(c: &mut Criterion) {
+    let dim = 128usize;
+    let query: Vec<f32> = (0..dim)
+        .map(|i| ((i * 11 + 37) % 1000) as f32 * 0.001 - 0.5)
+        .collect();
+
+    let mut group = c.benchmark_group("vector_ops/nearest_k");
+    for &n in &[100u64, 1000] {
+        let db: Vec<(u64, Vec<f32>)> = (0..n)
+            .map(|id| {
+                let v: Vec<f32> = (0..dim)
+                    .map(|j| ((id as usize * 7 + j * 13) % 1000) as f32 * 0.001 - 0.5)
+                    .collect();
+                (id, v)
+            })
+            .collect();
+        let q = query.clone();
+        group.throughput(Throughput::Elements(n));
+        group.bench_with_input(
+            BenchmarkId::new("cosine_k10", n),
+            &n,
+            |bench, _| {
+                bench.iter_batched(
+                    || (db.clone(), q.clone()),
+                    |(db, q)| nearest_k(db.into_iter(), &q, 10, cosine_distance),
+                    BatchSize::LargeInput,
+                );
+            },
+        );
+    }
+    group.finish();
+}
+
+criterion_group!(
+    benches,
+    bench_dot_product,
+    bench_euclidean,
+    bench_cosine_similarity,
+    bench_cosine_distance,
+    bench_manhattan,
+    bench_hamming,
+    bench_metric_dispatch,
+    bench_l2_norm,
+    bench_l2_normalize,
+    bench_quantize_binary,
+    bench_quantize_scalar,
+    bench_sq_euclidean,
+    bench_nearest_k,
+);
+criterion_main!(benches);


### PR DESCRIPTION
## Summary
- 4 Criterion bench files covering core hot paths (KV, blob, vector ops, IVF-PQ)
- New `bench.yml` CI workflow using `benchmark-action/github-action-benchmark`
- Baselines stored via `actions/cache` (no gh-pages pollution)
- Two-tier alerting: PR comment at 15% regression, CI fail at 50%

### Bench files
| File | Benchmarks |
|------|-----------|
| `criterion_kv.rs` | insert (100/1K/10K), random get, range scan |
| `criterion_blob.rs` | store blob (1K/64K/1M), get blob (1K/64K/1M) |
| `criterion_vector_ops.rs` | 5 distance metrics x 4 dims, hamming, l2_norm, quantize, nearest_k |
| `criterion_ivfpq.rs` | insert_batch (10/100/1K), search 500 vectors k=10 |

### CI design
- Standalone workflow (not in ci-pass) -- does not block fast CI feedback
- `RUSTFLAGS=""` to avoid Criterion macro warnings
- Bencher output format for benchmark-action compatibility
- Cache key: `bench-baseline-Linux` (stable across Cargo.lock changes)

## Test plan
- [x] All 4 bench files compile and pass `--test` mode
- [x] Bencher output format verified
- [x] Clippy clean (`--all --all-targets --all-features`)
- [x] No non-ASCII characters
- [ ] CI workflow runs successfully on this PR
- [ ] After merge: first master push establishes baseline