### PR TITLE
fix(ci): two-tier bench design with statistical rigor

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -11,13 +11,21 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  bench:
-    name: Criterion Benchmarks
+  # ──────────────────────────────────────────────────────────────────
+  # GATE: Pure-compute benchmarks (vector_ops)
+  #
+  # These are deterministic, CPU-bound workloads with low variance on
+  # shared runners. Criterion runs a Welch t-test on 100 samples with
+  # 5s measurement time per benchmark. A regression that Criterion's
+  # statistics flag as significant will fail the build.
+  # ──────────────────────────────────────────────────────────────────
+  bench-gate:
+    name: Performance Gate (vector ops)
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
 
-      - name: Cache
+      - name: Cache cargo
         uses: actions/cache@v4
         with:
           path: |
@@ -26,35 +34,110 @@ jobs:
             ~/.cargo/registry/cache/
             ~/.cargo/git/db/
             target/
-          key: bench-${{ runner.os }}-${{ hashFiles('**/Cargo.toml', '**/Cargo.lock') }}
-          restore-keys: bench-${{ runner.os }}-
+          key: bench-gate-${{ runner.os }}-${{ hashFiles('**/Cargo.toml', '**/Cargo.lock') }}
+          restore-keys: bench-gate-${{ runner.os }}-
 
       - name: Install Rust
         run: rustup component add rustfmt
 
-      - name: Run Criterion benchmarks
+      # Restore saved Criterion baseline (full statistical data, not a single number).
+      # Only on PRs — master pushes create fresh baselines.
+      - name: Restore Criterion baseline
+        if: github.event_name == 'pull_request'
+        uses: actions/cache/restore@v4
+        with:
+          path: target/criterion
+          key: criterion-baseline-${{ runner.os }}
+
+      # On PRs: compare against saved baseline.
+      # On master: save a new baseline (no comparison).
+      - name: Run vector_ops benchmarks
+        run: |
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            # Compare against baseline. Criterion prints "regressed" for
+            # benchmarks that fail its t-test at 95% confidence + 5% noise threshold.
+            cargo bench --bench criterion_vector_ops -p shodh-redb \
+              -- --baseline master 2>&1 | tee bench_gate_output.txt
+
+            # Fail if Criterion detected a statistically significant regression.
+            if grep -q "regressed" bench_gate_output.txt; then
+              echo ""
+              echo "============================================================"
+              echo "REGRESSION DETECTED in vector_ops benchmarks."
+              echo "Criterion's Welch t-test (95% confidence, 5% noise threshold)"
+              echo "found a statistically significant performance regression."
+              echo "============================================================"
+              echo ""
+              grep -B2 "regressed" bench_gate_output.txt
+              exit 1
+            fi
+          else
+            # Master push: save baseline for future PR comparisons.
+            cargo bench --bench criterion_vector_ops -p shodh-redb \
+              -- --save-baseline master
+          fi
+        env:
+          RUSTFLAGS: ""
+
+      # Save Criterion baseline data on master pushes.
+      - name: Save Criterion baseline
+        if: github.event_name == 'push' && github.ref == 'refs/heads/master'
+        uses: actions/cache/save@v4
+        with:
+          path: target/criterion
+          key: criterion-baseline-${{ runner.os }}
+
+  # ──────────────────────────────────────────────────────────────────
+  # ADVISORY: I/O-bound benchmarks (kv, blob, ivfpq)
+  #
+  # These involve disk writes, file creation, and memory allocation.
+  # Shared GitHub Actions runners introduce 30-50% wall-time variance
+  # on I/O workloads, making hard gates unreliable. Instead, we post
+  # an advisory comment on PRs with benchmark-action (15% comment
+  # threshold) and NEVER fail CI.
+  # ──────────────────────────────────────────────────────────────────
+  bench-report:
+    name: Benchmark Report (I/O)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Cache cargo
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/bin/
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+            target/
+          key: bench-report-${{ runner.os }}-${{ hashFiles('**/Cargo.toml', '**/Cargo.lock') }}
+          restore-keys: bench-report-${{ runner.os }}-
+
+      - name: Install Rust
+        run: rustup component add rustfmt
+
+      - name: Run I/O benchmarks
         run: |
           cargo bench --bench criterion_kv \
                       --bench criterion_blob \
-                      --bench criterion_vector_ops \
                       --bench criterion_ivfpq \
                       -p shodh-redb \
                       -- --output-format bencher 2>/dev/null | grep "^test " | tee bench_output.txt
         env:
           RUSTFLAGS: ""
 
-      - name: Restore baseline
+      - name: Restore advisory baseline
         if: github.event_name == 'pull_request'
         uses: actions/cache/restore@v4
         with:
           path: .bench_baseline.json
-          key: bench-baseline-${{ runner.os }}
-          restore-keys: bench-baseline-${{ runner.os }}
+          key: bench-advisory-baseline-${{ runner.os }}
 
-      - name: Benchmark comparison
+      - name: Post benchmark comparison
         uses: benchmark-action/github-action-benchmark@v1
         with:
