### PR TITLE
fix(verify_integrity): peg read hold to durable txn id, not last_committed

### DIFF
--- a/src/db.rs
+++ b/src/db.rs
@@ -1152,19 +1152,30 @@ impl Database {
             });
         }
 
-        // Register a read transaction to ensure MVCC protection during
-        // verification. Without this, process_freed_pages in a concurrent
-        // writer can free pages that the verification traversal is reading,
-        // causing checksum mismatches and debug_assert failures.
+        // Register a read hold pegged to the last **durable** transaction id
+        // so that `oldest_live_read_transaction` matches the persisted (primary)
+        // roots we read below. A plain `allocate_read_transaction` would peg
+        // the hold to `get_last_committed_transaction_id`, which after a
+        // non-durable commit returns the secondary slot's id `N` while the
+        // primary root still corresponds to an older durable id `N-K`. A
+        // concurrent durable commit's `process_freed_pages` would then free
+        // entries in DATA_FREED_TABLE / SYSTEM_FREED_TABLE for txns
+        // `N-K+1 ..= N` -- pages still reachable from the primary root --
+        // and the verification walk would follow pointers into reclaimed
+        // pages (panicking inside EntryGuard::value_checked with a reversed
+        // value_range when the page is reused mid-write).
         //
-        // Capture the root pointers atomically with guard registration so
-        // that concurrent commits cannot change the root between guard
-        // creation and the actual tree walk. This prevents false-positive
-        // structural corruption reports (e.g. "leaf at depth 1, expected 2")
-        // when a root split races with verification.
-        let guard = Arc::new(self.allocate_read_transaction()?);
-        // Use persisted roots (primary slot) to avoid racing with non-durable
-        // writers that may free pages from unreachable tables in the secondary slot.
+        // Pegging the hold to the durable id keeps `oldest_live_read_transaction`
+        // <= primary's id, so freeing only touches entries that are
+        // unreachable from the primary root. Capture the root pointers
+        // immediately after registration so that concurrent commits cannot
+        // change the root between guard creation and the tree walk; this
+        // prevents false-positive structural corruption reports (e.g.
+        // "leaf at depth 1, expected 2") when a root split races with
+        // verification.
+        let guard = Arc::new(self.allocate_durable_read_transaction()?);
+        // Use persisted roots (primary slot) to match the durable id pinned
+        // by the guard above.
         let snapshot_data_root = self.mem.get_persisted_data_root();
         let snapshot_system_root = self.mem.get_persisted_system_root();
 
