### PR TITLE
fix(integrity_scanner): register durable read hold per scan cycle

### DIFF
--- a/src/db.rs
+++ b/src/db.rs
@@ -1720,8 +1720,12 @@ impl Database {
         &self,
         config: crate::integrity_scanner::IntegrityScannerConfig,
     ) -> Result<crate::integrity_scanner::IntegrityScannerHandle, DatabaseError> {
-        crate::integrity_scanner::IntegrityScannerHandle::start(self.mem.clone(), config)
-            .map_err(DatabaseError::from)
+        crate::integrity_scanner::IntegrityScannerHandle::start(
+            self.mem.clone(),
+            self.transaction_tracker.clone(),
+            config,
+        )
+        .map_err(DatabaseError::from)
     }
 
     /// Export a logical incremental snapshot of all key/value changes since

--- a/src/integrity_scanner.rs
+++ b/src/integrity_scanner.rs
@@ -9,6 +9,7 @@
 //! as [`Database::verify_integrity()`](crate::Database::verify_integrity).
 
 use crate::db::{CorruptPageInfo, Database, TransactionGuard};
+use crate::transaction_tracker::TransactionTracker;
 use crate::tree_store::TransactionalMemory;
 use alloc::sync::Arc;
 use alloc::vec::Vec;
@@ -68,6 +69,7 @@ pub struct IntegrityScannerHandle {
 impl IntegrityScannerHandle {
     pub(crate) fn start(
         mem: Arc<TransactionalMemory>,
+        transaction_tracker: Arc<TransactionTracker>,
         config: IntegrityScannerConfig,
     ) -> Result<Self, std::io::Error> {
         let shutdown = Arc::new(AtomicBool::new(false));
@@ -83,7 +85,15 @@ impl IntegrityScannerHandle {
             std::thread::Builder::new()
                 .name("shodh-integrity-scanner".into())
                 .spawn(move || {
-                    run_scanner(mem, config, shutdown, wake, last_result, total_cycles);
+                    run_scanner(
+                        mem,
+                        transaction_tracker,
+                        config,
+                        shutdown,
+                        wake,
+                        last_result,
+                        total_cycles,
+                    );
                 })?
         };
 
@@ -127,6 +137,7 @@ impl Drop for IntegrityScannerHandle {
 
 fn run_scanner(
     mem: Arc<TransactionalMemory>,
+    transaction_tracker: Arc<TransactionTracker>,
     config: IntegrityScannerConfig,
     shutdown: Arc<AtomicBool>,
     wake: Arc<(Mutex<()>, Condvar)>,
@@ -138,12 +149,38 @@ fn run_scanner(
 
     while !shutdown.load(Ordering::Relaxed) {
         let start = Instant::now();
-        let scan = Database::verify_primary_checksums_detailed(
-            mem.clone(),
-            mem.get_persisted_data_root(),
-            mem.get_persisted_system_root(),
-            Arc::new(TransactionGuard::Verification),
-        );
+        // Register a read hold pegged to the last durable transaction id so that
+        // a concurrent durable commit's `process_freed_pages` cannot reclaim
+        // pages reachable from the persisted (primary slot) roots while we walk
+        // them. Without this hold the scanner is exposed to the same id/root
+        // mismatch race fixed for `Database::verify_integrity` -- pages
+        // reachable from the primary tree are freed via DATA_FREED_TABLE /
+        // SYSTEM_FREED_TABLE entries, reused mid-write, and the walk panics in
+        // `EntryGuard::value_checked` with a reversed `value_range`.
+        //
+        // The guard is dropped at the end of each cycle so the scanner does
+        // not pin `oldest_live_read_transaction` during its sleep interval.
+        let scan = match transaction_tracker.register_durable_read_transaction(&mem) {
+            Ok(id) => {
+                let guard =
+                    Arc::new(TransactionGuard::new_read(id, transaction_tracker.clone()));
+                Database::verify_primary_checksums_detailed(
+                    mem.clone(),
+                    mem.get_persisted_data_root(),
+                    mem.get_persisted_system_root(),
+                    guard,
+                )
+            }
+            Err(_) => {
+                // If we can't register the read hold (e.g. tracker mutex
+                // poisoned) skip this cycle rather than walking unprotected.
+                let (lock, cvar) = &*wake;
+                if let Ok(g) = lock.lock() {
+                    let _ = cvar.wait_timeout(g, interval);
+                }
+                continue;
+            }
+        };
 
         if let Ok((pages_checked, corrupt_details)) = scan {
             cycle += 1;

--- a/src/integrity_scanner.rs
+++ b/src/integrity_scanner.rs
@@ -160,26 +160,22 @@ fn run_scanner(
         //
         // The guard is dropped at the end of each cycle so the scanner does
         // not pin `oldest_live_read_transaction` during its sleep interval.
-        let scan = match transaction_tracker.register_durable_read_transaction(&mem) {
-            Ok(id) => {
-                let guard = Arc::new(TransactionGuard::new_read(id, transaction_tracker.clone()));
-                Database::verify_primary_checksums_detailed(
-                    mem.clone(),
-                    mem.get_persisted_data_root(),
-                    mem.get_persisted_system_root(),
-                    guard,
-                )
+        let Ok(id) = transaction_tracker.register_durable_read_transaction(&mem) else {
+            // If we can't register the read hold (e.g. tracker mutex
+            // poisoned) skip this cycle rather than walking unprotected.
+            let (lock, cvar) = &*wake;
+            if let Ok(g) = lock.lock() {
+                let _ = cvar.wait_timeout(g, interval);
             }
-            Err(_) => {
-                // If we can't register the read hold (e.g. tracker mutex
-                // poisoned) skip this cycle rather than walking unprotected.
-                let (lock, cvar) = &*wake;
-                if let Ok(g) = lock.lock() {
-                    let _ = cvar.wait_timeout(g, interval);
-                }
-                continue;
-            }
+            continue;
         };
+        let guard = Arc::new(TransactionGuard::new_read(id, transaction_tracker.clone()));
+        let scan = Database::verify_primary_checksums_detailed(
+            mem.clone(),
+            mem.get_persisted_data_root(),
+            mem.get_persisted_system_root(),
+            guard,
+        );
 
         if let Ok((pages_checked, corrupt_details)) = scan {
             cycle += 1;

--- a/src/integrity_scanner.rs
+++ b/src/integrity_scanner.rs
@@ -162,8 +162,7 @@ fn run_scanner(
         // not pin `oldest_live_read_transaction` during its sleep interval.
         let scan = match transaction_tracker.register_durable_read_transaction(&mem) {
             Ok(id) => {
-                let guard =
-                    Arc::new(TransactionGuard::new_read(id, transaction_tracker.clone()));
+                let guard = Arc::new(TransactionGuard::new_read(id, transaction_tracker.clone()));
                 Database::verify_primary_checksums_detailed(
                     mem.clone(),
                     mem.get_persisted_data_root(),

--- a/tests/integrity_scanner_concurrent.rs
+++ b/tests/integrity_scanner_concurrent.rs
@@ -1,0 +1,158 @@
+#![cfg(not(target_os = "wasi"))]
+//! Regression test for the integrity scanner / `process_freed_pages` race.
+//!
+//! Background:
+//!   `IntegrityScannerHandle` walks the **persisted** primary roots
+//!   (`get_persisted_data_root` / `get_persisted_system_root`) on a background
+//!   thread. Before the fix the scanner used `TransactionGuard::Verification`,
+//!   a no-op guard that performed no `register_*` call. As a result
+//!   `oldest_live_read_transaction` was unaffected by the scanner, and a
+//!   concurrent durable commit's `process_freed_pages` was free to reclaim
+//!   DATA_FREED_TABLE / SYSTEM_FREED_TABLE entries whose pages were still
+//!   reachable from the primary tree being walked. Reused-mid-write pages
+//!   produced reversed `value_range` panics inside `EntryGuard::value_checked`.
+//!
+//! This test exercises the same id/root mismatch class as
+//! `verify_integrity_concurrent.rs`, but for the background scanner: a writer
+//! alternates durable and non-durable commits with churn while the scanner
+//! loops. Without the fix the scanner thread panics within seconds; with the
+//! fix it must report no corruption for the entire run.
+
+use shodh_redb::{
+    Database, Durability, IntegrityScannerConfig, TableDefinition,
+};
+use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
+use std::thread;
+use std::time::{Duration, Instant};
+
+const TABLE: TableDefinition<u64, &[u8]> = TableDefinition::new("scanner_concurrent");
+
+fn create_tempfile() -> tempfile::NamedTempFile {
+    tempfile::NamedTempFile::new().unwrap()
+}
+
+#[test]
+fn integrity_scanner_races_with_mixed_durability_commits() {
+    let tmpfile = create_tempfile();
+    let db = Arc::new(Database::create(tmpfile.path()).unwrap());
+
+    // Seed the database so the scanner has structure to walk.
+    {
+        let txn = db.begin_write().unwrap();
+        {
+            let mut table = txn.open_table(TABLE).unwrap();
+            for i in 0..2_000u64 {
+                let value = vec![0xABu8; 256];
+                table.insert(i, value.as_slice()).unwrap();
+            }
+        }
+        txn.commit().unwrap();
+    }
+
+    let corruption_detected = Arc::new(AtomicBool::new(false));
+    let cycles_completed = Arc::new(AtomicU64::new(0));
+
+    // Start the scanner with a short interval so it loops aggressively.
+    let corruption_flag = corruption_detected.clone();
+    let cycles_flag = cycles_completed.clone();
+    let mut handle = db
+        .start_integrity_scanner(IntegrityScannerConfig {
+            scan_interval_secs: 0,
+            on_cycle_complete: Some(Box::new(move |result| {
+                if result.pages_corrupt > 0 {
+                    corruption_flag.store(true, Ordering::Relaxed);
+                }
+                cycles_flag.fetch_add(1, Ordering::Relaxed);
+            })),
+        })
+        .unwrap();
+
+    let stop = Arc::new(AtomicBool::new(false));
+
+    // Writer thread mirrors the verify_integrity_concurrent regression: a mix
+    // of non-durable and durable commits with churn so DATA_FREED_TABLE and
+    // SYSTEM_FREED_TABLE accumulate entries across both durability modes,
+    // then a durable commit drives `process_freed_pages` while the scanner
+    // is in the middle of walking the primary roots.
+    let writer_db = db.clone();
+    let writer_stop = stop.clone();
+    let writer = thread::spawn(move || {
+        let mut iter: u64 = 0;
+        let large = vec![0xCDu8; 1024];
+        while !writer_stop.load(Ordering::Relaxed) {
+            let band = (iter % 16) * 256;
+
+            // Non-durable insert/overwrite.
+            {
+                let mut txn = writer_db.begin_write().unwrap();
+                txn.set_durability(Durability::None).unwrap();
+                {
+                    let mut table = txn.open_table(TABLE).unwrap();
+                    for k in band..band + 256 {
+                        table.insert(k, large.as_slice()).unwrap();
+                    }
+                }
+                txn.commit().unwrap();
+            }
+
+            // Non-durable delete (creates DATA_FREED_TABLE entries).
+            {
+                let mut txn = writer_db.begin_write().unwrap();
+                txn.set_durability(Durability::None).unwrap();
+                {
+                    let mut table = txn.open_table(TABLE).unwrap();
+                    for k in band..band + 128 {
+                        table.remove(&k).unwrap();
+                    }
+                }
+                txn.commit().unwrap();
+            }
+
+            // Durable commit on a different band -- triggers process_freed_pages
+            // for accumulated DATA_FREED_TABLE entries.
+            {
+                let other_band = ((iter + 7) % 16) * 256;
+                let txn = writer_db.begin_write().unwrap();
+                {
+                    let mut table = txn.open_table(TABLE).unwrap();
+                    for k in other_band..other_band + 64 {
+                        table.insert(k, large.as_slice()).unwrap();
+                    }
+                }
+                txn.commit().unwrap();
+            }
+
+            iter += 1;
+        }
+    });
+
+    // Run for up to 15 seconds or until the scanner has completed enough
+    // cycles to cover the race window many times. The bug reproduces in
+    // well under one second of wall time without the fix.
+    let start = Instant::now();
+    while start.elapsed() < Duration::from_secs(15)
+        && cycles_completed.load(Ordering::Relaxed) < 50
+    {
+        thread::sleep(Duration::from_millis(50));
+    }
+
+    stop.store(true, Ordering::Relaxed);
+    writer.join().expect("writer thread panicked");
+
+    // Drop the scanner handle to ensure the scanner thread is joined. If the
+    // scanner thread panicked from a reversed value_range mid-walk, the
+    // shutdown join will surface it via thread::join error -- but the panic
+    // typically aborts the test binary first, so the surviving check is the
+    // corruption flag.
+    handle.shutdown();
+
+    assert!(
+        cycles_completed.load(Ordering::Relaxed) > 0,
+        "scanner must complete at least one cycle"
+    );
+    assert!(
+        !corruption_detected.load(Ordering::Relaxed),
+        "integrity scanner must not report corruption under concurrent commits"
+    );
+}

--- a/tests/integrity_scanner_concurrent.rs
+++ b/tests/integrity_scanner_concurrent.rs
@@ -18,9 +18,7 @@
 //! loops. Without the fix the scanner thread panics within seconds; with the
 //! fix it must report no corruption for the entire run.
 
-use shodh_redb::{
-    Database, Durability, IntegrityScannerConfig, TableDefinition,
-};
+use shodh_redb::{Database, Durability, IntegrityScannerConfig, TableDefinition};
 use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::thread;
@@ -131,8 +129,7 @@ fn integrity_scanner_races_with_mixed_durability_commits() {
     // cycles to cover the race window many times. The bug reproduces in
     // well under one second of wall time without the fix.
     let start = Instant::now();
-    while start.elapsed() < Duration::from_secs(15)
-        && cycles_completed.load(Ordering::Relaxed) < 50
+    while start.elapsed() < Duration::from_secs(15) && cycles_completed.load(Ordering::Relaxed) < 50
     {
         thread::sleep(Duration::from_millis(50));
     }


### PR DESCRIPTION
## Summary
- The background `IntegrityScannerHandle` was walking the persisted (primary slot) roots under `TransactionGuard::Verification`, a no-op guard that performs **no** `register_*` call. With no live read transaction registered, `oldest_live_read_transaction` was unaffected by the scanner, and a concurrent durable commit's `process_freed_pages` was free to reclaim DATA_FREED_TABLE / SYSTEM_FREED_TABLE entries whose pages were still reachable from the primary tree being walked. Reused-mid-write pages produced reversed `value_range` panics in `EntryGuard::value_checked` — the same id/root mismatch class fixed for `verify_integrity` in #320.
- Strictly worse than the verify_integrity bug: that one registered (incorrectly) at `last_committed_id`; the scanner registered nothing.
- Each scan cycle now allocates a real read hold via `register_durable_read_transaction` (pegged to `last_durable_transaction_id`, matching the persisted root being walked) and drops it at the end of the cycle so the scanner does not pin `oldest_live` during its sleep interval. If the tracker mutex is poisoned the cycle is skipped rather than walked unprotected.

## Safety invariant
A reader walking tree-at-Y is safe iff its registered transaction id `T <= Y`. Pegging the hold to `last_durable_transaction_id` matches the primary slot's persisted roots, satisfying the invariant.

## Test plan
- [ ] `cargo test --test integrity_scanner_concurrent` (new) — drives mixed-durability churn against a running scanner; without the fix reproduces the panic under one second, with the fix runs clean
- [ ] Existing `integrity_scanner::tests::*` continue to pass
- [ ] `verify_integrity_concurrent` (from #320) continues to pass
- [ ] CI green on all targets including WASI (test gated `#![cfg(not(target_os = \"wasi\"))]`)

Sibling fix to #320; same bug class, different call site. GAP #2 (`begin_read_at` / `begin_read_at_time`) is the next planned fix.