### PR TITLE
fix: harden 4 panic/truncation vectors from audit

### DIFF
--- a/src/blob_store/writer.rs
+++ b/src/blob_store/writer.rs
@@ -3,6 +3,7 @@ use crate::blob_store::types::{
     BLOB_CHUNK_SIZE, BlobId, BlobMeta, BlobRef, ContentType, Sha256Key, StoreOptions,
 };
 use crate::tree_store::{Xxh3StreamHasher, hash64_with_seed};
+use alloc::format;
 use alloc::string::{String, ToString};
 use alloc::vec::Vec;
 use core::sync::atomic::Ordering;
@@ -126,7 +127,15 @@ impl<'txn> BlobWriter<'txn> {
         }
         self.txn
             .blob_write_chunk(self.sequence, self.next_chunk_index, &self.chunk_buf)?;
-        self.next_chunk_index += 1;
+        // Guard against u32 wrap-around at extreme blob sizes
+        // (u32::MAX * BLOB_CHUNK_SIZE ~ 256 TiB). Wrapping silently would
+        // corrupt chunk ordering, so reject the write instead.
+        self.next_chunk_index = self.next_chunk_index.checked_add(1).ok_or_else(|| {
+            crate::StorageError::Internal(format!(
+                "blob chunk index overflow at sequence {}: exceeded u32::MAX chunks",
+                self.sequence
+            ))
+        })?;
         self.chunk_buf.clear();
         Ok(())
     }

