### PR TITLE
fix: eliminate production panics in metadata deserialization

### DIFF
--- a/LIMITATIONS.md
+++ b/LIMITATIONS.md
@@ -48,4 +48,4 @@
 
 ## Error Handling
 
-- **`Value` trait**: The `Value::from_bytes` trait method returns `Self`, not `Result<Self>`. If on-disk table definition metadata is corrupted, `InternalTableDefinition::from_bytes` will panic with a diagnostic message rather than returning an error. On `std` builds, all internal call sites wrap this in `catch_unwind` and convert panics to `StorageError::Corrupted`. On `no_std` builds, corrupt metadata causes an unrecoverable panic. All other deserialization paths return `StorageError::Corrupted`.
+- **`Value` trait**: The `Value::from_bytes` trait method returns `Self`, not `Result<Self>`. If on-disk table definition metadata is corrupted, `InternalTableDefinition::from_bytes` panics with a diagnostic message. On `std` builds, all internal call sites wrap this in `catch_unwind` and convert panics to `StorageError::Corrupted`. On `no_std` builds, corrupt metadata causes an unrecoverable panic. All other deserialization paths return `StorageError::Corrupted` directly.

--- a/src/tree_store/btree_base.rs
+++ b/src/tree_store/btree_base.rs
@@ -312,6 +312,40 @@ impl<V: Value + 'static> AccessGuard<'_, V> {
             V::from_bytes(&mem[start..end])
         }
     }
+
+    /// Access the stored value, catching panics from corrupt data.
+    ///
+    /// Wraps `Value::from_bytes` in `catch_unwind` so that deserialization
+    /// panics (e.g. from corrupted on-disk metadata) are converted to
+    /// `StorageError::Corrupted` instead of aborting the process.
+    #[cfg(feature = "std")]
+    pub(crate) fn value_checked(
+        &self,
+    ) -> core::result::Result<V::SelfType<'_>, crate::StorageError> {
+        let bytes: &[u8] = if let Some(ref decompressed) = self.decompressed_value {
+            decompressed
+        } else {
+            let mem = self.page.memory();
+            let end = self.offset.saturating_add(self.len).min(mem.len());
+            let start = self.offset.min(end);
+            &mem[start..end]
+        };
+        // SAFETY: catch_unwind requires UnwindSafe. The byte slice reference
+        // does not have interior mutability, so AssertUnwindSafe is sound.
+        let ptr = bytes.as_ptr();
+        let len = bytes.len();
+        std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            // Reconstruct the slice inside the closure so the borrow checker
+            // does not complain about capturing a local reference.
+            let slice = unsafe { core::slice::from_raw_parts(ptr, len) };
+            V::from_bytes(slice)
+        }))
+        .map_err(|_| {
+            crate::StorageError::Corrupted(alloc::string::String::from(
+                "panic in Value::from_bytes (corrupted metadata)",
+            ))
+        })
+    }
 }
 
 impl<V: Value + 'static> Drop for AccessGuard<'_, V> {

--- a/src/tree_store/btree_base.rs
+++ b/src/tree_store/btree_base.rs
@@ -315,9 +315,10 @@ impl<V: Value + 'static> AccessGuard<'_, V> {
 
     /// Access the stored value, catching panics from corrupt data.
     ///
-    /// Wraps `Value::from_bytes` in `catch_unwind` so that deserialization
-    /// panics (e.g. from corrupted on-disk metadata) are converted to
-    /// `StorageError::Corrupted` instead of aborting the process.
+    /// On `std` builds, wraps `Value::from_bytes` in `catch_unwind` so that
+    /// deserialization panics (e.g. from corrupted on-disk metadata) are
+    /// converted to `StorageError::Corrupted` instead of aborting the process.
+    /// On `no_std` builds, calls `from_bytes` directly (panics on corrupt data).
     #[cfg(feature = "std")]
     pub(crate) fn value_checked(
         &self,
@@ -345,6 +346,14 @@ impl<V: Value + 'static> AccessGuard<'_, V> {
                 "panic in Value::from_bytes (corrupted metadata)",
             ))
         })
+    }
+
+    /// `no_std` fallback: calls `from_bytes` directly (no panic protection).
+    #[cfg(not(feature = "std"))]
+    pub(crate) fn value_checked(
+        &self,
+    ) -> core::result::Result<V::SelfType<'_>, crate::StorageError> {
+        Ok(self.value())
     }
 }
 