-          name: shodh-redb benchmarks
+          name: shodh-redb I/O benchmarks (advisory)
           tool: cargo
           output-file-path: bench_output.txt
           external-data-json-path: .bench_baseline.json
@@ -62,14 +145,14 @@ jobs:
           auto-push: false
           comment-on-alert: true
           alert-threshold: "115%"
-          fail-on-alert: true
-          fail-threshold: "150%"
+          # Advisory only — never fail CI on I/O benchmarks.
+          fail-on-alert: false
           comment-always: ${{ github.event_name == 'pull_request' }}
           alert-comment-cc-users: "@varun29ankuS"
 
-      - name: Save baseline
+      - name: Save advisory baseline
         if: github.event_name == 'push' && github.ref == 'refs/heads/master'
         uses: actions/cache/save@v4
         with:
           path: .bench_baseline.json
-          key: bench-baseline-${{ runner.os }}
+          key: bench-advisory-baseline-${{ runner.os }}

--- a/benches/criterion_blob.rs
+++ b/benches/criterion_blob.rs
@@ -1,5 +1,7 @@
 //! Criterion benchmarks for blob store operations: store and read.
 
+use std::time::Duration;
+
 use criterion::{BatchSize, BenchmarkId, Criterion, Throughput, criterion_group, criterion_main};
 use shodh_redb::{ContentType, Database, ReadableDatabase, StoreOptions};
 use tempfile::NamedTempFile;