--- a/src/ivfpq/pq.rs
+++ b/src/ivfpq/pq.rs
@@ -81,11 +81,22 @@ impl Codebooks {
     /// Decode PQ codes back to an approximate vector.
     ///
     /// Reconstructs the vector by concatenating the codebook centroids
-    /// indicated by each code byte.
+    /// indicated by each code byte. Returns an empty `Vec` if `codes.len()`
+    /// does not exactly match `num_subvectors`, which would otherwise produce
+    /// a silently truncated reconstruction.
     pub fn decode(&self, codes: &[u8]) -> Vec<f32> {
+        if codes.len() != self.num_subvectors {
+            return Vec::new();
+        }
         let mut vector = Vec::with_capacity(self.num_subvectors * self.sub_dim);
         for (m, &code) in codes.iter().enumerate() {
-            vector.extend_from_slice(self.centroid(m, code as usize));
+            let centroid = self.centroid(m, code as usize);
+            if centroid.len() != self.sub_dim {
+                // Codebook data is short -- bail out rather than emit a
+                // truncated vector.
+                return Vec::new();
+            }
+            vector.extend_from_slice(centroid);
         }
         vector
     }
@@ -95,12 +106,27 @@ impl Codebooks {
         self.num_subvectors * 256 * self.sub_dim
     }
 
-    /// Serialize all codebooks to bytes (f32 little-endian).
+    /// Serialize a single codebook to bytes (f32 little-endian).
     ///
     /// Each codebook `m` is serialized as `256 * sub_dim * 4` bytes.
+    /// Returns an empty `Vec` if `m >= num_subvectors` or if the underlying
+    /// codebook data is short, instead of panicking on out-of-bounds access.
     pub fn serialize_codebook(&self, m: usize) -> Vec<u8> {
-        let start = m * 256 * self.sub_dim;
-        let end = start + 256 * self.sub_dim;
+        if m >= self.num_subvectors {
+            return Vec::new();
+        }
+        let Some(start) = m.checked_mul(256).and_then(|v| v.checked_mul(self.sub_dim)) else {
+            return Vec::new();
+        };
+        let Some(end) = (256usize)
+            .checked_mul(self.sub_dim)
+            .and_then(|len| start.checked_add(len))
+        else {
+            return Vec::new();
+        };
+        if end > self.data.len() {
+            return Vec::new();
+        }
         let floats = &self.data[start..end];
         let mut bytes = Vec::with_capacity(floats.len() * 4);
         for &f in floats {
@@ -311,5 +337,66 @@ mod tests {
         let floats = Codebooks::deserialize_codebook(&bytes, 4);
         assert_eq!(floats.len(), 256 * 4);
         assert!((floats[0] - 1.0).abs() < 1e-6);
+    }
+
+    /// Regression: `serialize_codebook(m)` must not panic when `m` is out of
+    /// range. Previously did unchecked slicing on `self.data`.
+    #[test]
+    fn serialize_codebook_out_of_range_returns_empty() {
+        let codebooks = Codebooks {
+            data: [1.0_f32; 256 * 4].to_vec(),
+            num_subvectors: 1,
+            sub_dim: 4,
+        };
+        // m == num_subvectors is out of range
+        assert!(codebooks.serialize_codebook(1).is_empty());
+        // far out of range
+        assert!(codebooks.serialize_codebook(usize::MAX).is_empty());
+    }
+
+    /// Regression: `serialize_codebook` must not panic when the codebook data
+    /// is shorter than the declared `num_subvectors * 256 * sub_dim`.
+    #[test]
+    fn serialize_codebook_short_data_returns_empty() {
+        let codebooks = Codebooks {
+            data: vec![1.0_f32; 10], // way too short for declared dims
+            num_subvectors: 2,
+            sub_dim: 4,
+        };
+        assert!(codebooks.serialize_codebook(0).is_empty());
+        assert!(codebooks.serialize_codebook(1).is_empty());
+    }
+
+    /// Regression: `decode` must not silently truncate when the code length
+    /// disagrees with `num_subvectors`. Previously, longer-than-expected codes
+    /// produced a truncated reconstruction; shorter ones produced a partial
+    /// vector with no error indication.
+    #[test]
+    fn decode_wrong_length_returns_empty() {
+        let codebooks = Codebooks {
+            data: [1.0_f32; 256 * 4 * 2].to_vec(), // 2 subvecs, sub_dim=4
+            num_subvectors: 2,
+            sub_dim: 4,
+        };
+        // Too short
+        assert!(codebooks.decode(&[0]).is_empty());
+        // Too long
+        assert!(codebooks.decode(&[0, 0, 0]).is_empty());
+        // Exactly right -- non-empty
+        let v = codebooks.decode(&[0, 0]);
+        assert_eq!(v.len(), 8);
+    }
+
+    /// Regression: `decode` must not produce a truncated vector when codebook
+    /// data is short relative to the declared shape.
+    #[test]
+    fn decode_short_codebook_data_returns_empty() {
+        let codebooks = Codebooks {
+            data: vec![1.0_f32; 10], // too short
+            num_subvectors: 2,
+            sub_dim: 4,
+        };
+        // codes match num_subvectors, but centroid lookup will fail
+        assert!(codebooks.decode(&[0, 0]).is_empty());
     }
 }

--- a/src/multimap_table.rs
+++ b/src/multimap_table.rs
@@ -736,18 +736,40 @@ impl<V: Key> DynamicCollection<V> {
     }
 
     fn collection_type(&self) -> crate::Result<DynamicCollectionType> {
-        DynamicCollectionType::try_from_byte(self.data[0])
+        let type_byte = *self
+            .data
+            .first()
+            .ok_or_else(|| StorageError::Corrupted("empty DynamicCollection value".to_string()))?;
+        let ct = DynamicCollectionType::try_from_byte(type_byte)?;
+        // Validate that the payload is long enough for the indicated type so
+        // that downstream accessors (`as_subtree`, `get_num_values`) cannot
+        // panic on a truncated/corrupted value.
+        if let SubtreeV2 = ct {
+            let required = 1 + BtreeHeader::serialized_size();
+            if self.data.len() < required {
+                return Err(StorageError::Corrupted(format!(
+                    "DynamicCollection SubtreeV2 truncated: {} bytes, need {}",
+                    self.data.len(),
+                    required
+                )));
+            }
+        }
+        Ok(ct)
     }
 
     fn as_inline(&self) -> &[u8] {
         &self.data[1..]
     }
 
+    /// Decode the `BtreeHeader` portion of a `SubtreeV2` collection.
+    ///
+    /// Precondition: caller has verified `collection_type()? == SubtreeV2`,
+    /// which guarantees `self.data.len() >= 1 + BtreeHeader::serialized_size()`.
     fn as_subtree(&self) -> BtreeHeader {
         BtreeHeader::from_le_bytes(
             self.data[1..=BtreeHeader::serialized_size()]
                 .try_into()
-                .unwrap(),
+                .expect("SubtreeV2 length validated by collection_type()"),
         )
     }
 
@@ -760,11 +782,12 @@ impl<V: Key> DynamicCollection<V> {
                 accessor.num_pairs() as u64
             }
             SubtreeV2 => {
+                // Length validated by `collection_type()` (SubtreeV2 branch).
                 let offset = 1 + PageNumber::serialized_size() + size_of::<Checksum>();
                 u64::from_le_bytes(
                     self.data[offset..(offset + size_of::<u64>())]
                         .try_into()
-                        .unwrap(),
+                        .expect("SubtreeV2 length validated by collection_type()"),
                 )
             }
         })