--- a/src/tree_store/btree_iters.rs
+++ b/src/tree_store/btree_iters.rs
@@ -263,6 +263,31 @@ impl<K: Key, V: Value> EntryGuard<K, V> {
         }
     }
 
+    /// Access the stored value, catching panics from corrupt data.
+    #[cfg(feature = "std")]
+    pub(crate) fn value_checked(
+        &self,
+    ) -> core::result::Result<V::SelfType<'_>, crate::StorageError> {
+        let bytes: &[u8] = if let Some(ref decompressed) = self.decompressed_value {
+            decompressed
+        } else {
+            &self.page.memory()[self.value_range.clone()]
+        };
+        let ptr = bytes.as_ptr();
+        let len = bytes.len();
+        // SAFETY: catch_unwind requires UnwindSafe. The byte slice has no
+        // interior mutability, so AssertUnwindSafe is sound.
+        std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            let slice = unsafe { core::slice::from_raw_parts(ptr, len) };
+            V::from_bytes(slice)
+        }))
+        .map_err(|_| {
+            crate::StorageError::Corrupted(alloc::string::String::from(
+                "panic in Value::from_bytes (corrupted metadata)",
+            ))
+        })
+    }
+
     pub(crate) fn into_raw(self) -> (PageImpl, Range<usize>, Range<usize>, Option<Vec<u8>>) {
         (
             self.page,

--- a/src/tree_store/btree_iters.rs
+++ b/src/tree_store/btree_iters.rs
@@ -264,6 +264,9 @@ impl<K: Key, V: Value> EntryGuard<K, V> {
     }
 
     /// Access the stored value, catching panics from corrupt data.
+    ///
+    /// On `std` builds, wraps `from_bytes` in `catch_unwind`. On `no_std`,
+    /// calls `from_bytes` directly (panics on corrupt data).
     #[cfg(feature = "std")]
     pub(crate) fn value_checked(
         &self,
@@ -286,6 +289,14 @@ impl<K: Key, V: Value> EntryGuard<K, V> {
                 "panic in Value::from_bytes (corrupted metadata)",
             ))
         })
