### PR TITLE
fix(soak): scale file-size threshold by op count, not wall time

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -342,6 +342,13 @@ jobs:
             args: "--features compression_lz4"
           - name: compression_zstd
             args: "--features compression_zstd"
+          # Release-mode test variants catch bugs that only surface under
+          # optimized builds (e.g. cfg(debug_assertions)-gated fields, UB
+          # masked by debug zero-init, op-rate-sensitive resource bounds).
+          - name: release-default
+            args: "--release"
+          - name: release-all-features
+            args: "--release --all-features"
     steps:
       - uses: actions/checkout@v4
 

--- a/tests/soak_tests.rs
+++ b/tests/soak_tests.rs
@@ -579,14 +579,32 @@ fn run_soak(durability: Durability) {
             );
         }
 
-        // Check file size sanity -- scale limit with soak duration.
-        // Base: 256 MB for 60s. Scale linearly for longer runs.
-        let duration_secs = soak_duration().as_secs().max(1);
-        let max_file_bytes = 256u64 * 1024 * 1024 * duration_secs.max(60) / 60;
+        // Check file size sanity -- scale limit with actual write volume,
+        // not wall-clock duration. Release-mode runs perform many more ops in
+        // the same wall time, so a duration-based bound either false-positives
+        // (release) or hides real leaks (debug). Op-count-based bounds scale
+        // with work done in either profile.
+        //
+        // Per-op upper bounds on raw user payload:
+        //   kv_writes   : 8 B key + max 191 B value -> 200 B
+        //   blob_writes : up to 65 KiB              -> 66560 B
+        //   vec_inserts : 64 dim * f32              -> 256 B
+        //   ttl_inserts : 8 B key + max 191 B value -> 200 B
+        // Multiplier 16x absorbs B-tree copy-on-write churn, page-level
+        // fragmentation, and freed-but-not-yet-reclaimed pages mid-test.
+        // Floor 64 MiB covers empty-database overhead (page headers, system
+        // tables, allocator state) on short runs with low op counts.
+        let kv = stats.kv_writes.load(Ordering::Relaxed);
+        let blob = stats.blob_writes.load(Ordering::Relaxed);
+        let vecs = stats.vec_inserts.load(Ordering::Relaxed);
+        let ttl = stats.ttl_inserts.load(Ordering::Relaxed);
+        let payload_bytes = kv * 200 + blob * 66560 + vecs * 256 + ttl * 200;
+        let max_file_bytes = 64u64 * 1024 * 1024 + payload_bytes * 16;
         let file_size = std::fs::metadata(tmpfile.path()).unwrap().len();
         assert!(
             file_size < max_file_bytes,
-            "file size {file_size} bytes exceeds {} MB  -- possible leak",
+            "file size {file_size} bytes exceeds {} MiB \
+             (kv={kv}, blob={blob}, vec={vecs}, ttl={ttl}) -- possible leak",
             max_file_bytes / (1024 * 1024)
         );
 


### PR DESCRIPTION
## Problem

The soak test's file-size leak detector used a wall-clock-based threshold
(256 MiB at 60s, scaled linearly thereafter). Release-mode runs at the
default 10s duration produce ~270 MiB of legitimate file growth -- many
more ops in the same wall time -- and trip the assert.

This blocked re-adding release-mode test variants to CI (dropped in #317
to unblock the 0.5.0 release). The release plan flagged it as a
mandatory follow-up before the gap reopened across more PRs.

## Fix

Replace duration-based bound with an op-count-based bound:

```
max_file_bytes
    = 64 MiB floor
    + 16 * ( kv_writes  * 200 B
           + blob_writes * 65 KiB
           + vec_inserts * 256 B
           + ttl_inserts * 200 B )
```

- Per-op constants are upper bounds on raw user payload.
- 16x multiplier absorbs B-tree COW churn and freed-but-not-yet-reclaimed
  pages mid-run.
- 64 MiB floor covers empty-DB overhead (page headers, system tables,
  allocator state) on short low-op runs.

Threshold now scales with **work done**, so it behaves identically in
debug and release modes -- a real leak (file grows independently of op
count) trips it in either profile.

## CI

Re-adds `release-default` and `release-all-features` to the
`test-features` matrix. The PR's own CI run is the validation that the
threshold survives release-mode op rates.

## Diagnostic

Failure message now includes the op counters:

```
file size {N} bytes exceeds {M} MiB (kv=..., blob=..., vec=..., ttl=...) -- possible leak
```

A real leak is diagnosable from the assert output alone -- no rerun
needed to figure out the workload state.

## Risk

- If per-op upper bounds are too low, false positives. Bounds are
  literal upper bounds (`make_value` length, blob size formula, vec
  dim), so this can only fail if the workload generators change.
- If the 16x multiplier is too tight, false positives under high page
  churn. Picked deliberately generous; can lower in a follow-up if we
  see we're masking a real leak signal.