@@ -894,18 +917,35 @@ impl UntypedDynamicCollection {
     }
 
     fn collection_type(&self) -> crate::Result<DynamicCollectionType> {
-        DynamicCollectionType::try_from_byte(self.data[0])
+        let type_byte = *self.data.first().ok_or_else(|| {
+            StorageError::Corrupted("empty UntypedDynamicCollection value".to_string())
+        })?;
+        let ct = DynamicCollectionType::try_from_byte(type_byte)?;
+        if let SubtreeV2 = ct {
+            let required = 1 + BtreeHeader::serialized_size();
+            if self.data.len() < required {
+                return Err(StorageError::Corrupted(format!(
+                    "UntypedDynamicCollection SubtreeV2 truncated: {} bytes, need {}",
+                    self.data.len(),
+                    required
+                )));
+            }
+        }
+        Ok(ct)
     }
 
     fn as_inline(&self) -> &[u8] {
         &self.data[1..]
     }
 
+    /// Decode the `BtreeHeader` portion of a `SubtreeV2` collection.
+    ///
+    /// Precondition: caller has verified `collection_type()? == SubtreeV2`.
     fn as_subtree(&self) -> BtreeHeader {
         BtreeHeader::from_le_bytes(
             self.data[1..=BtreeHeader::serialized_size()]
                 .try_into()
-                .unwrap(),
+                .expect("SubtreeV2 length validated by collection_type()"),
         )
     }
 }
@@ -1930,6 +1970,68 @@ impl<K: Key + 'static, V: Key + 'static> ReadableMultimapTable<K, V>
             self.transaction_guard.clone(),
             self.mem.clone(),
         ))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::tree_store::BtreeHeader;
+
+    /// Regression: `collection_type()` on an empty value must return a
+    /// `Corrupted` error rather than panic on `self.data[0]`.
+    #[test]
+    fn collection_type_empty_data_is_corrupted() {
+        let coll = DynamicCollection::<u64>::new(&[]);
+        assert!(matches!(
+            coll.collection_type(),
+            Err(StorageError::Corrupted(_))
+        ));
+
+        let untyped = UntypedDynamicCollection::new(&[]);
+        assert!(matches!(
+            untyped.collection_type(),
+            Err(StorageError::Corrupted(_))
+        ));
+    }
+
+    /// Regression: a `SubtreeV2` value whose payload is shorter than
+    /// `1 + BtreeHeader::serialized_size()` must surface as a `Corrupted`
+    /// error rather than panic inside `as_subtree()` /
+    /// `get_num_values()`.
+    #[test]
+    fn collection_type_short_subtree_is_corrupted() {
+        let type_byte: u8 = SubtreeV2.into();
+        // One byte short of the required header
+        let short_len = BtreeHeader::serialized_size(); // (we'd need +1)
+        let mut data = vec![type_byte];
+        data.resize(short_len, 0u8);
+
+        let coll = DynamicCollection::<u64>::new(&data);
+        assert!(matches!(
+            coll.collection_type(),
+            Err(StorageError::Corrupted(_))
+        ));
+
+        let untyped = UntypedDynamicCollection::new(&data);
+        assert!(matches!(
+            untyped.collection_type(),
+            Err(StorageError::Corrupted(_))
+        ));
+    }
+
+    /// A correctly-sized SubtreeV2 payload still validates and decodes.
+    #[test]
+    fn collection_type_valid_subtree_ok() {
+        let bytes = UntypedDynamicCollection::make_subtree_data(BtreeHeader::new(
+            crate::tree_store::PageNumber::new(0, 0, 0),
+            0u128,
+            0,
+        ));
+        let coll = UntypedDynamicCollection::new(&bytes);
+        assert!(matches!(coll.collection_type(), Ok(SubtreeV2)));
+        // as_subtree should not panic now
+        let _ = coll.as_subtree();
     }
 }
 