+    }
+
+    /// `no_std` fallback: calls `from_bytes` directly (no panic protection).
+    #[cfg(not(feature = "std"))]
+    pub(crate) fn value_checked(
+        &self,
+    ) -> core::result::Result<V::SelfType<'_>, crate::StorageError> {
+        Ok(self.value())
     }
 
     pub(crate) fn into_raw(self) -> (PageImpl, Range<usize>, Range<usize>, Option<Vec<u8>>) {

--- a/src/tree_store/page_store/cached_file.rs
+++ b/src/tree_store/page_store/cached_file.rs
@@ -7,7 +7,7 @@ use alloc::string::String;
 use alloc::sync::Arc;
 use alloc::vec;
 use alloc::vec::Vec;
-use core::ops::{Index, IndexMut};
+use core::ops::Index;
 use core::slice::SliceIndex;
 use core::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 #[cfg(feature = "cache_metrics")]
@@ -44,22 +44,6 @@ impl<I: SliceIndex<[u8]>> Index<I> for WritablePage {
 
     fn index(&self, index: I) -> &Self::Output {
         self.mem().index(index)
-    }
-}
-
-impl<I: SliceIndex<[u8]>> IndexMut<I> for WritablePage {
-    fn index_mut(&mut self, index: I) -> &mut Self::Output {
-        // IndexMut cannot return Result. In correct code WritablePage holds the
-        // sole Arc reference, making get_mut infallible. We keep the panic as a
-        // last-resort guard because the trait signature offers no alternative.
-        debug_assert!(
-            Arc::strong_count(&self.data) == 1,
-            "WritablePage::index_mut() requires exclusive Arc ownership"
-        );
-        match Arc::get_mut(&mut self.data) {
-            Some(data) => data.index_mut(index),
-            None => panic!("WritablePage::index_mut() called while other Arc references exist"),
-        }
     }
 }
 

--- a/src/tree_store/table_tree.rs
+++ b/src/tree_store/table_tree.rs
@@ -77,7 +77,11 @@ impl Iterator for TableNameIter {
         for entry in self.inner.by_ref() {
             match entry {
                 Ok(entry) => {
-                    if entry.value().get_type() == self.table_type {
+                    let definition = match entry.value_checked() {
+                        Ok(d) => d,
+                        Err(e) => return Some(Err(e)),
+                    };
+                    if definition.get_type() == self.table_type {
                         return Some(Ok(entry.key().to_string()));
                     }
                 }
@@ -119,7 +123,7 @@ impl TableTree {
 
         for entry in self.tree.range::<RangeFull, &str>(&(..))? {
             let entry = entry?;
-            let definition = entry.value();
+            let definition = entry.value_checked()?;
             match definition {
                 InternalTableDefinition::Normal {
                     table_root,
@@ -186,7 +190,7 @@ impl TableTree {
         for entry in self.tree.range::<RangeFull, &str>(&(..))? {
             let entry = entry?;
             let table_name = entry.key().to_string();
-            let definition = entry.value();
+            let definition = entry.value_checked()?;
             match definition {
                 InternalTableDefinition::Normal {
                     table_root,
@@ -254,7 +258,7 @@ impl TableTree {
         for entry in self.tree.range::<RangeFull, &str>(&(..))? {
             let entry = entry?;
             let table_name = entry.key().to_string();
-            let definition = entry.value();
+            let definition = entry.value_checked()?;
             match definition {
                 InternalTableDefinition::Normal {
                     table_root,
@@ -329,7 +333,7 @@ impl TableTree {
         table_type: TableType,
     ) -> Result<Option<InternalTableDefinition>, TableError> {
         if let Some(guard) = self.tree.get(&name)? {
-            let definition = guard.value();
+            let definition = guard.value_checked()?;
             definition.check_match_untyped(table_type, name)?;
             Ok(Some(definition))
         } else {
@@ -520,7 +524,7 @@ impl TableTreeMut<'_> {
                         "pending table '{name}' not found in table tree"
                     ))
                 })?
-                .value();
+                .value_checked()?;
             // No-op if the root has not changed
             match definition {
                 InternalTableDefinition::Normal { table_root, .. }
@@ -604,7 +608,8 @@ impl TableTreeMut<'_> {
                 &name,
                 &InternalTableDefinition::new::<K, V>(TableType::Normal, None, 0),
             )?
-            .map(|x| x.value());
+            .map(|x| x.value_checked())
+            .transpose()?;
         if let Some(existing) = existing {
             self.tree.insert(&name, &existing)?;
         }
@@ -615,7 +620,7 @@ impl TableTreeMut<'_> {
             .ok_or_else(|| {
                 StorageError::Internal(alloc::format!("table '{name}' missing after insert"))
             })?
-            .value()
+            .value_checked()?
         {
             InternalTableDefinition::Normal { table_root, .. } => table_root,
             InternalTableDefinition::Multimap { .. } => {
@@ -851,7 +856,7 @@ impl TableTreeMut<'_> {
     ) -> Result {
         for entry in self.tree.range::<RangeFull, &str>(&(..))? {
             let entry = entry?;
-            let mut definition = entry.value();
+            let mut definition = entry.value_checked()?;
             if let Some((updated_root, updated_length)) =
                 self.pending_table_updates.get(entry.key())
             {
@@ -884,7 +889,7 @@ impl TableTreeMut<'_> {
     ) -> Result {
         for entry in self.tree.range::<RangeFull, &str>(&(..))? {
             let entry = entry?;
-            let mut definition = entry.value();
+            let mut definition = entry.value_checked()?;
             if let Some((updated_root, updated_length)) =
                 self.pending_table_updates.get(entry.key())
             {
@@ -922,7 +927,7 @@ impl TableTreeMut<'_> {
 
         for entry in self.tree.range::<RangeFull, &str>(&(..))? {
             let entry = entry?;
-            let mut definition = entry.value();
+            let mut definition = entry.value_checked()?;
             if let Some((updated_root, length)) = self.pending_table_updates.get(entry.key()) {
                 definition.set_header(*updated_root, *length);
             }


### PR DESCRIPTION
## Summary
- Remove dead `IndexMut` impl on `WritablePage` that contained a bare `panic!()` -- all mutation already goes through `mem_mut()` which returns `Result`
- Add `value_checked()` to `AccessGuard` and `EntryGuard` that wraps `Value::from_bytes` in `catch_unwind`, converting panics from corrupted `InternalTableDefinition` metadata into `StorageError::Corrupted`
- Replace all 11 `.value()` calls in `table_tree.rs` with `.value_checked()?` so corrupt table metadata no longer crashes the process on `std` builds
- Update `LIMITATIONS.md` to document the `catch_unwind` protection

## Test plan
- [x] `cargo clippy --all-features --all-targets -- -D warnings` clean
- [x] `cargo test --lib` -- 233 passed
- [x] `cargo fmt -- --check` clean
- [ ] CI: all platform tests pass