@@ -2161,6 +2172,25 @@ impl Database {
         let id = self
             .transaction_tracker
             .register_read_transaction(&self.mem)?;
+
+        Ok(TransactionGuard::new_read(
+            id,
+            self.transaction_tracker.clone(),
+        ))
+    }
+
+    /// Allocate a read guard pegged to the last durable (primary slot) txn id.
+    ///
+    /// Use this when the caller intends to read the persisted roots
+    /// (`get_persisted_data_root` / `get_persisted_system_root`). Pegging the
+    /// guard to the durable id keeps `oldest_live_read_transaction` low enough
+    /// that a concurrent durable commit's `process_freed_pages` will not
+    /// reclaim any page reachable from the persisted roots.
+    #[cfg(feature = "std")]
+    fn allocate_durable_read_transaction(&self) -> Result<TransactionGuard> {
+        let id = self
+            .transaction_tracker
+            .register_durable_read_transaction(&self.mem)?;
 
         Ok(TransactionGuard::new_read(
             id,

--- a/src/transaction_tracker.rs
+++ b/src/transaction_tracker.rs
@@ -346,6 +346,40 @@ impl TransactionTracker {
         Ok(id)
     }
 
+    /// Register a read hold pegged to the last **durable** transaction id
+    /// (the primary slot's id), regardless of whether `read_from_secondary`
+    /// is currently set.
+    ///
+    /// This is the correct registration when the caller intends to read the
+    /// **persisted** roots (`get_persisted_data_root` / `get_persisted_system_root`).
+    /// Using `register_read_transaction` in that case creates an id/root
+    /// mismatch: the registered id may be the secondary (non-durable) txn id
+    /// `N`, but the persisted root being walked corresponds to the older
+    /// primary id `N-K`. A concurrent durable commit's `process_freed_pages`
+    /// then frees pages reachable from the primary root (entries in
+    /// `DATA_FREED_TABLE` / `SYSTEM_FREED_TABLE` for txns in `N-K+1 ..= N`),
+    /// causing the reader to follow pointers into reclaimed pages.
+    ///
+    /// Pegging the registration to the durable id ensures
+    /// `oldest_live_read_transaction <= durable_id`, so `process_freed_pages`
+    /// only frees entries with txn `<= durable_id` -- which by construction
+    /// are not reachable from the durable root being walked.
+    #[cfg(feature = "std")]
+    pub(crate) fn register_durable_read_transaction(
+        &self,
+        mem: &TransactionalMemory,
+    ) -> Result<TransactionId> {
+        let mut state = self.state.lock()?;
+        let id = mem.get_last_durable_transaction_id()?;
+        state
+            .live_read_transactions
+            .entry(id)
+            .and_modify(|x| *x += 1)
+            .or_insert(1);
+
+        Ok(id)
+    }
+
     pub(crate) fn deallocate_read_transaction(&self, id: TransactionId) -> Result {
         #[cfg(feature = "std")]
         let mut state = self.state.lock()?;

--- a/tests/verify_integrity_concurrent.rs
+++ b/tests/verify_integrity_concurrent.rs
@@ -1,3 +1,4 @@
+#![cfg(not(target_os = "wasi"))]
 //! Regression test for the verify_integrity / process_freed_pages race.
 //!
 //! Background:

--- a/tests/verify_integrity_concurrent.rs
+++ b/tests/verify_integrity_concurrent.rs
@@ -22,9 +22,7 @@
 //! Without the fix this reproduces the panic in seconds; with the fix it
 //! must run clean and never report corruption.
 
-use shodh_redb::{
-    Database, Durability, ReadableDatabase, ReadableTable, TableDefinition, VerifyLevel,
-};
+use shodh_redb::{Database, Durability, TableDefinition, VerifyLevel};
 use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::thread;

--- a/tests/verify_integrity_concurrent.rs
+++ b/tests/verify_integrity_concurrent.rs
@@ -1,0 +1,152 @@
+//! Regression test for the verify_integrity / process_freed_pages race.
+//!
+//! Background:
+//!   `Database::verify_integrity` reads the **persisted** roots
+//!   (`get_persisted_data_root` / `get_persisted_system_root`, which always
+//!   come from the primary slot) but registered its read hold via
+//!   `register_read_transaction`, which uses `get_last_committed_transaction_id`.
+//!   After a non-durable commit `read_from_secondary = true`, so the
+//!   committed-id read returns the secondary slot's id `N` while the persisted
+//!   root still reflects an older durable id `N-K`. A concurrent durable
+//!   commit's `process_freed_pages` then frees DATA_FREED_TABLE /
+//!   SYSTEM_FREED_TABLE entries for txns `N-K+1 ..= N` -- pages still
+//!   reachable from the primary root being walked. The verification walk
+//!   follows pointers into reclaimed pages and panics inside
+//!   `EntryGuard::value_checked` (typically with a reversed `value_range`
+//!   such as `3226..0` when the page has been reused mid-write).
+//!
+//! This test exercises that exact pattern: a writer alternates durable and
+//! non-durable commits with churn (insert + delete) so DATA_FREED_TABLE and
+//! SYSTEM_FREED_TABLE accumulate entries across both durability modes,
+//! while a verifier loops on `verify_integrity(VerifyLevel::Full)`.
+//! Without the fix this reproduces the panic in seconds; with the fix it
+//! must run clean and never report corruption.
+
+use shodh_redb::{
+    Database, Durability, ReadableDatabase, ReadableTable, TableDefinition, VerifyLevel,
+};
+use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::thread;
+use std::time::{Duration, Instant};
+
+const TABLE: TableDefinition<u64, &[u8]> = TableDefinition::new("verify_concurrent");
+
+fn create_tempfile() -> tempfile::NamedTempFile {
+    tempfile::NamedTempFile::new().unwrap()
+}
+
+#[test]
+fn verify_integrity_races_with_mixed_durability_commits() {
+    let tmpfile = create_tempfile();
+    let db = Arc::new(Database::create(tmpfile.path()).unwrap());
+
+    // Seed the database so verification has structure to walk.
+    {
+        let txn = db.begin_write().unwrap();
+        {
+            let mut table = txn.open_table(TABLE).unwrap();
+            for i in 0..2_000u64 {
+                let value = vec![0xABu8; 256];
+                table.insert(i, value.as_slice()).unwrap();
+            }
+        }
+        txn.commit().unwrap();
+    }
+
+    let stop = Arc::new(AtomicBool::new(false));
+
+    // Writer thread: alternate durable and non-durable commits with churn.
+    // Each iteration:
+    //   - one non-durable commit that inserts/overwrites a band of keys,
+    //   - one non-durable commit that deletes part of that band,
+    //   - one durable commit that overwrites a different band.
+    // The deletes populate DATA_FREED_TABLE entries; the durable commit
+    // triggers `process_freed_pages`; the non-durable commits keep
+    // `read_from_secondary = true` so the verifier reads stale primary
+    // roots while last_committed_id advances on the secondary slot.
+    let writer_db = db.clone();
+    let writer_stop = stop.clone();
+    let writer = thread::spawn(move || {
+        let mut iter: u64 = 0;
+        let large = vec![0xCDu8; 1024];
+        while !writer_stop.load(Ordering::Relaxed) {
+            let band = (iter % 16) * 256;
+
+            // Non-durable insert/overwrite.
+            {
+                let mut txn = writer_db.begin_write().unwrap();
+                txn.set_durability(Durability::None).unwrap();
+                {
+                    let mut table = txn.open_table(TABLE).unwrap();
+                    for k in band..band + 256 {
+                        table.insert(k, large.as_slice()).unwrap();
+                    }
+                }
+                txn.commit().unwrap();
+            }
+
+            // Non-durable delete (creates DATA_FREED_TABLE entries).
+            {
+                let mut txn = writer_db.begin_write().unwrap();
+                txn.set_durability(Durability::None).unwrap();
+                {
+                    let mut table = txn.open_table(TABLE).unwrap();
+                    for k in band..band + 128 {
+                        table.remove(&k).unwrap();
+                    }
+                }
+                txn.commit().unwrap();
+            }
+
+            // Durable commit on a different band -- triggers process_freed_pages
+            // for accumulated DATA_FREED_TABLE entries.
+            {
+                let other_band = ((iter + 7) % 16) * 256;
+                let txn = writer_db.begin_write().unwrap();
+                {
+                    let mut table = txn.open_table(TABLE).unwrap();
+                    for k in other_band..other_band + 64 {
+                        table.insert(k, large.as_slice()).unwrap();
+                    }
+                }
+                txn.commit().unwrap();
+            }
+
+            iter += 1;
+        }
+    });
+
+    // Verifier thread: loop on verify_integrity(Full). Without the fix this
+    // panics inside `EntryGuard::value_checked` with a reversed value_range
+    // when a reachable page is reclaimed and reused mid-write.
+    let verifier_db = db.clone();
+    let verifier_stop = stop.clone();
+    let verifier = thread::spawn(move || -> Result<(), String> {
+        let start = Instant::now();
+        let mut runs: u64 = 0;
+        // Cap by iterations and wall-clock to keep CI cheap but still cover
+        // the race window many times. The bug reproduces in well under
+        // 1 second of wall time without the fix.
+        while runs < 200 && start.elapsed() < Duration::from_secs(15) {
+            let report = verifier_db
+                .verify_integrity(VerifyLevel::Full)
+                .map_err(|e| format!("verify_integrity returned error: {e:?}"))?;
+            if !report.valid {
+                return Err(format!(
+                    "verify_integrity reported corruption: {} pages corrupt, structural_valid={:?}, details={:?}",
+                    report.pages_corrupt, report.structural_valid, report.corrupt_details
+                ));
+            }
+            runs += 1;
+        }
+        verifier_stop.store(true, Ordering::Relaxed);
+        Ok(())
+    });
+
+    let verifier_result = verifier.join().expect("verifier thread panicked");
+    stop.store(true, Ordering::Relaxed);
+    writer.join().expect("writer thread panicked");
+
+    verifier_result.expect("verify_integrity must remain valid under concurrent commits");
+}


### PR DESCRIPTION
## Bug

`Database::verify_integrity` walks the **persisted (primary slot)** roots via `get_persisted_data_root` / `get_persisted_system_root`, but registered its read hold via `register_read_transaction`, which uses `get_last_committed_transaction_id`. The two are not the same after a non-durable commit:

- non-durable commit sets `read_from_secondary = true` (`page_manager.rs:1240`)
- `get_last_committed_transaction_id` then returns the **secondary** id `N` (`page_manager.rs:1425-1432`)
- `get_persisted_data_root` always returns the **primary** root, which corresponds to the older durable id `N-K`

A concurrent durable commit's pre-commit `process_freed_pages` (`transactions.rs:2515-2534`, `transactions.rs:3211-3250`) then frees DATA_FREED_TABLE / SYSTEM_FREED_TABLE entries for txns `N-K+1 ..= N` — pages still reachable from the primary root being walked. The verification traversal follows a pointer into a reclaimed-and-reused page and panics inside `EntryGuard::value_checked` (`btree_iters.rs:277`), typically with a reversed `value_range` such as `3226..0` when the page has been reused mid-write.

Repro on master: `tests/soak_tests.rs::soak_mixed_workload` under `.github/workflows/ci.yml::Test Features (release-default)`. The previously-merged PR #319 surfaced this race by re-enabling release-mode test variants in CI.

## Fix

Add `register_durable_read_transaction` / `allocate_durable_read_transaction` that pin the read hold to `mem.get_last_durable_transaction_id` — always the primary slot id, regardless of `read_from_secondary`. Switch `verify_integrity` to use it.

**Correctness:** with the registered id `T_durable` matching the primary root being walked, `oldest_live_read_transaction <= T_durable`, so `process_freed_pages` only frees entries with `X <= T_durable`. Pages reachable from `T_durable`'s tree are by construction not in `DATA_FREED_TABLE[X]` for `X <= T_durable` (those are pages that became unreachable at or before `T_durable`). Same argument applies to system-tree walking via `SYSTEM_FREED_TABLE`.

The post-commit reader re-check from PR \`879191a\` (system-tree only) does not address this case because the reader **is** registered — just at the wrong id for the root it is reading. The fix is at the registration semantics.

## Regression test

\`tests/verify_integrity_concurrent.rs\`: writer alternates durable + non-durable commits with insert/delete churn so DATA_FREED_TABLE and SYSTEM_FREED_TABLE accumulate across both modes; verifier loops on \`verify_integrity(VerifyLevel::Full)\`. Without the fix the panic reproduces in well under a second. With the fix the test runs clean.

## Standards

No CI checks disabled. No thresholds touched. No assertions weakened. Root cause fixed at the registration semantics.

## Test plan
- [ ] Test (Ubuntu) green
- [ ] Test (Windows) green
- [ ] Test (macOS) green
- [ ] Test Features (release-default) green
- [ ] Test Features (release-all-features) green
- [ ] Test Features (no_std) green
- [ ] Clippy / Rustfmt green
- [ ] Performance Gate green