### PR TITLE
fix(begin_read_at): pin history hold for the reader's lifetime

### DIFF
--- a/src/db.rs
+++ b/src/db.rs
@@ -2206,7 +2206,6 @@ impl Database {
     ///
     /// The pin and existence check are performed atomically under the
     /// tracker lock, so this serialises correctly with retention pruning.
-    #[cfg(feature = "std")]
     fn allocate_historical_read_transaction(
         &self,
         transaction_id: u64,

--- a/src/db.rs
+++ b/src/db.rs
@@ -2198,6 +2198,32 @@ impl Database {
         ))
     }
 
+    /// Allocate a read guard pinned to a specific historical transaction id
+    /// (e.g. one looked up from the retention history table). Returns
+    /// `Ok(None)` if the snapshot has already been evicted from the retention
+    /// window -- in that case the historical pages may have already been
+    /// reclaimed by `process_freed_pages` and reading is unsafe.
+    ///
+    /// The pin and existence check are performed atomically under the
+    /// tracker lock, so this serialises correctly with retention pruning.
+    #[cfg(feature = "std")]
+    fn allocate_historical_read_transaction(
+        &self,
+        transaction_id: u64,
+    ) -> Result<Option<TransactionGuard>> {
+        let id = TransactionId::new(transaction_id);
+        let pinned = self
+            .transaction_tracker
+            .try_register_historical_read_transaction(id)?;
+        if !pinned {
+            return Ok(None);
+        }
+        Ok(Some(TransactionGuard::new_read(
+            id,
+            self.transaction_tracker.clone(),
+        )))
+    }
+
     /// Convenience method for [`Builder::new`]
     pub fn builder() -> Builder {
         Builder::new()
@@ -2248,6 +2274,22 @@ impl Database {
     /// Returns a [`ReadTransaction`] that sees the user-table state as of the
     /// requested commit.
     pub fn begin_read_at(&self, transaction_id: u64) -> Result<ReadTransaction, TransactionError> {
+        // Pin the snapshot's history hold BEFORE walking its `user_root`.
+        // Without this, retention pruning could `deallocate_history_hold`
+        // for `transaction_id` during the read, allowing
+        // `oldest_live_read_transaction` to advance past `transaction_id`
+        // and `process_freed_pages` to reclaim pages reachable from the
+        // historical user tree -- the same id/root mismatch class fixed
+        // for `verify_integrity` and the integrity scanner. The pin must
+        // be allocated against the snapshot's id (T_history), not against
+        // `last_committed_id` which may be much newer and would not satisfy
+        // the invariant `registered_id <= walked_tree_id`.
+        let guard = self
+            .allocate_historical_read_transaction(transaction_id)
+            .map_err(TransactionError::Storage)?
+            .ok_or(TransactionError::Storage(
+                StorageError::HistorySnapshotNotFound(transaction_id),
+            ))?;
         let lookup_txn = self.begin_read()?;
         let snapshot = lookup_txn
             .get_history_snapshot_ro(transaction_id)
@@ -2256,7 +2298,6 @@ impl Database {
                 StorageError::HistorySnapshotNotFound(transaction_id),
             ))?;
         let user_root = snapshot.user_root();
-        let guard = self.allocate_read_transaction()?;
         drop(lookup_txn);
         ReadTransaction::new_historical(
             self.mem.clone(),
@@ -2277,33 +2318,50 @@ impl Database {
         &self,
         timestamp_ms: u64,
     ) -> Result<ReadTransaction, TransactionError> {
-        let lookup_txn = self.begin_read()?;
-        let ids = lookup_txn
-            .list_history_snapshot_ids_ro()
-            .map_err(TransactionError::Storage)?;
-        let mut best: Option<Option<BtreeHeader>> = None;
-        for id in ids {
-            if let Some(snap) = lookup_txn
-                .get_history_snapshot_ro(id)
+        // Bounded retry: the candidate snapshot picked by the in-flight
+        // lookup may be evicted by retention pruning between the scan and
+        // the pin. After a few collisions, return HistorySnapshotNotFound.
+        for _ in 0..3 {
+            let lookup_txn = self.begin_read()?;
+            let ids = lookup_txn
+                .list_history_snapshot_ids_ro()
+                .map_err(TransactionError::Storage)?;
+            let mut best: Option<(u64, Option<BtreeHeader>)> = None;
+            for id in ids {
+                if let Some(snap) = lookup_txn
+                    .get_history_snapshot_ro(id)
+                    .map_err(TransactionError::Storage)?
+                    && snap.timestamp_ms() <= timestamp_ms
+                {
+                    best = Some((id, snap.user_root()));
+                }
+            }
+            drop(lookup_txn);
+            let Some((best_id, best_root)) = best else {
+                return Err(TransactionError::Storage(
+                    StorageError::HistorySnapshotNotFound(timestamp_ms),
+                ));
+            };
+            // Pin the chosen snapshot's history hold under the tracker
+            // lock. If the snapshot was already evicted in the gap,
+            // try_register returns None and we re-scan.
+            if let Some(guard) = self
+                .allocate_historical_read_transaction(best_id)
                 .map_err(TransactionError::Storage)?
-                && snap.timestamp_ms() <= timestamp_ms
             {
-                best = Some(snap.user_root());
+                return ReadTransaction::new_historical(
+                    self.mem.clone(),
+                    guard,
+                    best_root,
+                    Arc::clone(&self.observer),
+                    #[cfg(feature = "metrics")]
+                    Arc::clone(&self.db_metrics),
+                );
             }
         }
-        let best_root = best.ok_or(TransactionError::Storage(
+        Err(TransactionError::Storage(
             StorageError::HistorySnapshotNotFound(timestamp_ms),
-        ))?;
-        let guard = self.allocate_read_transaction()?;
-        drop(lookup_txn);
-        ReadTransaction::new_historical(
-            self.mem.clone(),
-            guard,
-            best_root,
-            Arc::clone(&self.observer),
-            #[cfg(feature = "metrics")]
-            Arc::clone(&self.db_metrics),
-        )
+        ))
     }
 
     /// List all retained transaction snapshots.

--- a/src/transaction_tracker.rs
+++ b/src/transaction_tracker.rs
@@ -380,6 +380,40 @@ impl TransactionTracker {
         Ok(id)
     }
 
+    /// Atomically attempt to extend the read hold on an existing historical
+    /// snapshot. Returns `true` if `transaction_id` was already present in
+    /// `live_read_transactions` (i.e. the snapshot's `register_history_hold`
+    /// is still alive) and the count was incremented; returns `false` if the
+    /// snapshot has already been evicted from the retention window.
+    ///
+    /// This is the correct registration for time-travel reads
+    /// (`Database::begin_read_at`, `Database::begin_read_at_time`): the
+    /// caller looks up a historical snapshot in the system history table,
+    /// then must extend the snapshot's hold before walking pages reachable
+    /// from its `user_root`. Without this, retention pruning could
+    /// `deallocate_history_hold(transaction_id)` between the lookup and the
+    /// read, allowing `oldest_live_read_transaction` to advance past
+    /// `transaction_id` and `process_freed_pages` to reclaim pages
+    /// reachable from the historical user tree -- the same id/root mismatch
+    /// class fixed for `verify_integrity` and the integrity scanner.
+    ///
+    /// The check-and-increment is atomic under the tracker lock, so it
+    /// serialises correctly with retention pruning's
+    /// `deallocate_history_hold` call.
+    #[cfg(feature = "std")]
+    pub(crate) fn try_register_historical_read_transaction(
+        &self,
+        transaction_id: TransactionId,
+    ) -> Result<bool> {
+        let mut state = self.state.lock()?;
+        if let Some(ref_count) = state.live_read_transactions.get_mut(&transaction_id) {
+            *ref_count += 1;
+            Ok(true)
+        } else {
+            Ok(false)
+        }
+    }
+
     pub(crate) fn deallocate_read_transaction(&self, id: TransactionId) -> Result {
         #[cfg(feature = "std")]
         let mut state = self.state.lock()?;

--- a/src/transaction_tracker.rs
+++ b/src/transaction_tracker.rs
@@ -400,12 +400,14 @@ impl TransactionTracker {
     /// The check-and-increment is atomic under the tracker lock, so it
     /// serialises correctly with retention pruning's
     /// `deallocate_history_hold` call.
-    #[cfg(feature = "std")]
     pub(crate) fn try_register_historical_read_transaction(
         &self,
         transaction_id: TransactionId,
     ) -> Result<bool> {
+        #[cfg(feature = "std")]
         let mut state = self.state.lock()?;
+        #[cfg(not(feature = "std"))]
+        let mut state = self.state.lock();
         if let Some(ref_count) = state.live_read_transactions.get_mut(&transaction_id) {
             *ref_count += 1;
             Ok(true)

--- a/tests/begin_read_at_eviction.rs
+++ b/tests/begin_read_at_eviction.rs
@@ -28,7 +28,7 @@
 //!   5. continually walks the reader's tables -- without the fix this
 //!      panics within seconds; with the fix all reads remain valid
 
-use shodh_redb::{Database, ReadableDatabase, ReadableTable, TableDefinition};
+use shodh_redb::{Database, TableDefinition};
 use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::thread;

--- a/tests/begin_read_at_eviction.rs
+++ b/tests/begin_read_at_eviction.rs
@@ -149,9 +149,14 @@ fn begin_read_at_survives_retention_eviction_and_durable_freeing() {
     // run. If it didn't, the test failed to exercise the race window.
     let post_history = db.transaction_history().unwrap();
     assert!(
-        !post_history.iter().any(|info| info.transaction_id == t_history),
+        !post_history
+            .iter()
+            .any(|info| info.transaction_id == t_history),
         "test must drive retention pruning past T_history (history now: {:?})",
-        post_history.iter().map(|i| i.transaction_id).collect::<Vec<_>>()
+        post_history
+            .iter()
+            .map(|i| i.transaction_id)
+            .collect::<Vec<_>>()
     );
 
     drop(historical_rtxn);

--- a/tests/begin_read_at_eviction.rs
+++ b/tests/begin_read_at_eviction.rs
@@ -1,0 +1,158 @@
+#![cfg(not(target_os = "wasi"))]
+//! Regression test for the `begin_read_at` / retention-pruning race.
+//!
+//! Background:
+//!   `Database::begin_read_at(T_history)` and `Database::begin_read_at_time`
+//!   used to register the read guard via `allocate_read_transaction`, which
+//!   pegs the hold to `last_committed_transaction_id` (T_guard) -- typically
+//!   far newer than `T_history`. The historical reader then walks the
+//!   snapshot's `user_root` (a tree-at-T_history) but only
+//!   `history_hold[T_history]` registered at commit time pins those pages.
+//!   Once retention pruning evicts T_history from the system history table
+//!   it calls `deallocate_history_hold(T_history)`, the entry drops to zero,
+//!   `oldest_live_read_transaction` advances past T_history, and a durable
+//!   commit's `process_freed_pages` reclaims `DATA_FREED_TABLE` /
+//!   `SYSTEM_FREED_TABLE` entries whose pages are still reachable from the
+//!   reader's historical `user_root`. The reader then follows pointers into
+//!   reused-mid-write pages and panics inside `EntryGuard::value_checked`
+//!   with a reversed `value_range` -- the same id/root mismatch class as
+//!   `verify_integrity` (#320) and the integrity scanner (#321).
+//!
+//! This test:
+//!   1. opens a database with small `set_history_retention`
+//!   2. captures `T_history` from an early commit
+//!   3. opens a `begin_read_at(T_history)` reader and keeps it alive
+//!   4. concurrently drives durable commits with churn that exceed the
+//!      retention window, so retention pruning evicts `T_history` and
+//!      `process_freed_pages` runs against the freed entries
+//!   5. continually walks the reader's tables -- without the fix this
+//!      panics within seconds; with the fix all reads remain valid
+
+use shodh_redb::{Database, ReadableDatabase, ReadableTable, TableDefinition};
+use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::thread;
+use std::time::{Duration, Instant};
+
+const TABLE: TableDefinition<u64, &[u8]> = TableDefinition::new("history_eviction");
+
+fn create_tempfile() -> tempfile::NamedTempFile {
+    tempfile::NamedTempFile::new().unwrap()
+}
+
+#[test]
+fn begin_read_at_survives_retention_eviction_and_durable_freeing() {
+    let tmpfile = create_tempfile();
+    // Small retention window so we can quickly prune past T_history.
+    let db = Arc::new(
+        Database::builder()
+            .set_history_retention(3)
+            .create(tmpfile.path())
+            .unwrap(),
+    );
+
+    // Seed some keys so the historical user tree has structure to walk.
+    {
+        let txn = db.begin_write().unwrap();
+        {
+            let mut table = txn.open_table(TABLE).unwrap();
+            let value = vec![0xABu8; 256];
+            for k in 0..2_000u64 {
+                table.insert(k, value.as_slice()).unwrap();
+            }
+        }
+        txn.commit().unwrap();
+    }
+
+    // Capture T_history (the snapshot we will read from).
+    let history = db.transaction_history().unwrap();
+    assert!(
+        !history.is_empty(),
+        "history_retention > 0 must record snapshots"
+    );
+    let t_history = history.last().unwrap().transaction_id;
+
+    // Open the historical read transaction; this is the reader whose
+    // `user_root` walk must remain safe across retention eviction.
+    let historical_rtxn = db.begin_read_at(t_history).unwrap();
+
+    let stop = Arc::new(AtomicBool::new(false));
+
+    // Writer: hammer durable commits with insert + delete churn so
+    // DATA_FREED_TABLE entries accumulate AND process_freed_pages runs
+    // every commit. Many commits in a row also blow past the retention
+    // window of 3, forcing pruning of T_history.
+    let writer_db = db.clone();
+    let writer_stop = stop.clone();
+    let writer = thread::spawn(move || {
+        let mut iter: u64 = 0;
+        let large = vec![0xCDu8; 1024];
+        while !writer_stop.load(Ordering::Relaxed) {
+            let band = (iter % 16) * 256;
+
+            // Durable insert/overwrite -- creates new history snapshot, may
+            // prune the oldest one.
+            {
+                let txn = writer_db.begin_write().unwrap();
+                {
+                    let mut table = txn.open_table(TABLE).unwrap();
+                    for k in band..band + 256 {
+                        table.insert(k, large.as_slice()).unwrap();
+                    }
+                }
+                txn.commit().unwrap();
+            }
+
+            // Durable delete -- DATA_FREED_TABLE entries that
+            // process_freed_pages will reclaim on the next durable commit.
+            {
+                let txn = writer_db.begin_write().unwrap();
+                {
+                    let mut table = txn.open_table(TABLE).unwrap();
+                    for k in band..band + 128 {
+                        table.remove(&k).unwrap();
+                    }
+                }
+                txn.commit().unwrap();
+            }
+
+            iter += 1;
+        }
+    });
+
+    // Reader: walk the historical user tree continuously. Without the fix
+    // this panics inside EntryGuard::value_checked once retention prunes
+    // T_history and durable process_freed_pages reclaims a page reachable
+    // from the snapshot's user_root.
+    let start = Instant::now();
+    let mut reads: u64 = 0;
+    while reads < 200 && start.elapsed() < Duration::from_secs(15) {
+        let table = historical_rtxn.open_table(TABLE).unwrap();
+        // Walk a range covering all originally-seeded keys; the historical
+        // snapshot must still see exactly the seed values.
+        let mut count = 0u64;
+        for entry in table.range::<u64>(..).unwrap() {
+            let (key_guard, val_guard) = entry.unwrap();
+            assert_eq!(val_guard.value().len(), 256, "historical value length");
+            assert_eq!(val_guard.value()[0], 0xAB, "historical value byte");
+            let _ = key_guard.value();
+            count += 1;
+        }
+        assert_eq!(count, 2_000, "historical snapshot must see all seed rows");
+        reads += 1;
+    }
+
+    stop.store(true, Ordering::Relaxed);
+    writer.join().expect("writer thread panicked");
+
+    // Confirm retention pruning actually evicted T_history during the
+    // run. If it didn't, the test failed to exercise the race window.
+    let post_history = db.transaction_history().unwrap();
+    assert!(
+        !post_history.iter().any(|info| info.transaction_id == t_history),
+        "test must drive retention pruning past T_history (history now: {:?})",
+        post_history.iter().map(|i| i.transaction_id).collect::<Vec<_>>()
+    );
+
+    drop(historical_rtxn);
+}


### PR DESCRIPTION
## Summary
- `begin_read_at` and `begin_read_at_time` registered the read guard via `allocate_read_transaction`, pegged to `last_committed_transaction_id` (T_guard) — which is generally far newer than the snapshot's `T_history`. The reader then walked the snapshot's `user_root` (a tree-at-T_history) but only `history_hold[T_history]` registered at commit time pinned those pages.
- Once retention pruning evicted `T_history` from the system history table, `deallocate_history_hold(T_history)` dropped the count to zero, `oldest_live_read_transaction` advanced past `T_history`, and a durable commit's `process_freed_pages` was free to reclaim `DATA_FREED_TABLE` / `SYSTEM_FREED_TABLE` entries whose pages were still reachable from the reader's historical `user_root`. The reader then followed pointers into reused-mid-write pages and panicked inside `EntryGuard::value_checked` with a reversed `value_range`.
- Same id/root mismatch class as #320 (verify_integrity) and #321 (integrity scanner) — the third sibling identified during the post-#320 audit sweep.

## Fix
- New `TransactionTracker::try_register_historical_read_transaction(T)` — under the tracker lock, returns `true` and increments `live_read_transactions[T]` only if the snapshot's hold still exists. The check-and-increment is atomic so it serialises correctly with retention pruning's `deallocate_history_hold`.
- New private `Database::allocate_historical_read_transaction(T)` returning `Result<Option<TransactionGuard>>`. Existing `TransactionGuard::Drop` correctly deallocates.
- `begin_read_at(transaction_id)` pins via the new method first; if `None`, returns `HistorySnapshotNotFound`.
- `begin_read_at_time(timestamp_ms)` retries up to 3 times — the chosen snapshot can be evicted in the gap between the scan and the pin attempt; after 3 collisions returns `HistorySnapshotNotFound`.

## Safety invariant
A reader walking tree-at-Y is safe iff its registered transaction id `T <= Y`. Pinning the hold to `T_history` (not `last_committed`) keeps `oldest_live_read_transaction <= T_history` for the reader's entire lifetime, regardless of whether retention prunes the snapshot mid-read.

## Test plan
- [ ] `cargo test --test begin_read_at_eviction` (new) — keeps a `begin_read_at` reader alive across enough durable commits to evict `T_history` and run `process_freed_pages`; reader walks must remain valid
- [ ] `cargo test --test history_tests` — existing time-travel coverage continues to pass
- [ ] CI green on all targets including WASI (test gated `#![cfg(not(target_os = \"wasi\"))]`)

Third and final fix in the id/root mismatch sweep:
- #320 — `verify_integrity` (merged)
- #321 — `IntegrityScanner` (in review)
- #322 — `begin_read_at` / `begin_read_at_time` (this PR)