### PR TITLE
fix: release build broken (Clone for PageImpl) + close release-mode CI gap

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -342,14 +342,6 @@ jobs:
             args: "--features compression_lz4"
           - name: compression_zstd
             args: "--features compression_zstd"
-          # Run the full test suite in release mode at least once to catch
-          # runtime divergence between debug and release builds (e.g. removed
-          # debug_assert!s exposing latent off-by-one logic, or release-only
-          # codegen issues in unsafe blocks).
-          - name: release
-            args: "--release"
-          - name: release-all-features
-            args: "--release --all-features"
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -83,6 +83,16 @@ jobs:
             args: "--all --all-targets --all-features"
           - name: no-features
             args: "--all --all-targets --no-default-features"
+          # Release-mode variants catch bugs that debug-only assertions or
+          # cfg(debug_assertions)-gated fields hide. Without these, code that
+          # references a debug-only field outside a cfg gate compiles cleanly
+          # in debug CI but breaks at the user's release build.
+          - name: release-default
+            args: "--release --all --all-targets"
+          - name: release-all-features
+            args: "--release --all --all-targets --all-features"
+          - name: release-no-features
+            args: "--release --all --all-targets --no-default-features"
           - name: wasm32
             args: ""
             wasm: true
@@ -332,6 +342,14 @@ jobs:
             args: "--features compression_lz4"
           - name: compression_zstd
             args: "--features compression_zstd"
+          # Run the full test suite in release mode at least once to catch
+          # runtime divergence between debug and release builds (e.g. removed
+          # debug_assert!s exposing latent off-by-one logic, or release-only
+          # codegen issues in unsafe blocks).
+          - name: release
+            args: "--release"
+          - name: release-all-features
+            args: "--release --all-features"
     steps:
       - uses: actions/checkout@v4
 

--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,7 @@ crates/*/target/
 
 # Local audit docs (not for GitHub)
 AUDIT_PLAYBOOK.md
+
+# Benchmark datasets (SIFT1M and similar). Cargo.toml already excludes
+# these from publication; this prevents accidental git commits too.
+/data/

--- a/src/tree_store/page_store/base.rs
+++ b/src/tree_store/page_store/base.rs
@@ -1,4 +1,6 @@
-use crate::compat::{HashMap, HashSet, Mutex};
+use crate::compat::HashSet;
+#[cfg(debug_assertions)]
+use crate::compat::{HashMap, Mutex};
 use crate::tree_store::page_store::cached_file::WritablePage;
 use crate::tree_store::page_store::page_manager::MAX_MAX_PAGE_ORDER;
 use alloc::sync::Arc;
@@ -233,10 +235,19 @@ impl Page for PageImpl {
 
 impl Clone for PageImpl {
     fn clone(&self) -> Self {
-        *self.open_pages.lock().entry(self.page_number).or_insert(0) += 1;
+        // Debug-only ref-count bookkeeping: the `open_pages` field exists only
+        // under `cfg(debug_assertions)`. The Drop impl above is similarly
+        // gated, so this Clone must match it. In release builds, Arc<[u8]>
+        // already keeps the page memory alive after a free; the bookkeeping
+        // is a debug-time use-after-free detector, not a correctness primitive.
+        #[cfg(debug_assertions)]
+        {
+            *self.open_pages.lock().entry(self.page_number).or_insert(0) += 1;
+        }
         Self {
             mem: self.mem.clone(),
             page_number: self.page_number,
+            #[cfg(debug_assertions)]
             open_pages: self.open_pages.clone(),
         }
     }

--- a/src/tree_store/page_store/page_manager.rs
+++ b/src/tree_store/page_store/page_manager.rs
@@ -1,6 +1,6 @@
+use crate::compat::Mutex;
 #[cfg(debug_assertions)]
 use crate::compat::{HashMap, HashSet};
-use crate::compat::Mutex;
 use crate::db::{ReadVerification, ReadVerificationAction, ReadVerificationCallback};
 use crate::transaction_tracker::TransactionId;
 use crate::transactions::{AllocatorStateKey, AllocatorStateTree, AllocatorStateTreeMut};

--- a/src/tree_store/page_store/page_manager.rs
+++ b/src/tree_store/page_store/page_manager.rs
@@ -1,6 +1,6 @@
 #[cfg(debug_assertions)]
-use crate::compat::HashSet;
-use crate::compat::{HashMap, Mutex};
+use crate::compat::{HashMap, HashSet};
+use crate::compat::Mutex;
 use crate::db::{ReadVerification, ReadVerificationAction, ReadVerificationCallback};
 use crate::transaction_tracker::TransactionId;
 use crate::transactions::{AllocatorStateKey, AllocatorStateTree, AllocatorStateTreeMut};


### PR DESCRIPTION
## Summary

Master release builds have been broken. \`Clone for PageImpl\` references \`self.open_pages\` unconditionally, but the field is \`#[cfg(debug_assertions)]\`-gated -- so release-mode builds fail with E0609/E0560. The \`Drop\` impl is correctly gated; this is a Drop/Clone inconsistency.

The reason it slipped through: every CI \`test\` and \`compile\` job runs in **debug** mode. The only release-mode job is the \`Performance Gate\` in a separate workflow, which is not part of the required \`ci-pass\` aggregator -- so the broken release build went silent on master.

## Changes

### Source fixes
- \`src/tree_store/page_store/base.rs\`: gate the bookkeeping line and the \`open_pages\` field initializer in \`Clone for PageImpl\` (matches \`Drop\`).
- \`src/tree_store/page_store/base.rs\`: gate dead release imports (\`HashMap\`, \`Mutex\`).
- \`src/tree_store/page_store/page_manager.rs\`: hoist \`Mutex\` out of the \`#[cfg(debug_assertions)]\` import set (it's used unconditionally by the \`state\` field); move \`HashMap\` and \`HashSet\` together under the gate.

### CI gap closure
- \`.github/workflows/ci.yml\`: add three release-mode entries to the \`compile\` matrix (\`release-default\`, \`release-all-features\`, \`release-no-features\`). These are \`cargo check --release --all --all-targets ...\` and would have caught this regression.
- \`.github/workflows/ci.yml\`: add two release-mode entries to the \`test-features\` matrix (\`release\`, \`release-all-features\`) so runtime divergence between debug and release (e.g. removed \`debug_assert!\`s exposing latent logic) is exercised in CI.

### Hygiene
- \`.gitignore\`: ignore \`/data/\` benchmark datasets (711 MB SIFT1M nearly committed during this fix). Cargo.toml already excludes them from publication; gitignore matches that rule.

## Verified

- Audit complete for similar bugs: every other access of a \`#[cfg(debug_assertions)]\`-gated field on \`PageImpl\`, \`PageMut\`, or \`TransactionTracker\` is properly gated. The Clone bug was the only outstanding instance.

## Test plan
- [ ] All existing CI checks pass
- [ ] New \`Compile (release-default)\`, \`Compile (release-all-features)\`, \`Compile (release-no-features)\` jobs pass
- [ ] New \`Test Features (release)\`, \`Test Features (release-all-features)\` jobs pass
- [ ] \`Performance Gate (vector ops)\` passes (was the canary that revealed this bug)
- [ ] Existing Test/Lint/MSRV jobs still green (no debug-mode regression)

## Follow-up (not in this PR)
- The \`Performance Gate\` job lives in \`bench.yml\` and is not part of \`ci-pass\` \`needs:\`. Consider either moving it into \`ci.yml\` or configuring branch protection to require it directly. Out of scope here -- this PR closes the compile gap; perf-gate gating is a follow-up.