--- a/src/multimap_table.rs
+++ b/src/multimap_table.rs
@@ -1973,6 +1973,8 @@ impl<K: Key + 'static, V: Key + 'static> ReadableMultimapTable<K, V>
     }
 }
 
+impl<K: Key, V: Key> Sealed for ReadOnlyMultimapTable<K, V> {}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -2020,7 +2022,7 @@ mod tests {
         ));
     }
 
-    /// A correctly-sized SubtreeV2 payload still validates and decodes.
+    /// A correctly-sized `SubtreeV2` payload still validates and decodes.
     #[test]
     fn collection_type_valid_subtree_ok() {
         let bytes = UntypedDynamicCollection::make_subtree_data(BtreeHeader::new(
@@ -2034,5 +2036,3 @@ mod tests {
         let _ = coll.as_subtree();
     }
 }
-
-impl<K: Key, V: Key> Sealed for ReadOnlyMultimapTable<K, V> {}


### PR DESCRIPTION
## Summary

Four concrete panic / silent-truncation vectors found in a fresh adversarial audit. All fixes are minimal-scope and verified by tests.

| # | File | Class | Trigger |
|---|------|-------|---------|
| 1 | `src/ivfpq/pq.rs` | Panic | `serialize_codebook(m)` with `m >= num_subvectors` or short codebook data |
| 2 | `src/ivfpq/pq.rs` | Silent corruption | `decode(codes)` with `codes.len() != num_subvectors` produced truncated vectors |
| 3 | `src/blob_store/writer.rs` | Silent corruption | `next_chunk_index` wraps at `u32::MAX` (~256 TiB blobs) |
| 4 | `src/multimap_table.rs` | Panic | `as_subtree()` / `get_num_values()` panic on truncated SubtreeV2 payload |

## Approach

- Fixes 1, 2: bounds checks at the public API boundary, return empty `Vec` (consistent with existing `centroid()` style).
- Fix 3: `checked_add(1)` returning `StorageError::Internal` on overflow.
- Fix 4: validate length once in `collection_type()` (the gateway every caller routes through). Downstream accessors keep their original `BtreeHeader` return type but the `.unwrap()` is now provably unreachable; converted to `.expect(...)` with a documented precondition. **No signature changes ripple** — all 11 call sites already gate on `collection_type()?`.

## Tests

- 4 new regression tests in `ivfpq::pq::tests` (out-of-range `m`, short codebook data, wrong-length codes, short-codebook decode)
- 3 new regression tests in `multimap_table::tests` (empty data, short SubtreeV2, valid SubtreeV2 round-trip)
- All 240 existing lib tests still pass
- `cargo clippy --lib -- -D warnings`: clean
- `cargo fmt --all -- --check`: clean

## Items deliberately NOT fixed in this PR

The original audit agent surfaced 15 findings; only these 4 were verified as real. The others were either (a) hallucinated (`kmeans` n=0 is short-circuited at line 256), (b) style not bugs (CDC `unwrap` after `is_some_and`), or (c) hand-waved without evidence (header-swap atomicity claims).

## Test plan

- [x] `cargo test --lib` — 240/240 pass
- [x] `cargo clippy --lib -- -D warnings`
- [x] `cargo fmt --all -- --check`
- [ ] CI green