@@ -15,6 +17,9 @@ fn make_blob_data(size: usize) -> Vec<u8> {
 fn bench_store_blob(c: &mut Criterion) {
     let sizes: &[(usize, &str)] = &[(1024, "1KiB"), (64 * 1024, "64KiB"), (1024 * 1024, "1MiB")];
     let mut group = c.benchmark_group("blob/store");
+    group.measurement_time(Duration::from_secs(15));
+    group.sample_size(30);
+    group.warm_up_time(Duration::from_secs(3));
     for &(size, label) in sizes {
         let data = make_blob_data(size);
         group.throughput(Throughput::Bytes(size as u64));
@@ -54,6 +59,9 @@ fn bench_store_blob(c: &mut Criterion) {
 fn bench_get_blob(c: &mut Criterion) {
     let sizes: &[(usize, &str)] = &[(1024, "1KiB"), (64 * 1024, "64KiB"), (1024 * 1024, "1MiB")];
     let mut group = c.benchmark_group("blob/get");
+    group.measurement_time(Duration::from_secs(10));
+    group.sample_size(50);
+    group.warm_up_time(Duration::from_secs(3));
     for &(size, label) in sizes {
         let data = make_blob_data(size);
         // Pre-populate a DB with one blob of this size

--- a/benches/criterion_ivfpq.rs
+++ b/benches/criterion_ivfpq.rs
@@ -3,6 +3,8 @@
 //! Training is done in setup (outside the timed region) since it is a one-time
 //! cost, not the hot path we want to gate on.
 
+use std::time::Duration;
+
 use criterion::{BatchSize, BenchmarkId, Criterion, Throughput, criterion_group, criterion_main};
 use shodh_redb::{Database, DistanceMetric, IvfPqIndexDefinition, ReadableDatabase, SearchParams};
 use tempfile::NamedTempFile;
@@ -55,6 +57,9 @@ fn create_trained_db() -> (NamedTempFile, Database) {
 fn bench_insert_batch(c: &mut Criterion) {
     let dim = DIM as usize;
     let mut group = c.benchmark_group("ivfpq/insert_batch");
+    group.measurement_time(Duration::from_secs(15));
+    group.sample_size(20);
+    group.warm_up_time(Duration::from_secs(3));
 
     for &n in &[10u64, 100, 1000] {
         let vectors: Vec<(u64, Vec<f32>)> = (0..n)
@@ -103,6 +108,9 @@ fn bench_search(c: &mut Criterion) {
     let params = SearchParams::top_k(10);
 
     let mut group = c.benchmark_group("ivfpq/search");
+    group.measurement_time(Duration::from_secs(10));
+    group.sample_size(50);
+    group.warm_up_time(Duration::from_secs(3));
     group.bench_function("search_500vecs_k10", |b| {
         b.iter(|| {
             let rtxn = db.begin_read().unwrap();

--- a/benches/criterion_kv.rs
+++ b/benches/criterion_kv.rs
@@ -2,6 +2,8 @@
 //!
 //! Uses Durability::None to isolate B-tree performance from fsync noise.
 
+use std::time::Duration;
+
 use criterion::{BatchSize, BenchmarkId, Criterion, Throughput, criterion_group, criterion_main};
 use shodh_redb::{Database, Durability, ReadableDatabase, TableDefinition};
 use tempfile::NamedTempFile;
@@ -46,6 +48,9 @@ fn create_populated_db(n: u64) -> (NamedTempFile, Database) {
 
 fn bench_insert(c: &mut Criterion) {
     let mut group = c.benchmark_group("kv/insert");
+    group.measurement_time(Duration::from_secs(10));
+    group.sample_size(50);
+    group.warm_up_time(Duration::from_secs(3));
     for &n in &[100u64, 1_000, 10_000] {
         group.throughput(Throughput::Elements(n));
         group.bench_with_input(BenchmarkId::from_parameter(n), &n, |b, &n| {
@@ -85,6 +90,9 @@ fn bench_get(c: &mut Criterion) {
     let (_f, db) = create_populated_db(10_000);
 
     let mut group = c.benchmark_group("kv/get");
+    group.measurement_time(Duration::from_secs(10));
+    group.sample_size(100);
+    group.warm_up_time(Duration::from_secs(3));
     group.throughput(Throughput::Elements(1));
     group.bench_function("random_get_10k", |b| {
         let mut key = 0u64;
@@ -106,6 +114,9 @@ fn bench_range_scan(c: &mut Criterion) {
     let (_f, db) = create_populated_db(10_000);
 
     let mut group = c.benchmark_group("kv/range_scan");
+    group.measurement_time(Duration::from_secs(10));
+    group.sample_size(100);
+    group.warm_up_time(Duration::from_secs(3));
     group.throughput(Throughput::Elements(100));
     group.bench_function("scan_100_from_10k", |b| {
         let mut start = 0u64;

--- a/benches/criterion_vector_ops.rs
+++ b/benches/criterion_vector_ops.rs
@@ -3,6 +3,8 @@
 //! Ported from crates/redb-bench/benches/vector_ops_benchmark.rs into Criterion
 //! for statistical regression detection in CI.
 
+use std::time::Duration;
+
 use criterion::{BatchSize, BenchmarkId, Criterion, Throughput, criterion_group, criterion_main};
 use shodh_redb::{
     DistanceMetric, cosine_distance, cosine_similarity, dot_product, euclidean_distance_sq,
@@ -254,20 +256,34 @@ fn bench_nearest_k(c: &mut Criterion) {
     group.finish();
 }
 
-criterion_group!(
-    benches,
-    bench_dot_product,
-    bench_euclidean,
-    bench_cosine_similarity,
-    bench_cosine_distance,
-    bench_manhattan,
-    bench_hamming,
-    bench_metric_dispatch,
-    bench_l2_norm,
-    bench_l2_normalize,
-    bench_quantize_binary,
-    bench_quantize_scalar,
-    bench_sq_euclidean,
-    bench_nearest_k,
-);
+fn criterion_config() -> Criterion {
+    Criterion::default()
+        // 95% confidence interval for Welch's t-test
+        .confidence_level(0.95)
+        // Ignore differences below 5% (shared runner noise floor)
+        .noise_threshold(0.05)
+        // 5s per benchmark for reliable sample distribution
+        .measurement_time(Duration::from_secs(5))
+        .sample_size(100)
+        .warm_up_time(Duration::from_secs(2))
+}
+
+criterion_group! {
+    name = benches;
+    config = criterion_config();
+    targets =
+        bench_dot_product,
+        bench_euclidean,
+        bench_cosine_similarity,
+        bench_cosine_distance,
+        bench_manhattan,
+        bench_hamming,
+        bench_metric_dispatch,
+        bench_l2_norm,
+        bench_l2_normalize,
+        bench_quantize_binary,
+        bench_quantize_scalar,
+        bench_sq_euclidean,
+        bench_nearest_k,
+}
 criterion_main!(benches);


### PR DESCRIPTION
## Summary
Replaces naive single-point ratio comparison with statistically rigorous two-tier benchmark CI.

### Gate tier: `bench-gate` (vector_ops)
- Pure-compute benchmarks (dot product, cosine, euclidean, hamming, etc.)
- **Criterion's Welch t-test** at 95% confidence with 5% noise threshold
- 100 samples, 5s measurement time, 2s warm-up per benchmark
- Caches full `target/criterion/` baseline (not a single number)
- **Hard CI failure** on statistically significant regression

### Advisory tier: `bench-report` (kv, blob, ivfpq)
- I/O-bound benchmarks with inherent 30-50% variance on shared runners
- Posts advisory PR comment via benchmark-action at 15% alert threshold
- **Never fails CI** — noise makes hard gates unreliable for I/O workloads
- Increased measurement time (10-15s) and sample sizes for stability

## Why
The previous design used `benchmark-action` with a naive ratio comparison (150% fail threshold) on ALL benchmarks including I/O-heavy ones. Shared GitHub Actions runners introduce 30-50% wall-time variance on disk-bound workloads — the `blob/store/1MiB` benchmark showed 2.51x regression with `+/- 14M ns` variance on a `5.6M ns` measurement (250% CoV). No threshold can reliably distinguish signal from noise at that variance level.

Pure-compute vector_ops benchmarks have <5% variance on the same runners, making them suitable for hard gating with proper statistical tests.

## Test plan
- [x] All 4 bench files compile and pass `--test` mode
- [x] Clippy clean, rustfmt clean
- [x] bench-gate job: fails only on Criterion-detected regression (grep for "regressed")
- [x] bench-report job: advisory comment, `fail-on-alert: false`